### PR TITLE
Refactor2/container runtime refactor

### DIFF
--- a/container-runtime/package-lock.json
+++ b/container-runtime/package-lock.json
@@ -32,7 +32,7 @@
     },
     "../sdk/dist": {
       "name": "@start9labs/start-sdk",
-      "version": "0.3.6-alpha5",
+      "version": "0.3.6-alpha6",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -48,9 +48,11 @@
         "@types/jest": "^29.4.0",
         "@types/lodash.merge": "^4.6.2",
         "jest": "^29.4.3",
+        "peggy": "^3.0.2",
         "prettier": "^3.2.5",
         "ts-jest": "^29.0.5",
         "ts-node": "^10.9.1",
+        "ts-pegjs": "^4.2.1",
         "tsx": "^4.7.1",
         "typescript": "^5.0.4"
       }
@@ -2309,10 +2311,12 @@
         "jest": "^29.4.3",
         "lodash.merge": "^4.6.2",
         "mime": "^4.0.3",
+        "peggy": "^3.0.2",
         "prettier": "^3.2.5",
         "ts-jest": "^29.0.5",
         "ts-matches": "^5.5.1",
         "ts-node": "^10.9.1",
+        "ts-pegjs": "^4.2.1",
         "tsx": "^4.7.1",
         "typescript": "^5.0.4",
         "yaml": "^2.2.2"

--- a/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
@@ -156,6 +156,39 @@ const matchPackagePropertyObject: Parser<unknown, PackagePropertyObject> =
     description: string,
   })
 
