### PR TITLE
fix: Logging in deno to filter out the info

### DIFF
--- a/backend/src/bins/start_deno.rs
+++ b/backend/src/bins/start_deno.rs
@@ -69,13 +69,12 @@ impl PackageLogger {
         use tracing_subscriber::prelude::*;
         use tracing_subscriber::{fmt, EnvFilter};
 
-        let filter_layer = EnvFilter::builder()
-            .with_default_directive(
-                format!("{}=info", std::module_path!().split("::").next().unwrap())
+        let filter_layer = EnvFilter::default()
+            .add_directive(
+                format!("{}=warn", std::module_path!().split("::").next().unwrap())
                     .parse()
                     .unwrap(),
-            )
-            .from_env_lossy();
+            );
         let fmt_layer = fmt::layer().with_writer(std::io::stderr).with_target(true);
         let journald_layer = tracing_journald::layer()
             .unwrap()


### PR DESCRIPTION
## Given

That during the testing there was found a noise in the logs that seemed to indicate error

## Why This solution

The actual solution was to change all the sdk that all the services use to no longer say error in the info. 
But the end case is that we are just going to filter up to the warn, and remove the noise in the logs for the services and js.

## Proof 

https://github.com/Start9Labs/start-os/assets/2364004/18525b35-bdb4-42cf-8dca-c47ddc22db4a


