### PR TITLE
fix ntp sync status check daemon

### DIFF
--- a/core/startos/src/context/rpc.rs
+++ b/core/startos/src/context/rpc.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use helpers::to_tmp_path;
 use josekit::jwk::Jwk;
@@ -25,7 +26,7 @@ use crate::db::model::{CurrentDependents, Database, PackageDataEntryMatchModelRe
 use crate::db::prelude::PatchDbExt;
 use crate::dependencies::compute_dependency_config_errs;
 use crate::disk::OsPartitionInfo;
-use crate::init::init_postgres;
+use crate::init::{check_time_is_synchronized, init_postgres};
 use crate::install::cleanup::{cleanup_failed, uninstall};
 use crate::manager::ManagerMap;
 use crate::middleware::auth::HashSessionToken;
@@ -174,6 +175,19 @@ impl RpcContext {
         let tor_proxy_url = format!("socks5h://{tor_proxy}");
         let devices = lshw().await?;
         let ram = get_mem_info().await?.total.0 as u64 * 1024 * 1024;
+
+        if !db.peek().await.as_server_info().as_ntp_synced().de()? {
+            let db = db.clone();
+            tokio::spawn(async move {
+                while !check_time_is_synchronized().await.unwrap() {
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                }
+                db.mutate(|v| v.as_server_info_mut().as_ntp_synced_mut().ser(&true))
+                    .await
+                    .unwrap()
+            });
+        }
+
         let seed = Arc::new(RpcContextSeed {
             is_closed: AtomicBool::new(false),
             datadir: base.datadir().to_path_buf(),

--- a/core/startos/src/init.rs
+++ b/core/startos/src/init.rs
@@ -342,6 +342,7 @@ pub async fn init(cfg: &RpcContextConfig) -> Result<InitResult, Error> {
             .arg("run")
             .arg("-d")
             .arg("--rm")
+            .arg("--init")
             .arg("--network=start9")
             .arg("--name=netdummy")
             .arg("start9/x_system/utils:latest")
@@ -379,11 +380,11 @@ pub async fn init(cfg: &RpcContextConfig) -> Result<InitResult, Error> {
         tracing::info!("Set CPU Governor");
     }
 
-    let mut time_not_synced = true;
+    server_info.ntp_synced = false;
     let mut not_made_progress = 0u32;
     for _ in 0..1800 {
         if check_time_is_synchronized().await? {
-            time_not_synced = false;
+            server_info.ntp_synced = true;
             break;
         }
         let t = SystemTime::now();
@@ -400,7 +401,7 @@ pub async fn init(cfg: &RpcContextConfig) -> Result<InitResult, Error> {
             break;
         }
     }
-    if time_not_synced {
+    if !server_info.ntp_synced {
         tracing::warn!("Timed out waiting for system time to synchronize");
     } else {
         tracing::info!("Syncronized system clock");
@@ -416,21 +417,6 @@ pub async fn init(cfg: &RpcContextConfig) -> Result<InitResult, Error> {
         backup_progress: None,
         shutting_down: false,
         restarting: false,
-    };
-
-    server_info.ntp_synced = if time_not_synced {
-        let db = db.clone();
-        tokio::spawn(async move {
-            while !check_time_is_synchronized().await.unwrap() {
-                tokio::time::sleep(Duration::from_secs(30)).await;
-            }
-            db.mutate(|v| v.as_server_info_mut().as_ntp_synced_mut().ser(&true))
-                .await
-                .unwrap()
-        });
-        false
-    } else {
-        true
     };
 
     db.mutate(|v| {


### PR DESCRIPTION
the previous implementation launched the ntp status check daemon during `start-init`. since `start-init` uses a different tokio runtime than `startd`, this daemon is shutdown after initialization completes. I have moved the ntp status check daemon to `RpcContext::init`.