### PR TITLE
handle current-dependents properly during update

### DIFF
--- a/backend/src/install/mod.rs
+++ b/backend/src/install/mod.rs
@@ -1360,21 +1360,22 @@ pub async fn install_s9pk<R: AsyncRead + AsyncSeek + Unpin>(
                 .await?;
             *main_status = prev.status.main;
             main_status.save(&mut tx).await?;
+        } else {
+            remove_from_current_dependents_lists(
+                &mut tx,
+                pkg_id,
+                &prev.current_dependencies,
+                &receipts.config.current_dependents,
+            )
+            .await?; // remove previous
+            add_dependent_to_current_dependents_lists(
+                &mut tx,
+                pkg_id,
+                &current_dependencies,
+                &receipts.config.current_dependents,
+            )
+            .await?; // add new
         }
-        remove_from_current_dependents_lists(
-            &mut tx,
-            pkg_id,
-            &prev.current_dependencies,
-            &receipts.config.current_dependents,
-        )
-        .await?; // remove previous
-        add_dependent_to_current_dependents_lists(
-            &mut tx,
-            pkg_id,
-            &current_dependencies,
-            &receipts.config.current_dependents,
-        )
-        .await?; // add new
         update_dependency_errors_of_dependents(
             ctx,
             &mut tx,


### PR DESCRIPTION
This one is a bit confusing, so I'll explain.

The issue here is that the &current_dependencies that we pass to add_dependent_to_current_dependents_lists is out of date, since it changes during configure. If we wanted to keep this code mostly the same, we would need to refetch current_dependencies after configure. However, since configure already does update this, we can just put it in the other side of an else.