### PR TITLE
appmgr: update tokio tar to v3

### DIFF
--- a/appmgr/Cargo.lock
+++ b/appmgr/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "simple-logging",
- "tokio 0.3.4",
+ "tokio 0.3.5",
  "tokio-compat-02",
  "tokio-tar",
 ]
@@ -612,7 +612,7 @@ checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -1429,7 +1429,7 @@ dependencies = [
  "cloudabi 0.1.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1819,13 +1819,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b82c2a1e8eb6e1bfde608de2bcbebd4072aa32d056ea48a986990cd5ca0f5a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -1995,9 +2004,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
 ]
@@ -2014,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2138,7 +2147,7 @@ checksum = "2c29947abdee2a218277abeca306f25789c938e500ea5a9d4b12a5a504466902"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -2208,7 +2217,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "rand 0.7.3",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2249,7 +2258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 dependencies = [
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -2288,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfe2523e6fa84ddf5e688151d4e5fddc51678de9752c6512a24714c23818d61"
+checksum = "a12a3eb39ee2c231be64487f1fcbe726c8f2514876a55480a5ab8559fc374252"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 0.6.0",
@@ -2318,7 +2327,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.1.11",
  "tokio 0.2.22",
- "tokio 0.3.4",
+ "tokio 0.3.5",
 ]
 
 [[package]]
@@ -2334,15 +2343,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tar"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a9e415c93375be93253134543229563114a2be8d46440d6d8f25b2ec62a7fb"
+version = "0.3.0"
+source = "git+https://github.com/dr-bonez/tokio-tar.git#1ba710f344ddb2a5b4d98bb96c905195c3cd9d43"
 dependencies = [
  "filetime",
  "futures-core",
  "libc",
- "redox_syscall",
- "tokio 0.2.22",
+ "redox_syscall 0.2.1",
+ "tokio 0.3.5",
  "xattr",
 ]
 

--- a/appmgr/Cargo.toml
+++ b/appmgr/Cargo.toml
@@ -40,11 +40,11 @@ rand = "0.7.3"
 regex = "1.4.2"
 reqwest = { version = "0.10.9", features = ["stream", "json"] }
 rpassword = "5.0.0"
-serde = { version = "1.0.117", features = ["derive", "rc"] }
+serde = { version = "1.0.118", features = ["derive", "rc"] }
 serde_yaml = "0.8.14"
 serde_cbor = "0.11.1"
 serde_json = "1.0.59"
 simple-logging = "2.0"
-tokio = { version = "0.3.4", features = ["full"] }
+tokio = { version = "0.3.5", features = ["full"] }
 tokio-compat-02 = "0.1.2"
-tokio-tar = "0.2.0"
+tokio-tar = { version = "0.3.0", git = "https://github.com/dr-bonez/tokio-tar.git" }

--- a/appmgr/src/pack.rs
+++ b/appmgr/src/pack.rs
@@ -5,7 +5,6 @@ use failure::ResultExt;
 use futures::stream::StreamExt;
 use linear_map::LinearMap;
 use rand::SeedableRng;
-use tokio_compat_02::IoCompat;
 use tokio_tar as tar;
 
 use crate::config::{ConfigRuleEntry, ConfigSpec};
@@ -42,7 +41,7 @@ pub async fn pack(path: &str, output: &str) -> Result<(), failure::Error> {
         output.display(),
     );
     let out_file = tokio::fs::File::create(output).await?;
-    let mut out = tar::Builder::new(IoCompat::new(out_file));
+    let mut out = tar::Builder::new(out_file);
     log::info!("Reading {}/manifest.yaml.", path.display());
     let manifest: Manifest = crate::util::from_yaml_async_reader(
         tokio::fs::File::open(path.join("manifest.yaml"))
@@ -131,7 +130,7 @@ pub async fn pack(path: &str, output: &str) -> Result<(), failure::Error> {
             h.set_size(0);
             h.set_path(format!("APPMGR_DIR_END:{}", asset.src.display()))?;
             h.set_cksum();
-            out.append(&h, IoCompat::new(tokio::io::empty())).await?;
+            out.append(&h, tokio::io::empty()).await?;
         } else {
             out.append_path_with_name(&file_path, &asset.src).await?;
         }
@@ -145,8 +144,7 @@ pub async fn pack(path: &str, output: &str) -> Result<(), failure::Error> {
             log::info!("Writing image.tar to archive.");
             let mut header = tar::Header::new_gnu();
             header.set_size(image.metadata().await?.len());
-            out.append_data(&mut header, "image.tar", IoCompat::new(image))
-                .await?;
+            out.append_data(&mut header, "image.tar", image).await?;
         }
     }
     out.into_inner().await?;
@@ -201,7 +199,7 @@ pub async fn verify(path: &str) -> Result<(), failure::Error> {
         .await
         .with_context(|e| format!("{}: {}", path.display(), e))?;
     log::info!("Extracting archive.");
-    let mut pkg = tar::Archive::new(IoCompat::new(r));
+    let mut pkg = tar::Archive::new(r);
     let mut entries = pkg.entries()?;
     log::info!("Opening manifest from archive.");
     let manifest = entries
@@ -214,7 +212,7 @@ pub async fn verify(path: &str) -> Result<(), failure::Error> {
         manifest.path()?.display()
     );
     log::trace!("Deserializing manifest.");
-    let manifest: Manifest = from_cbor_async_reader(IoCompat::new(manifest)).await?;
+    let manifest: Manifest = from_cbor_async_reader(manifest).await?;
     let manifest = manifest.into_latest();
     ensure!(
         crate::version::Current::new()
@@ -247,7 +245,7 @@ pub async fn verify(path: &str) -> Result<(), failure::Error> {
         config_spec.path()?.display()
     );
     log::trace!("Deserializing config spec.");
-    let config_spec: ConfigSpec = from_cbor_async_reader(IoCompat::new(config_spec)).await?;
+    let config_spec: ConfigSpec = from_cbor_async_reader(config_spec).await?;
     log::trace!("Validating config spec.");
     config_spec.validate(&manifest)?;
     let config = config_spec.gen(&mut rand::rngs::StdRng::from_entropy(), &None)?;
@@ -263,8 +261,7 @@ pub async fn verify(path: &str) -> Result<(), failure::Error> {
         config_rules.path()?.display()
     );
     log::trace!("Deserializing config rules.");
-    let config_rules: Vec<ConfigRuleEntry> =
-        from_cbor_async_reader(IoCompat::new(config_rules)).await?;
+    let config_rules: Vec<ConfigRuleEntry> = from_cbor_async_reader(config_rules).await?;
     log::trace!("Validating config rules against config spec.");
     let mut cfgs = LinearMap::new();
     cfgs.insert(name, Cow::Borrowed(&config));
@@ -378,7 +375,7 @@ pub async fn verify(path: &str) -> Result<(), failure::Error> {
                 .await
                 .ok_or_else(|| format_err!("image.tar is missing manifest.json"))??;
             let image_manifest: Vec<DockerManifest> =
-                from_json_async_reader(IoCompat::new(image_manifest)).await?;
+                from_json_async_reader(image_manifest).await?;
             image_manifest
                 .into_iter()
                 .flat_map(|a| a.repo_tags)


### PR DESCRIPTION
turns out tokio tar was using tokio-v2 in ways I couldn't apply the compat adapter. I have updated tokio tar to use tokio v3 and have created a pr here: https://github.com/vorot93/tokio-tar/pull/3