+const matchResult = object({
+  result: any,
+})
+const matchError = object({
+  error: string,
+})
+const matchErrorCode = object<{
+  "error-code": [number, string] | readonly [number, string]
+}>({
+  "error-code": tuple(number, string),
+})
+
+const assertNever = (
+  x: never,
+  message = "Not expecting to get here",
+): never => {
+  throw new Error(message)
+}
+const fromReturnType = <A>(a: U.ResultType<A>): A => {
+  if (matchResult.test(a)) {
+    return a.result
+  }
+  if (matchError.test(a)) {
+    console.info({ passedErrorStack: new Error().stack, error: a.error })
+    throw { error: a.error }
+  }
+  if (matchErrorCode.test(a)) {
+    const [code, message] = a["error-code"]
+    throw { error: message, code }
+  }
+  return assertNever(a)
+}
+
 const matchPackagePropertyString: Parser<unknown, PackagePropertyString> =
   object(
     {
@@ -204,7 +237,43 @@ export class SystemForEmbassy implements System {
     readonly moduleCode: Partial<U.ExpectedExports>,
   ) {}
 
-  async init(): Promise<void> {}
+  async actionsMetadata(effects: T.Effects): Promise<T.ActionMetadata[]> {
+    const actions = Object.entries(this.manifest.actions ?? {})
+    return Promise.all(
+      actions.map(async ([actionId, action]): Promise<T.ActionMetadata> => {
+        const name = action.name ?? actionId
+        const description = action.description
+        const warning = action.warning ?? null
+        const disabled = false
+        const input = (await convertToNewConfig(action["input-spec"] as any))
+          .spec
+        const hasRunning = !!action["allowed-statuses"].find(
+          (x) => x === "running",
+        )
+        const hasStopped = !!action["allowed-statuses"].find(
+          (x) => x === "stopped",
+        )
+        // prettier-ignore
+        const allowedStatuses = 
+        hasRunning && hasStopped ? "any":
+        hasRunning ? "onlyRunning" :
+        "onlyStopped"
+
+        const group = null
+        return {
+          name,
+          description,
+          warning,
+          disabled,
+          allowedStatuses,
+          group,
+          input,
+        }
+      }),
+    )
+  }
+
+  async containerInit(): Promise<void> {}
 
   async exit(): Promise<void> {
     if (this.currentRunning) await this.currentRunning.clean()
@@ -228,146 +297,7 @@ export class SystemForEmbassy implements System {
     }
   }
 
-  async execute(
-    effects: Effects,
-    options: {
-      procedure: JsonPath
-      input: unknown
-      timeout?: number | undefined
-    },
-  ): Promise<RpcResult> {
-    return this._execute(effects, options)
-      .then((x) =>
-        matches(x)
-          .when(
-            object({
-              result: any,
-            }),
-            (x) => x,
-          )
-          .when(
-            object({
-              error: string,
-            }),
-            (x) => ({
-              error: {
-                code: 0,
-                message: x.error,
-              },
-            }),
-          )
-          .when(
-            object({
-              "error-code": tuple(number, string),
-            }),
-            ({ "error-code": [code, message] }) => ({
-              error: {
-                code,
-                message,
-              },
-            }),
-          )
-          .defaultTo({ result: x }),
-      )
-      .catch((error: unknown) => {
-        if (error instanceof Error)
-          return {
-            error: {
-              code: 0,
-              message: error.name,
-              data: {
-                details: error.message,
-                debug: `${error?.cause ?? "[noCause]"}:${error?.stack ?? "[noStack]"}`,
-              },
-            },
-          }
-        if (matchRpcResult.test(error)) return error
-        return {
-          error: {
-            code: 0,
-            message: String(error),
-          },
-        }
-      })
-  }
-  async _execute(
-    effects: Effects,
-    options: {
-      procedure: JsonPath
-      input: unknown
-      timeout?: number | undefined
-    },
-  ): Promise<unknown> {
-    const input = options.input
-    switch (options.procedure) {
-      case "/backup/create":
-        return this.createBackup(effects, options.timeout || null)
-      case "/backup/restore":
-        return this.restoreBackup(effects, options.timeout || null)
-      case "/config/get":
-        return this.getConfig(effects, options.timeout || null)
-      case "/config/set":
-        return this.setConfig(effects, input, options.timeout || null)
-      case "/properties":
-        return this.properties(effects, options.timeout || null)
-      case "/actions/metadata":
-        return todo()
-      case "/init":
-        return this.initProcedure(
-          effects,
-          string.optional().unsafeCast(input),
-          options.timeout || null,
-        )
-      case "/uninit":
-        return this.uninit(
-          effects,
-          string.optional().unsafeCast(input),
-          options.timeout || null,
-        )
-      default:
-        const procedures = unNestPath(options.procedure)
-        switch (true) {
-          case procedures[1] === "actions" && procedures[3] === "get":
-            return this.action(
-              effects,
-              procedures[2],
-              input,
-              options.timeout || null,
-            )
-          case procedures[1] === "actions" && procedures[3] === "run":
-            return this.action(
-              effects,
-              procedures[2],
-              input,
-              options.timeout || null,
-            )
-          case procedures[1] === "dependencies" && procedures[3] === "query":
-            return this.dependenciesAutoconfig(
-              effects,
-              procedures[2],
-              input,
-              options.timeout || null,
-            )
-
-          case procedures[1] === "dependencies" && procedures[3] === "update":
-            return this.dependenciesAutoconfig(
-              effects,
-              procedures[2],
-              input,
-              options.timeout || null,
-            )
-        }
-    }
-    throw new Error(`Could not find the path for ${options.procedure}`)
-  }
-  async sandbox(
-    effects: Effects,
-    options: { procedure: Procedure; input: unknown; timeout?: number },
-  ): Promise<RpcResult> {
-    return this.execute(effects, options)
-  }
-
-  private async initProcedure(
+  async packageInit(
     effects: Effects,
     previousVersion: Optional<string>,
     timeoutMs: number | null,
@@ -484,7 +414,7 @@ export class SystemForEmbassy implements System {
       })
     }
   }
-  private async uninit(
+  async packageUninit(
     effects: Effects,
     nextVersion: Optional<string>,
     timeoutMs: number | null,
@@ -493,7 +423,7 @@ export class SystemForEmbassy implements System {
     await effects.setMainStatus({ status: "stopped" })
   }
 
-  private async createBackup(
+  async createBackup(
     effects: Effects,
     timeoutMs: number | null,
   ): Promise<void> {
@@ -514,7 +444,7 @@ export class SystemForEmbassy implements System {
       await moduleCode.createBackup?.(polyfillEffects(effects, this.manifest))
     }
   }
-  private async restoreBackup(
+  async restoreBackup(
     effects: Effects,
     timeoutMs: number | null,
   ): Promise<void> {
@@ -538,7 +468,7 @@ export class SystemForEmbassy implements System {
       await moduleCode.restoreBackup?.(polyfillEffects(effects, this.manifest))
     }
   }
-  private async getConfig(
+  async getConfig(
     effects: Effects,
     timeoutMs: number | null,
   ): Promise<T.ConfigRes> {
@@ -581,7 +511,7 @@ export class SystemForEmbassy implements System {
       )) as any
     }
   }
-  private async setConfig(
+  async setConfig(
     effects: Effects,
     newConfigWithoutPointers: unknown,
     timeoutMs: number | null,
@@ -668,7 +598,7 @@ export class SystemForEmbassy implements System {
     })
   }
 
-  private async migration(
+  async migration(
     effects: Effects,
     fromVersion: string,
     timeoutMs: number | null,
@@ -740,10 +670,10 @@ export class SystemForEmbassy implements System {
     }
     return { configured: true }
   }
-  private async properties(
+  async properties(
     effects: Effects,
     timeoutMs: number | null,
-  ): Promise<ReturnType<T.ExpectedExports.properties>> {
+  ): Promise<T.PropertiesReturn> {
     // TODO BLU-J set the properties ever so often
     const setConfigValue = this.manifest.properties
     if (!setConfigValue) throw new Error("There is no properties")
@@ -771,24 +701,22 @@ export class SystemForEmbassy implements System {
       if (!method)
         throw new Error("Expecting that the method properties exists")
       const properties = matchProperties.unsafeCast(
-        await method(polyfillEffects(effects, this.manifest)).then((x) => {
-          if ("result" in x) return x.result
-          if ("error" in x) throw new Error("Error getting config: " + x.error)
-          throw new Error("Error getting config: " + x["error-code"][1])
-        }),
+        await method(polyfillEffects(effects, this.manifest)).then(
+          fromReturnType,
+        ),
       )
       return asProperty(properties.data)
     }
     throw new Error(`Unknown type in the fetch properties: ${setConfigValue}`)
   }
-  private async action(
+  async action(
     effects: Effects,
     actionId: string,
     formData: unknown,
     timeoutMs: number | null,
-  ): Promise<T.ActionResult> {
+  ): Promise<T.configTypes.InputSpec> {
     const actionProcedure = this.manifest.actions?.[actionId]?.implementation
-    if (!actionProcedure) return { message: "Action not found", value: null }
+    if (!actionProcedure) throw Error("Action not found")
     if (actionProcedure.type === "docker") {
       const container = await DockerProcedureContainer.of(
         effects,
@@ -796,33 +724,31 @@ export class SystemForEmbassy implements System {
         actionProcedure,
         this.manifest.volumes,
       )
-      return JSON.parse(
-        (
-          await container.execFail(
-            [
-              actionProcedure.entrypoint,
-              ...actionProcedure.args,
-              JSON.stringify(formData),
-            ],
-            timeoutMs,
-          )
-        ).stdout.toString(),
+      return fromReturnType(
+        JSON.parse(
+          (
+            await container.execFail(
+              [
+                actionProcedure.entrypoint,
+                ...actionProcedure.args,
+                JSON.stringify(formData),
+              ],
+              timeoutMs,
+            )
+          ).stdout.toString(),
+        ),
       )
     } else {
       const moduleCode = await this.moduleCode
       const method = moduleCode.action?.[actionId]
       if (!method) throw new Error("Expecting that the method action exists")
-      return (await method(
+      return await method(
         polyfillEffects(effects, this.manifest),
         formData as any,
-      ).then((x) => {
-        if ("result" in x) return x.result
-        if ("error" in x) throw new Error("Error getting config: " + x.error)
-        throw new Error("Error getting config: " + x["error-code"][1])
-      })) as any
+      ).then(fromReturnType)
     }
   }
-  private async dependenciesCheck(
+  async dependenciesCheck(
     effects: Effects,
     id: string,
     oldConfig: unknown,
@@ -868,7 +794,7 @@ export class SystemForEmbassy implements System {
       return {}
     }
   }
-  private async dependenciesAutoconfig(
+  async dependenciesAutoconfig(
     effects: Effects,
     id: string,
     oldConfig: unknown,

--- a/container-runtime/src/Adapters/Systems/SystemForStartOs.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForStartOs.ts
@@ -95,10 +95,10 @@ export class SystemForStartOs implements System {
     id: string,
     formData: unknown,
     timeoutMs: number | null,
-  ): Promise<T.configTypes.InputSpec> {
+  ): Promise<T.ActionResult> {
     const action = (await this.abi.actions({ effects }))[id]
     if (!action) throw new Error(`Action ${id} not found`)
-    return action.getConfig({ effects })
+    return action.run({ effects })
   }
   dependenciesCheck(
     effects: Effects,
@@ -124,8 +124,8 @@ export class SystemForStartOs implements System {
       remoteConfig,
     })) // TODO
   }
-  actionsMetadata(effects: T.Effects): Promise<T.ActionMetadata[]> {
-    throw new Error("Method not implemented.")
+  async actionsMetadata(effects: T.Effects): Promise<T.ActionMetadata[]> {
+    return this.abi.actionsMetadata({ effects })
   }
 
   async init(): Promise<void> {}

--- a/container-runtime/src/Adapters/Systems/SystemForStartOs.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForStartOs.ts
@@ -8,6 +8,7 @@ import { T } from "@start9labs/start-sdk"
 import { Volume } from "../../Models/Volume"
 import { MainEffects } from "@start9labs/start-sdk/cjs/lib/StartSdk"
 import { CallbackHolder } from "../../Models/CallbackHolder"
+import { Optional } from "ts-matches/lib/parsers/interfaces"
 
 export const STARTOS_JS_LOCATION = "/usr/lib/startos/package/index.js"
 
@@ -25,6 +26,107 @@ export class SystemForStartOs implements System {
   }
 
   constructor(readonly abi: T.ABI) {}
+  containerInit(): Promise<void> {
+    throw new Error("Method not implemented.")
+  }
+  async packageInit(
+    effects: Effects,
+    previousVersion: Optional<string> = null,
+    timeoutMs: number | null = null,
+  ): Promise<void> {
+    return void (await this.abi.init({ effects, previousVersion }))
+  }
+  async packageUninit(
+    effects: Effects,
+    nextVersion: Optional<string> = null,
+    timeoutMs: number | null = null,
+  ): Promise<void> {
+    return void (await this.abi.uninit({ effects, nextVersion }))
+  }
+  async createBackup(
+    effects: T.Effects,
+    timeoutMs: number | null,
+  ): Promise<void> {
+    return void (await this.abi.createBackup({
+      effects,
+      pathMaker: ((options) =>
+        new Volume(options.volume, options.path).path) as T.PathMaker,
+    }))
+  }
+  async restoreBackup(
+    effects: T.Effects,
+    timeoutMs: number | null,
+  ): Promise<void> {
+    return void (await this.abi.restoreBackup({
+      effects,
+      pathMaker: ((options) =>
+        new Volume(options.volume, options.path).path) as T.PathMaker,
+    }))
+  }
+  getConfig(
+    effects: T.Effects,
+    timeoutMs: number | null,
+  ): Promise<T.ConfigRes> {
+    return this.abi.getConfig({ effects })
+  }
+  async setConfig(
+    effects: Effects,
+    input: { effects: Effects; input: Record<string, unknown> },
+    timeoutMs: number | null,
+  ): Promise<void> {
+    const _: unknown = await this.abi.setConfig({ effects, input })
+    return
+  }
+  migration(
+    effects: Effects,
+    fromVersion: string,
+    timeoutMs: number | null,
+  ): Promise<T.MigrationRes> {
+    throw new Error("Method not implemented.")
+  }
+  properties(
+    effects: Effects,
+    timeoutMs: number | null,
+  ): Promise<T.PropertiesReturn> {
+    throw new Error("Method not implemented.")
+  }
+  async action(
+    effects: Effects,
+    id: string,
+    formData: unknown,
+    timeoutMs: number | null,
+  ): Promise<T.configTypes.InputSpec> {
+    const action = (await this.abi.actions({ effects }))[id]
+    if (!action) throw new Error(`Action ${id} not found`)
+    return action.getConfig({ effects })
+  }
+  dependenciesCheck(
+    effects: Effects,
+    id: string,
+    oldConfig: unknown,
+    timeoutMs: number | null,
+  ): Promise<any> {
+    const dependencyConfig = this.abi.dependencyConfig[id]
+    if (!dependencyConfig) throw new Error(`dependencyConfig ${id} not found`)
+    return dependencyConfig.query({ effects })
+  }
+  async dependenciesAutoconfig(
+    effects: Effects,
+    id: string,
+    remoteConfig: unknown,
+    timeoutMs: number | null,
+  ): Promise<void> {
+    const dependencyConfig = this.abi.dependencyConfig[id]
+    if (!dependencyConfig) throw new Error(`dependencyConfig ${id} not found`)
+    const queryResults = await this.getConfig(effects, timeoutMs)
+    return void (await dependencyConfig.update({
+      queryResults,
+      remoteConfig,
+    })) // TODO
+  }
+  actionsMetadata(effects: T.Effects): Promise<T.ActionMetadata[]> {
+    throw new Error("Method not implemented.")
+  }
 
   async init(): Promise<void> {}
 
@@ -69,158 +171,5 @@ export class SystemForStartOs implements System {
       await this.runningMain.effects.clearCallbacks()
       this.runningMain = undefined
     }
-  }
-
-  async execute(
-    effects: Effects,
-    options: {
-      procedure: Procedure
-      input: unknown
-      timeout?: number | undefined
-    },
-  ): Promise<RpcResult> {
-    return this._execute(effects, options)
-      .then((x) =>
-        matches(x)
-          .when(
-            object({
-              result: any,
-            }),
-            (x) => x,
-          )
-          .when(
-            object({
-              error: string,
-            }),
-            (x) => ({
-              error: {
-                code: 0,
-                message: x.error,
-              },
-            }),
-          )
-          .when(
-            object({
-              "error-code": tuple(number, string),
-            }),
-            ({ "error-code": [code, message] }) => ({
-              error: {
-                code,
-                message,
-              },
-            }),
-          )
-          .defaultTo({ result: x }),
-      )
-      .catch((error: unknown) => {
-        if (error instanceof Error)
-          return {
-            error: {
-              code: 0,
-              message: error.name,
-              data: {
-                details: error.message,
-                debug: `${error?.cause ?? "[noCause]"}:${error?.stack ?? "[noStack]"}`,
-              },
-            },
-          }
-        if (matchRpcResult.test(error)) return error
-        return {
-          error: {
-            code: 0,
-            message: String(error),
-          },
-        }
-      })
-  }
-  async _execute(
-    effects: Effects | MainEffects,
-    options: {
-      procedure: Procedure
-      input: unknown
-      timeout?: number | undefined
-    },
-  ): Promise<unknown> {
-    switch (options.procedure) {
-      case "/init": {
-        const previousVersion =
-          string.optional().unsafeCast(options.input) || null
-        return this.abi.init({ effects, previousVersion })
-      }
-      case "/uninit": {
-        const nextVersion = string.optional().unsafeCast(options.input) || null
-        return this.abi.uninit({ effects, nextVersion })
-      }
-      // case "/main/start": {
-      //
-      // }
-      // case "/main/stop": {
-      //   if (this.onTerm) await this.onTerm()
-      //   await effects.setMainStatus({ status: "stopped" })
-      //   delete this.onTerm
-      //   return duration(30, "s")
-      // }
-      case "/config/set": {
-        const input = options.input as any // TODO
-        return this.abi.setConfig({ effects, input })
-      }
-      case "/config/get": {
-        return this.abi.getConfig({ effects })
-      }
-      case "/backup/create":
-        return this.abi.createBackup({
-          effects,
-          pathMaker: ((options) =>
-            new Volume(options.volume, options.path).path) as T.PathMaker,
-        })
-      case "/backup/restore":
-        return this.abi.restoreBackup({
-          effects,
-          pathMaker: ((options) =>
-            new Volume(options.volume, options.path).path) as T.PathMaker,
-        })
-      case "/actions/metadata": {
-        return this.abi.actionsMetadata({ effects })
-      }
-      case "/properties": {
-        throw new Error("TODO")
-      }
-      default:
-        const procedures = unNestPath(options.procedure)
-        const id = procedures[2]
-        switch (true) {
-          case procedures[1] === "actions" && procedures[3] === "get": {
-            const action = (await this.abi.actions({ effects }))[id]
-            if (!action) throw new Error(`Action ${id} not found`)
-            return action.getConfig({ effects })
-          }
-          case procedures[1] === "actions" && procedures[3] === "run": {
-            const action = (await this.abi.actions({ effects }))[id]
-            if (!action) throw new Error(`Action ${id} not found`)
-            return action.run({ effects, input: options.input as any }) // TODO
-          }
-          case procedures[1] === "dependencies" && procedures[3] === "query": {
-            const dependencyConfig = this.abi.dependencyConfig[id]
-            if (!dependencyConfig)
-              throw new Error(`dependencyConfig ${id} not found`)
-            const localConfig = options.input
-            return dependencyConfig.query({ effects })
-          }
-          case procedures[1] === "dependencies" && procedures[3] === "update": {
-            const dependencyConfig = this.abi.dependencyConfig[id]
-            if (!dependencyConfig)
-              throw new Error(`dependencyConfig ${id} not found`)
-            return dependencyConfig.update(options.input as any) // TODO
-          }
-        }
-        return
-    }
-  }
-
-  async sandbox(
-    effects: Effects,
-    options: { procedure: Procedure; input: unknown; timeout?: number },
-  ): Promise<RpcResult> {
-    return this.execute(effects, options)
   }
 }

--- a/container-runtime/src/Interfaces/System.ts
+++ b/container-runtime/src/Interfaces/System.ts
@@ -3,6 +3,7 @@ import { RpcResult } from "../Adapters/RpcListener"
 import { Effects } from "../Models/Effects"
 import { CallbackHolder } from "../Models/CallbackHolder"
 import { MainEffects } from "@start9labs/start-sdk/cjs/lib/StartSdk"
+import { Optional } from "ts-matches/lib/parsers/interfaces"
 
 export type Procedure =
   | "/init"
@@ -22,28 +23,60 @@ export type ExecuteResult =
   | { ok: unknown }
   | { err: { code: number; message: string } }
 export type System = {
-  init(): Promise<void>
+  containerInit(): Promise<void>
 
   start(effects: MainEffects): Promise<void>
   callCallback(callback: number, args: any[]): void
   stop(): Promise<void>
 
-  execute(
+  packageInit(
     effects: Effects,
-    options: {
-      procedure: Procedure
-      input: unknown
-      timeout?: number
-    },
-  ): Promise<RpcResult>
-  sandbox(
+    previousVersion: Optional<string>,
+    timeoutMs: number | null,
+  ): Promise<void>
+  packageUninit(
     effects: Effects,
-    options: {
-      procedure: Procedure
-      input: unknown
-      timeout?: number
-    },
-  ): Promise<RpcResult>
+    nextVersion: Optional<string>,
+    timeoutMs: number | null,
+  ): Promise<void>
+
+  createBackup(effects: T.Effects, timeoutMs: number | null): Promise<void>
+  restoreBackup(effects: T.Effects, timeoutMs: number | null): Promise<void>
+  getConfig(effects: T.Effects, timeoutMs: number | null): Promise<T.ConfigRes>
+  setConfig(
+    effects: Effects,
+    input: { effects: Effects; input: Record<string, unknown> },
+    timeoutMs: number | null,
+  ): Promise<void>
+  migration(
+    effects: Effects,
+    fromVersion: string,
+    timeoutMs: number | null,
+  ): Promise<T.MigrationRes>
+  properties(
+    effects: Effects,
+    timeoutMs: number | null,
+  ): Promise<T.PropertiesReturn>
+  action(
+    effects: Effects,
+    actionId: string,
+    formData: unknown,
+    timeoutMs: number | null,
+  ): Promise<T.configTypes.InputSpec>
+
+  dependenciesCheck(
+    effects: Effects,
+    id: string,
+    oldConfig: unknown,
+    timeoutMs: number | null,
+  ): Promise<any>
+  dependenciesAutoconfig(
+    effects: Effects,
+    id: string,
+    oldConfig: unknown,
+    timeoutMs: number | null,
+  ): Promise<void>
+  actionsMetadata(effects: T.Effects): Promise<T.ActionMetadata[]>
 
   exit(): Promise<void>
 }

--- a/container-runtime/src/Interfaces/System.ts
+++ b/container-runtime/src/Interfaces/System.ts
@@ -62,7 +62,7 @@ export type System = {
     actionId: string,
     formData: unknown,
     timeoutMs: number | null,
-  ): Promise<T.configTypes.InputSpec>
+  ): Promise<T.ActionResult>
 
   dependenciesCheck(
     effects: Effects,

--- a/sdk/lib/types.ts
+++ b/sdk/lib/types.ts
@@ -35,6 +35,11 @@ export type ExportedAction = (options: {
   input?: Record<string, unknown>
 }) => Promise<ActionResult>
 export type MaybePromise<A> = Promise<A> | A
+
+export type Action = {
+  run: ExportedAction
+  getConfig: (options: { effects: Effects }) => Promise<InputSpec>
+}
 export namespace ExpectedExports {
   version: 1
   /** Set configuration is called after we have modified and saved the configuration in the start9 ui. Use this to make a file for the docker to read from for configuration.  */
@@ -71,10 +76,7 @@ export namespace ExpectedExports {
    * service starting, and that file would indicate that it would rescan all the data.
    */
   export type actions = (options: { effects: Effects }) => MaybePromise<{
-    [id: string]: {
-      run: ExportedAction
-      getConfig: (options: { effects: Effects }) => Promise<InputSpec>
-    }
+    [id: string]: Action
   }>
 
   export type actionsMetadata = (options: {


### PR DESCRIPTION
## Why

I want to make all the routes for each of the service adapters for the embassy and start9 services use fn's instead of routes