### PR TITLE
Certificate Imports/Exports

### DIFF
--- a/appmgr/src/context/rpc.rs
+++ b/appmgr/src/context/rpc.rs
@@ -154,6 +154,7 @@ impl RpcContext {
             base.tor_control
                 .unwrap_or(SocketAddr::from(([127, 0, 0, 1], 9051))),
             secret_store.clone(),
+            None,
         )
         .await?;
         let managers = ManagerMap::default();


### PR DESCRIPTION
This PR adds the ability to import existing root and intermediate certificates into the SSL Manager as opposed to generating them from scratch or loading them from existing persistence. This is a very very rough draft and I'm already dissatisfied with it in certain ways.

There are a number of invariants that are not checked which you can see in a TODO comment in the code here. I'd like you to take a look at it first and give me your thoughts, but my leanings after seeing this written out is that I'd like to only import the root certificate and ditch the intermediate certificate imports entirely. This means that we can avoid checking invariants and instead just generate intermediate certificates that are correct by virtue of being derived from the root certificate provided. There is no way around importing both the root key and root certificate since users will have saved the root certificate to their browsers and the key is not part of that document. However it may be beneficial to ditch the intermediate key/cert during this process.

Let me know what you think and we can proceed. I'm about to get on a flight.
