### PR TITLE
fix: Add in logging for the podman in the system logs

### DIFF
--- a/backend/src/db/model.rs
+++ b/backend/src/db/model.rs
@@ -45,7 +45,7 @@ impl Database {
                 last_wifi_region: None,
                 eos_version_compat: Current::new().compat().clone(),
                 lan_address,
-                tor_address: format!("http://{}", account.key.tor_address())
+                tor_address: format!("https://{}", account.key.tor_address())
                     .parse()
                     .unwrap(),
                 ip_info: BTreeMap::new(),

--- a/backend/src/diagnostic.rs
+++ b/backend/src/diagnostic.rs
@@ -9,7 +9,6 @@ use crate::disk::repair;
 use crate::init::SYSTEM_REBUILD_PATH;
 use crate::logs::{fetch_logs, LogResponse, LogSource};
 use crate::shutdown::Shutdown;
-use crate::system::SYSTEMD_UNIT;
 use crate::util::display_none;
 use crate::Error;
 
@@ -29,7 +28,7 @@ pub async fn logs(
     #[arg] cursor: Option<String>,
     #[arg] before: bool,
 ) -> Result<LogResponse, Error> {
-    Ok(fetch_logs(LogSource::Service(SYSTEMD_UNIT), limit, cursor, before).await?)
+    Ok(fetch_logs(LogSource::System, limit, cursor, before).await?)
 }
 
 #[command(display(display_none))]

--- a/backend/src/net/tor.rs
+++ b/backend/src/net/tor.rs
@@ -139,7 +139,7 @@ pub async fn logs_nofollow(
     _ctx: (),
     (limit, cursor, before, _): (Option<usize>, Option<String>, bool, bool),
 ) -> Result<LogResponse, Error> {
-    fetch_logs(LogSource::Service(SYSTEMD_UNIT), limit, cursor, before).await
+    fetch_logs(LogSource::Unit(SYSTEMD_UNIT), limit, cursor, before).await
 }
 
 #[command(rpc_only, rename = "follow", display(display_none))]
@@ -147,7 +147,7 @@ pub async fn logs_follow(
     #[context] ctx: RpcContext,
     #[parent_data] (limit, _, _, _): (Option<usize>, Option<String>, bool, bool),
 ) -> Result<LogFollowResponse, Error> {
-    follow_logs(ctx, LogSource::Service(SYSTEMD_UNIT), limit).await
+    follow_logs(ctx, LogSource::Unit(SYSTEMD_UNIT), limit).await
 }
 
 fn event_handler(_event: AsyncEvent<'static>) -> BoxFuture<'static, Result<(), ConnError>> {
@@ -305,7 +305,7 @@ async fn torctl(
             .invoke(ErrorKind::Tor)
             .await?;
 
-        let logs = journalctl(LogSource::Service(SYSTEMD_UNIT), 0, None, false, true).await?;
+        let logs = journalctl(LogSource::Unit(SYSTEMD_UNIT), 0, None, false, true).await?;
 
         let mut tcp_stream = None;
         for _ in 0..60 {

--- a/backend/src/system.rs
+++ b/backend/src/system.rs
@@ -23,8 +23,6 @@ use crate::util::serde::{display_serializable, IoFormat};
 use crate::util::{display_none, Invoke};
 use crate::{Error, ErrorKind, ResultExt};
 
-pub const SYSTEMD_UNIT: &'static str = "startd";
-
 #[command(subcommands(zram))]
 pub async fn experimental() -> Result<(), Error> {
     Ok(())
@@ -130,7 +128,7 @@ pub async fn logs_nofollow(
     _ctx: (),
     (limit, cursor, before, _): (Option<usize>, Option<String>, bool, bool),
 ) -> Result<LogResponse, Error> {
-    fetch_logs(LogSource::Service(SYSTEMD_UNIT), limit, cursor, before).await
+    fetch_logs(LogSource::System, limit, cursor, before).await
 }
 
 #[command(rpc_only, rename = "follow", display(display_none))]
@@ -138,7 +136,7 @@ pub async fn logs_follow(
     #[context] ctx: RpcContext,
     #[parent_data] (limit, _, _, _): (Option<usize>, Option<String>, bool, bool),
 ) -> Result<LogFollowResponse, Error> {
-    follow_logs(ctx, LogSource::Service(SYSTEMD_UNIT), limit).await
+    follow_logs(ctx, LogSource::System, limit).await
 }
 
 #[command(


### PR DESCRIPTION
### Proof of working

Os logs now
![image](https://github.com/Start9Labs/start-os/assets/2364004/f161a063-2aa2-4c89-9aea-18e1ae8caeb0)

Mempool logs now
![image](https://github.com/Start9Labs/start-os/assets/2364004/fd94c96b-522b-48ea-ac43-ad7477ce7299)

Now the logs of mempool are not going into the Os Logs now, which is what it used to do