### PR TITLE
backend: sdk init: output file location. fixes #1854

### DIFF
--- a/backend/src/developer/mod.rs
+++ b/backend/src/developer/mod.rs
@@ -35,6 +35,15 @@ pub fn init(#[context] ctx: SdkContext) -> Result<(), Error> {
                 .as_bytes(),
         )?;
         dev_key_file.sync_all()?;
+        println!(
+            "New developer key generated at {}",
+            ctx.developer_key_path.display()
+        );
+    } else {
+        println!(
+            "Developer key already exists at {}",
+            ctx.developer_key_path.display()
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
* `start-sdk init` used to run completely silent. Now we are showing the current/generated developer.key.pem based on ticket https://github.com/Start9Labs/start-os/issues/1854

sample run:

```
➜  backend git:(sdk_init_message-fixes1854) ✗ start-sdk init
New developer key generated at /Users/jadi/.embassy/developer.key.pem
➜  backend git:(sdk_init_message-fixes1854) ✗ start-sdk init
Developer key already exists at /Users/jadi/.embassy/developer.key.pem
```