### PR TITLE
fix: Make check-version posix compliant

### DIFF
--- a/check-version.sh
+++ b/check-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FE_VERSION="$(cat frontend/package.json | grep -Po '"version":[ \t\n]*"\K[^"]*')"
+FE_VERSION="$(cat frontend/package.json | grep '"version"' | sed 's/[ \t]*"version":[ \t]*"\([^"]*\)",/\1/')"
 
 # TODO: Validate other version sources - backend/Cargo.toml, backend/src/version/mod.rs
 


### PR DESCRIPTION
We found that we couldn't compile this on the mac arm os