### PR TITLE
Add qemu-guest-agent for advanced VM shutdown options

### DIFF
--- a/build/lib/depends
+++ b/build/lib/depends
@@ -34,6 +34,7 @@ nyx
 openssh-server
 postgresql
 psmisc
+qemu-guest-agent
 rsync
 samba-common-bin
 smartmontools


### PR DESCRIPTION
This may help anybody running StartOS in a VM to:
* properly shutdown the guest, instead of relying on ACPI commands
* freeze the guest file system when making a backup/snapshot, entering suspend, and thawing filesystems
* In the phase when the guest (VM) is resumed after pause (for example after shapshot) it immediately synchronizes its time with the hypervisor using qemu-guest-agent (as first step).

More info:
https://wiki.libvirt.org/Qemu_guest_agent.html
https://pve.proxmox.com/wiki/Qemu-guest-agent