### PR TITLE
frontend: ui: bugfix: consistent password length.

### DIFF
--- a/frontend/projects/ui/src/app/pages/login/login.page.html
+++ b/frontend/projects/ui/src/app/pages/login/login.page.html
@@ -24,6 +24,7 @@
                     [type]="unmasked ? 'text' : 'password'"
                     [(ngModel)]="password"
                     (ionChange)="error = ''"
+                    maxlength="64"
                   ></ion-input>
                   <ion-button fill="clear" color="light" (click)="toggleMask()">
                     <ion-icon


### PR DESCRIPTION
* The password set dialogue forces maxlenght=64 but when logging in, the dialogue does not forces this. This makes an issue when the user copy/pastes a longer than 64 character password in boxes. closes #2375