### PR TITLE
global error handling in order to reload page on chunk failed

### DIFF
--- a/ui/src/app/app.module.ts
+++ b/ui/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA, ErrorHandler } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 import { RouteReuseStrategy } from '@angular/router'
 import { IonicModule, IonicRouteStrategy, IonNav } from '@ionic/angular'
@@ -21,6 +21,7 @@ import { SharingModule } from './modules/sharing.module'
 import { FormBuilder } from '@angular/forms'
 import { GenericInputComponentModule } from './modals/generic-input/generic-input.component.module'
 import { AuthService } from './services/auth.service'
+import { GlobalErrorHandler } from './services/global-error-handler.service'
 
 @NgModule({
   declarations: [AppComponent],
@@ -57,6 +58,7 @@ import { AuthService } from './services/auth.service'
       useFactory: PatchDbServiceFactory,
       deps: [ConfigService, ApiService, LocalStorageBootstrap, AuthService],
     },
+    { provide: ErrorHandler, useClass: GlobalErrorHandler},
   ],
   bootstrap: [AppComponent],
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ],

--- a/ui/src/app/services/global-error-handler.service.ts
+++ b/ui/src/app/services/global-error-handler.service.ts
@@ -1,0 +1,13 @@
+import { ErrorHandler, Injectable } from '@angular/core'
+
+@Injectable()
+export class GlobalErrorHandler implements ErrorHandler {
+
+  handleError (error: any): void {
+   const chunkFailedMessage = /Loading chunk [\d]+ failed/
+
+    if (chunkFailedMessage.test(error.message)) {
+      window.location.reload()
+    }
+  }
+}


### PR DESCRIPTION
closes #645, closes #627.

Seems to be an issue with browser caching and Angular lazy loading. Actually chocked this hasn't come up more, but explains the sudden disappearance of the issue for @elvece. Info here: https://medium.com/fieldcircle/error-loading-chunk-xx-failed-with-angular-lazy-loaded-modules-6c5b1b6f8b8d.

I implemented a global error handler that looks for errors of this sort and force refreshes the browser to clear cache. Might be slightly jarring to the user, but that's better than a broken web app :)