### PR TITLE
fix: Docker stopping will include a timeout

### DIFF
--- a/core/install-sdk.sh
+++ b/core/install-sdk.sh
@@ -12,7 +12,7 @@ if [ -z "$PLATFORM" ]; then
   export PLATFORM=$(uname -m)
 fi
 
-cargo install --path=./startos --no-default-features --features=js_engine,sdk,cli --locked
+cargo install --path=./startos --no-default-features --features=js-engine,sdk,cli --locked
 startbox_loc=$(which startbox)
 ln -sf $startbox_loc $(dirname $startbox_loc)/start-cli
 ln -sf $startbox_loc $(dirname $startbox_loc)/start-sdk

--- a/core/install-sdk.sh
+++ b/core/install-sdk.sh
@@ -12,7 +12,7 @@ if [ -z "$PLATFORM" ]; then
   export PLATFORM=$(uname -m)
 fi
 
-cargo install --path=./startos --no-default-features --features=js-engine,sdk,cli --locked
+cargo install --path=./startos --no-default-features --features=sdk,cli --locked
 startbox_loc=$(which startbox)
 ln -sf $startbox_loc $(dirname $startbox_loc)/start-cli
 ln -sf $startbox_loc $(dirname $startbox_loc)/start-sdk

--- a/core/install-sdk.sh
+++ b/core/install-sdk.sh
@@ -12,7 +12,7 @@ if [ -z "$PLATFORM" ]; then
   export PLATFORM=$(uname -m)
 fi
 
-cargo install --path=./startos --no-default-features --features=sdk,cli --locked
+cargo install --path=./startos --no-default-features --features=js_engine,sdk,cli --locked
 startbox_loc=$(which startbox)
 ln -sf $startbox_loc $(dirname $startbox_loc)/start-cli
 ln -sf $startbox_loc $(dirname $startbox_loc)/start-sdk

--- a/core/startos/src/manager/manager_seed.rs
+++ b/core/startos/src/manager/manager_seed.rs
@@ -29,8 +29,15 @@ impl ManagerSeed {
         )
         .await
         {
-            Err(e) if e.kind == ErrorKind::NotFound => (), // Already stopped
-            Err(e) if e.kind == ErrorKind::Timeout => (),  // Already stopped In theory
+            Err(e) if e.kind == ErrorKind::NotFound => {
+                tracing::info!(
+                    "Command for package {command_id} should already be stopped",
+                    command_id = &self.manifest.id
+                );
+            } // Already stopped
+            Err(e) if e.kind == ErrorKind::Timeout => {
+                tracing::warn!("Command for package {command_id} had to be timed out, but we have dropped which means it should be killed", command_id = &self.manifest.id);
+            } // Already stopped In theory
             a => a?,
         }
         Ok(())

--- a/core/startos/src/manager/manager_seed.rs
+++ b/core/startos/src/manager/manager_seed.rs
@@ -30,6 +30,7 @@ impl ManagerSeed {
         .await
         {
             Err(e) if e.kind == ErrorKind::NotFound => (), // Already stopped
+            Err(e) if e.kind == ErrorKind::Timeout => (),  // Already stopped In theory
             a => a?,
         }
         Ok(())

--- a/core/startos/src/util/docker.rs
+++ b/core/startos/src/util/docker.rs
@@ -113,11 +113,10 @@ pub async fn stop_container(
     signal: Option<Signal>,
 ) -> Result<(), Error> {
     let mut cmd = Command::new(CONTAINER_TOOL);
+    let mut cmd = cmd.timeout(timeout);
     cmd.arg("stop");
     if let Some(dur) = timeout {
-        cmd.arg("-t")
-            .arg(dur.as_secs().to_string())
-            .timeout(Some(dur));
+        cmd.arg("-t").arg(dur.as_secs().to_string());
     }
     if let Some(sig) = signal {
         cmd.arg("-s").arg(sig.to_string());

--- a/core/startos/src/util/docker.rs
+++ b/core/startos/src/util/docker.rs
@@ -115,7 +115,9 @@ pub async fn stop_container(
     let mut cmd = Command::new(CONTAINER_TOOL);
     cmd.arg("stop");
     if let Some(dur) = timeout {
-        cmd.arg("-t").arg(dur.as_secs().to_string());
+        cmd.arg("-t")
+            .arg(dur.as_secs().to_string())
+            .timeout(Some(dur));
     }
     if let Some(sig) = signal {
         cmd.arg("-s").arg(sig.to_string());


### PR DESCRIPTION
So the timeout that was included in the original is not working therefore we move to a doubling with a timeout

![image](https://github.com/Start9Labs/start-os/assets/2364004/c55b36a1-6ce1-4a0d-8f30-1b9b74864c5d)
