### PR TITLE
fixes login locking up after refresh

### DIFF
--- a/backend/sqlx-data.json
+++ b/backend/sqlx-data.json
@@ -47,7 +47,7 @@
         {
           "name": "id: u32",
           "ordinal": 0,
-          "type_info": "Null"
+          "type_info": "Int64"
         }
       ],
       "parameters": {
@@ -64,6 +64,16 @@
       "columns": [],
       "parameters": {
         "Right": 2
+      },
+      "nullable": []
+    }
+  },
+  "2932aa02735b6422fca4ba889abfb3de8598178d4690076dc278898753d9df62": {
+    "query": "UPDATE session SET logged_out = CURRENT_TIMESTAMP WHERE id = ?",
+    "describe": {
+      "columns": [],
+      "parameters": {
+        "Right": 1
       },
       "nullable": []
     }

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -148,6 +148,10 @@ async fn deal_with_messages(
                         }
                         return Ok(())
                     }
+                    None => {
+                        tracing::info!("Closing WebSocket: Stream Finished");
+                        return Ok(())
+                    }
                     _ => (),
                 }
             }


### PR DESCRIPTION
I cannot for the life of me explain why this fixes it, but it does, so... fuck me I guess.

Here's how you repro the bug:
1. login
2. refresh
3. logout
4. refresh
5. login

The part of this pr that actually fixes it is the query change. The rest was stuff that I tried that didn't fix it, but was better to leave it that way.