### PR TITLE
chore: reimplement refactor for the changes

### DIFF
--- a/container-runtime/src/Adapters/RpcListener.ts
+++ b/container-runtime/src/Adapters/RpcListener.ts
@@ -19,7 +19,7 @@ import * as fs from "fs"
 
 import { CallbackHolder } from "../Models/CallbackHolder"
 import { AllGetDependencies } from "../Interfaces/AllGetDependencies"
-import { jsonPath } from "../Models/JsonPath"
+import { jsonPath, unNestPath } from "../Models/JsonPath"
 import { RunningMain, System } from "../Interfaces/System"
 import {
   MakeMainEffects,
@@ -64,7 +64,7 @@ const runType = object({
       input: any,
       timeout: number,
     },
-    ["timeout", "input"],
+    ["timeout"],
   ),
 })
 const sandboxRunType = object({
@@ -77,7 +77,7 @@ const sandboxRunType = object({
       input: any,
       timeout: number,
     },
-    ["timeout", "input"],
+    ["timeout"],
   ),
 })
 const callbackType = object({
@@ -226,27 +226,25 @@ export class RpcListener {
         const system = this.system
         const procedure = jsonPath.unsafeCast(params.procedure)
         const effects = this.getDependencies.makeProcedureEffects()(params.id)
-        return handleRpc(
-          id,
-          system.execute(effects, {
-            procedure,
-            input: params.input,
-            timeout: params.timeout,
-          }),
-        )
+        const input = params.input
+        const timeout = params.timeout
+        const result = getResult(procedure, system, effects, timeout, input)
+
+        return handleRpc(id, result)
       })
       .when(sandboxRunType, async ({ id, params }) => {
         const system = this.system
         const procedure = jsonPath.unsafeCast(params.procedure)
         const effects = this.makeProcedureEffects(params.id)
-        return handleRpc(
-          id,
-          system.sandbox(effects, {
-            procedure,
-            input: params.input,
-            timeout: params.timeout,
-          }),
+        const result = getResult(
+          procedure,
+          system,
+          effects,
+          params.input,
+          params.input,
         )
+
+        return handleRpc(id, result)
       })
       .when(callbackType, async ({ params: { callback, args } }) => {
         this.system.callCallback(callback, args)
@@ -280,7 +278,7 @@ export class RpcListener {
           (async () => {
             if (!this._system) {
               const system = await this.getDependencies.system()
-              await system.init()
+              await system.containerInit()
               this._system = system
             }
           })().then((result) => ({ result })),
@@ -341,4 +339,89 @@ export class RpcListener {
         }
       })
   }
+}
+function getResult(
+  procedure: typeof jsonPath._TYPE,
+  system: System,
+  effects: T.Effects,
+  timeout: number | undefined,
+  input: any,
+) {
+  return (async () => {
+    switch (procedure) {
+      case "/backup/create":
+        return system.createBackup(effects, timeout || null)
+      case "/backup/restore":
+        return system.restoreBackup(effects, timeout || null)
+      case "/config/get":
+        return system.getConfig(effects, timeout || null)
+      case "/config/set":
+        return system.setConfig(effects, input, timeout || null)
+      case "/properties":
+        return system.properties(effects, timeout || null)
+      case "/actions/metadata":
+        return system.actionsMetadata(effects)
+      case "/init":
+        return system.packageInit(
+          effects,
+          string.optional().unsafeCast(input),
+          timeout || null,
+        )
+      case "/uninit":
+        return system.packageUninit(
+          effects,
+          string.optional().unsafeCast(input),
+          timeout || null,
+        )
+      default:
+        const procedures = unNestPath(procedure)
+        switch (true) {
+          case procedures[1] === "actions" && procedures[3] === "get":
+            return system.action(effects, procedures[2], input, timeout || null)
+          case procedures[1] === "actions" && procedures[3] === "run":
+            return system.action(effects, procedures[2], input, timeout || null)
+          case procedures[1] === "dependencies" && procedures[3] === "query":
+            return system.dependenciesAutoconfig(
+              effects,
+              procedures[2],
+              input,
+              timeout || null,
+            )
+
+          case procedures[1] === "dependencies" && procedures[3] === "update":
+            return system.dependenciesAutoconfig(
+              effects,
+              procedures[2],
+              input,
+              timeout || null,
+            )
+        }
+    }
+  })().then(
+    (result) => ({ result }),
+    (error) =>
+      matches(error)
+        .when(
+          object(
+            {
+              error: string,
+              code: number,
+            },
+            ["code"],
+            { code: 0 },
+          ),
+          (error) => ({
+            error: {
+              code: error.code,
+              message: error.error,
+            },
+          }),
+        )
+        .defaultToLazy(() => ({
+          error: {
+            code: 0,
+            message: String(error),
+          },
+        })),
+  )
 }

--- a/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
@@ -61,6 +61,39 @@ const MANIFEST_LOCATION = "/usr/lib/startos/package/embassyManifest.json"
 export const EMBASSY_JS_LOCATION = "/usr/lib/startos/package/embassy.js"
 const EMBASSY_POINTER_PATH_PREFIX = "/embassyConfig" as StorePath
 
+const matchResult = object({
+  result: any,
+})
+const matchError = object({
+  error: string,
+})
+const matchErrorCode = object<{
+  "error-code": [number, string] | readonly [number, string]
+}>({
+  "error-code": tuple(number, string),
+})
+
+const assertNever = (
+  x: never,
+  message = "Not expecting to get here",
+): never => {
+  throw new Error(message)
+}
+const fromReturnType = <A>(a: U.ResultType<A>): A => {
+  if (matchResult.test(a)) {
+    return a.result
+  }
+  if (matchError.test(a)) {
+    console.info({ passedErrorStack: new Error().stack, error: a.error })
+    throw { error: a.error }
+  }
+  if (matchErrorCode.test(a)) {
+    const [code, message] = a["error-code"]
+    throw { error: message, code }
+  }
+  return assertNever(a)
+}
+
 const matchSetResult = object(
   {
     "depends-on": dictionary([string, array(string)]),
@@ -206,12 +239,49 @@ export class SystemForEmbassy implements System {
       moduleCode,
     )
   }
+
   constructor(
     readonly manifest: Manifest,
     readonly moduleCode: Partial<U.ExpectedExports>,
   ) {}
 
-  async init(): Promise<void> {}
+  async actionsMetadata(effects: T.Effects): Promise<T.ActionMetadata[]> {
+    const actions = Object.entries(this.manifest.actions ?? {})
+    return Promise.all(
+      actions.map(async ([actionId, action]): Promise<T.ActionMetadata> => {
+        const name = action.name ?? actionId
+        const description = action.description
+        const warning = action.warning ?? null
+        const disabled = false
+        const input = (await convertToNewConfig(action["input-spec"] as any))
+          .spec
+        const hasRunning = !!action["allowed-statuses"].find(
+          (x) => x === "running",
+        )
+        const hasStopped = !!action["allowed-statuses"].find(
+          (x) => x === "stopped",
+        )
+        // prettier-ignore
+        const allowedStatuses = 
+        hasRunning && hasStopped ? "any":
+        hasRunning ? "onlyRunning" :
+        "onlyStopped"
+
+        const group = null
+        return {
+          name,
+          description,
+          warning,
+          disabled,
+          allowedStatuses,
+          group,
+          input,
+        }
+      }),
+    )
+  }
+
+  async containerInit(): Promise<void> {}
 
   async exit(): Promise<void> {
     if (this.currentRunning) await this.currentRunning.clean()
@@ -235,141 +305,7 @@ export class SystemForEmbassy implements System {
     }
   }
 
-  async execute(
-    effects: Effects,
-    options: {
-      procedure: JsonPath
-      input?: unknown
-      timeout?: number | undefined
-    },
-  ): Promise<RpcResult> {
-    return this._execute(effects, options)
-      .then((x) =>
-        matches(x)
-          .when(
-            object({
-              result: any,
-            }),
-            (x) => x,
-          )
-          .when(
-            object({
-              error: string,
-            }),
-            (x) => ({
-              error: {
-                code: 0,
-                message: x.error,
-              },
-            }),
-          )
-          .when(
-            object({
-              "error-code": tuple(number, string),
-            }),
-            ({ "error-code": [code, message] }) => ({
-              error: {
-                code,
-                message,
-              },
-            }),
-          )
-          .defaultTo({ result: x }),
-      )
-      .catch((error: unknown) => {
-        if (error instanceof Error)
-          return {
-            error: {
-              code: 0,
-              message: error.name,
-              data: {
-                details: error.message,
-                debug: `${error?.cause ?? "[noCause]"}:${error?.stack ?? "[noStack]"}`,
-              },
-            },
-          }
-        if (matchRpcResult.test(error)) return error
-        return {
-          error: {
-            code: 0,
-            message: String(error),
-          },
-        }
-      })
-  }
-  async _execute(
-    effects: Effects,
-    options: {
-      procedure: JsonPath
-      input?: unknown
-      timeout?: number | undefined
-    },
-  ): Promise<unknown> {
-    const input = options.input
-    switch (options.procedure) {
-      case "/backup/create":
-        return this.createBackup(effects, options.timeout || null)
-      case "/backup/restore":
-        return this.restoreBackup(effects, options.timeout || null)
-      case "/config/get":
-        return this.getConfig(effects, options.timeout || null)
-      case "/config/set":
-        return this.setConfig(effects, input, options.timeout || null)
-      case "/properties":
-        return this.properties(effects, options.timeout || null)
-      case "/actions/metadata":
-        return todo()
-      case "/init":
-        return this.initProcedure(
-          effects,
-          string.optional().unsafeCast(input),
-          options.timeout || null,
-        )
-      case "/uninit":
-        return this.uninit(
-          effects,
-          string.optional().unsafeCast(input),
-          options.timeout || null,
-        )
-      default:
-        const procedures = unNestPath(options.procedure)
-        switch (true) {
-          case procedures[1] === "actions" && procedures[3] === "get":
-            return this.action(
-              effects,
-              procedures[2],
-              input,
-              options.timeout || null,
-            )
-          case procedures[1] === "actions" && procedures[3] === "run":
-            return this.action(
-              effects,
-              procedures[2],
-              input,
-              options.timeout || null,
-            )
-          case procedures[1] === "dependencies" && procedures[3] === "query":
-            return null
-
-          case procedures[1] === "dependencies" && procedures[3] === "update":
-            return this.dependenciesAutoconfig(
-              effects,
-              procedures[2],
-              input,
-              options.timeout || null,
-            )
-        }
-    }
-    throw new Error(`Could not find the path for ${options.procedure}`)
-  }
-  async sandbox(
-    effects: Effects,
-    options: { procedure: Procedure; input: unknown; timeout?: number },
-  ): Promise<RpcResult> {
-    return this.execute(effects, options)
-  }
-
-  private async initProcedure(
+  async packageInit(
     effects: Effects,
     previousVersion: Optional<string>,
     timeoutMs: number | null,
@@ -489,7 +425,7 @@ export class SystemForEmbassy implements System {
       })
     }
   }
-  private async uninit(
+  async packageUninit(
     effects: Effects,
     nextVersion: Optional<string>,
     timeoutMs: number | null,
@@ -498,7 +434,7 @@ export class SystemForEmbassy implements System {
     await effects.setMainStatus({ status: "stopped" })
   }
 
-  private async createBackup(
+  async createBackup(
     effects: Effects,
     timeoutMs: number | null,
   ): Promise<void> {
@@ -519,7 +455,7 @@ export class SystemForEmbassy implements System {
       await moduleCode.createBackup?.(polyfillEffects(effects, this.manifest))
     }
   }
-  private async restoreBackup(
+  async restoreBackup(
     effects: Effects,
     timeoutMs: number | null,
   ): Promise<void> {
@@ -543,7 +479,7 @@ export class SystemForEmbassy implements System {
       await moduleCode.restoreBackup?.(polyfillEffects(effects, this.manifest))
     }
   }
-  private async getConfig(
+  async getConfig(
     effects: Effects,
     timeoutMs: number | null,
   ): Promise<T.ConfigRes> {
@@ -584,7 +520,7 @@ export class SystemForEmbassy implements System {
       )) as any
     }
   }
-  private async setConfig(
+  async setConfig(
     effects: Effects,
     newConfigWithoutPointers: unknown,
     timeoutMs: number | null,
@@ -676,7 +612,7 @@ export class SystemForEmbassy implements System {
     })
   }
 
-  private async migration(
+  async migration(
     effects: Effects,
     fromVersion: string,
     timeoutMs: number | null,
@@ -748,10 +684,10 @@ export class SystemForEmbassy implements System {
     }
     return { configured: true }
   }
-  private async properties(
+  async properties(
     effects: Effects,
     timeoutMs: number | null,
-  ): Promise<ReturnType<T.ExpectedExports.properties>> {
+  ): Promise<T.PropertiesReturn> {
     // TODO BLU-J set the properties ever so often
     const setConfigValue = this.manifest.properties
     if (!setConfigValue) throw new Error("There is no properties")
@@ -779,36 +715,84 @@ export class SystemForEmbassy implements System {
       if (!method)
         throw new Error("Expecting that the method properties exists")
       const properties = matchProperties.unsafeCast(
-        await method(polyfillEffects(effects, this.manifest)).then((x) => {
-          if ("result" in x) return x.result
-          if ("error" in x) throw new Error("Error getting config: " + x.error)
-          throw new Error("Error getting config: " + x["error-code"][1])
-        }),
+        await method(polyfillEffects(effects, this.manifest)).then(
+          fromReturnType,
+        ),
       )
       return asProperty(properties.data)
     }
     throw new Error(`Unknown type in the fetch properties: ${setConfigValue}`)
   }
-  private async action(
+  async action(
     effects: Effects,
     actionId: string,
     formData: unknown,
     timeoutMs: number | null,
   ): Promise<T.ActionResult> {
     const actionProcedure = this.manifest.actions?.[actionId]?.implementation
-    if (!actionProcedure) return { message: "Action not found", value: null }
+    const toActionResult = ({
+      message,
+      value = "",
+      copyable,
+      qr,
+    }: U.ActionResult): T.ActionResult => ({
+      message,
+      value: {
+        value,
+        copyable,
+        qr,
+      },
+    })
+    if (!actionProcedure) throw Error("Action not found")
     if (actionProcedure.type === "docker") {
-      const overlay = actionProcedure.inject
-        ? this.currentRunning?.mainOverlay
-        : undefined
       const container = await DockerProcedureContainer.of(
         effects,
         this.manifest.id,
         actionProcedure,
         this.manifest.volumes,
-        {
-          overlay,
-        },
+      )
+      return toActionResult(
+        fromReturnType(
+          JSON.parse(
+            (
+              await container.execFail(
+                [
+                  actionProcedure.entrypoint,
+                  ...actionProcedure.args,
+                  JSON.stringify(formData),
+                ],
+                timeoutMs,
+              )
+            ).stdout.toString(),
+          ),
+        ),
+      )
+    } else {
+      const moduleCode = await this.moduleCode
+      const method = moduleCode.action?.[actionId]
+      if (!method) throw new Error("Expecting that the method action exists")
+      return await method(
+        polyfillEffects(effects, this.manifest),
+        formData as any,
+      )
+        .then(fromReturnType)
+        .then(toActionResult)
+    }
+  }
+  async dependenciesCheck(
+    effects: Effects,
+    id: string,
+    oldConfig: unknown,
+    timeoutMs: number | null,
+  ): Promise<object> {
+    const actionProcedure = this.manifest.dependencies?.[id]?.config?.check
+    if (!actionProcedure) return { message: "Action not found", value: null }
+    if (actionProcedure.type === "docker") {
+      const container = await DockerProcedureContainer.of(
+        effects,
+        this.manifest.id,
+        actionProcedure,
+        this.manifest.volumes,
       )
       return JSON.parse(
         (
@@ -816,27 +800,32 @@ export class SystemForEmbassy implements System {
             [
               actionProcedure.entrypoint,
               ...actionProcedure.args,
-              JSON.stringify(formData),
+              JSON.stringify(oldConfig),
             ],
             timeoutMs,
           )
         ).stdout.toString(),
       )
-    } else {
+    } else if (actionProcedure.type === "script") {
       const moduleCode = await this.moduleCode
-      const method = moduleCode.action?.[actionId]
-      if (!method) throw new Error("Expecting that the method action exists")
+      const method = moduleCode.dependencies?.[id]?.check
+      if (!method)
+        throw new Error(
+          `Expecting that the method dependency check ${id} exists`,
+        )
       return (await method(
         polyfillEffects(effects, this.manifest),
-        formData as any,
+        oldConfig as any,
       ).then((x) => {
         if ("result" in x) return x.result
         if ("error" in x) throw new Error("Error getting config: " + x.error)
         throw new Error("Error getting config: " + x["error-code"][1])
       })) as any
+    } else {
+      return {}
     }
   }
-  private async dependenciesAutoconfig(
+  async dependenciesAutoconfig(
     effects: Effects,
     id: string,
     input: unknown,

--- a/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
@@ -75,9 +75,9 @@ const matchErrorCode = object<{
 
 const assertNever = (
   x: never,
-  message = "Not expecting to get here",
+  message = "Not expecting to get here: ",
 ): never => {
-  throw new Error(message)
+  throw new Error(message + JSON.stringify(x))
 }
 const fromReturnType = <A>(a: U.ResultType<A>): A => {
   if (matchResult.test(a)) {
@@ -736,12 +736,11 @@ export class SystemForEmbassy implements System {
       copyable,
       qr,
     }: U.ActionResult): T.ActionResult => ({
+      version: "0",
       message,
-      value: {
-        value,
-        copyable,
-        qr,
-      },
+      value,
+      copyable,
+      qr,
     })
     if (!actionProcedure) throw Error("Action not found")
     if (actionProcedure.type === "docker") {
@@ -752,19 +751,17 @@ export class SystemForEmbassy implements System {
         this.manifest.volumes,
       )
       return toActionResult(
-        fromReturnType(
-          JSON.parse(
-            (
-              await container.execFail(
-                [
-                  actionProcedure.entrypoint,
-                  ...actionProcedure.args,
-                  JSON.stringify(formData),
-                ],
-                timeoutMs,
-              )
-            ).stdout.toString(),
-          ),
+        JSON.parse(
+          (
+            await container.execFail(
+              [
+                actionProcedure.entrypoint,
+                ...actionProcedure.args,
+                JSON.stringify(formData),
+              ],
+              timeoutMs,
+            )
+          ).stdout.toString(),
         ),
       )
     } else {

--- a/container-runtime/src/Interfaces/System.ts
+++ b/container-runtime/src/Interfaces/System.ts
@@ -3,6 +3,7 @@ import { RpcResult } from "../Adapters/RpcListener"
 import { Effects } from "../Models/Effects"
 import { CallbackHolder } from "../Models/CallbackHolder"
 import { MainEffects } from "@start9labs/start-sdk/cjs/lib/StartSdk"
+import { Optional } from "ts-matches/lib/parsers/interfaces"
 
 export type Procedure =
   | "/init"
@@ -22,28 +23,60 @@ export type ExecuteResult =
   | { ok: unknown }
   | { err: { code: number; message: string } }
 export type System = {
-  init(): Promise<void>
+  containerInit(): Promise<void>
 
   start(effects: MainEffects): Promise<void>
   callCallback(callback: number, args: any[]): void
   stop(): Promise<void>
 
-  execute(
+  packageInit(
     effects: Effects,
-    options: {
-      procedure: Procedure
-      input: unknown
-      timeout?: number
-    },
-  ): Promise<RpcResult>
-  sandbox(
+    previousVersion: Optional<string>,
+    timeoutMs: number | null,
+  ): Promise<void>
+  packageUninit(
     effects: Effects,
-    options: {
-      procedure: Procedure
-      input: unknown
-      timeout?: number
-    },
-  ): Promise<RpcResult>
+    nextVersion: Optional<string>,
+    timeoutMs: number | null,
+  ): Promise<void>
+
+  createBackup(effects: T.Effects, timeoutMs: number | null): Promise<void>
+  restoreBackup(effects: T.Effects, timeoutMs: number | null): Promise<void>
+  getConfig(effects: T.Effects, timeoutMs: number | null): Promise<T.ConfigRes>
+  setConfig(
+    effects: Effects,
+    input: { effects: Effects; input: Record<string, unknown> },
+    timeoutMs: number | null,
+  ): Promise<void>
+  migration(
+    effects: Effects,
+    fromVersion: string,
+    timeoutMs: number | null,
+  ): Promise<T.MigrationRes>
+  properties(
+    effects: Effects,
+    timeoutMs: number | null,
+  ): Promise<T.PropertiesReturn>
+  action(
+    effects: Effects,
+    actionId: string,
+    formData: unknown,
+    timeoutMs: number | null,
+  ): Promise<T.ActionResult>
+
+  dependenciesCheck(
+    effects: Effects,
+    id: string,
+    oldConfig: unknown,
+    timeoutMs: number | null,
+  ): Promise<any>
+  dependenciesAutoconfig(
+    effects: Effects,
+    id: string,
+    oldConfig: unknown,
+    timeoutMs: number | null,
+  ): Promise<void>
+  actionsMetadata(effects: T.Effects): Promise<T.ActionMetadata[]>
 
   exit(): Promise<void>
 }

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -231,7 +231,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e89b6941c2d1a7045538884d6e760ccfffdf8e1ffc2613d8efa74305e1f3752"
+checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
 dependencies = [
  "bindgen",
  "cc",
@@ -532,7 +532,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.72",
+ "syn 2.0.74",
  "which",
 ]
 
@@ -675,9 +675,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cache-padded"
@@ -687,12 +687,13 @@ checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -799,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.11"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -809,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.11"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -821,14 +822,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -839,9 +840,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cmake"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
 dependencies = [
  "cc",
 ]
@@ -1035,15 +1036,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -1117,16 +1118,16 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.6.0",
  "crossterm_winapi",
  "futures-core",
- "libc",
- "mio 0.8.11",
+ "mio",
  "parking_lot",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1236,7 +1237,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1260,7 +1261,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1271,7 +1272,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1302,7 +1303,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1325,7 +1326,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1348,7 +1349,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1416,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1570,7 +1571,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1667,14 +1668,14 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+checksum = "bf401df4a4e3872c4fe8151134cf483738e74b67fc934d6532c882b3d24a4550"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
- "windows-sys 0.52.0",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1685,9 +1686,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1828,7 +1829,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1941,7 +1942,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1960,7 +1961,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2069,6 +2070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,9 +2083,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hifijson"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ae468bcb4dfecf0e4949ee28abbc99076b6a0077f51ddbc94dbfff8e6a870c"
+checksum = "9958ab3ce3170c061a27679916bd9b969eceeb5e8b120438e6751d0987655c42"
 
 [[package]]
 name = "hkdf"
@@ -2273,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2432,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -2475,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "4.0.0"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924df4f0e24e2e7f9cdd90babb0b96f93b20f3ecfa949ea9e6613756b8c8e1bf"
+checksum = "0d762194228a2f1c11063e46e32e5acb96e66e906382b9eb5441f2e0504bbd5a"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2504,11 +2511,11 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2647,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2799,6 +2806,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
+ "redox_syscall 0.5.3",
 ]
 
 [[package]]
@@ -2945,24 +2953,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
-dependencies = [
- "hermit-abi",
- "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -3029,9 +3026,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "new_mime_guess"
-version = "4.0.1"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d684d1b59e0dc07b37e2203ef576987473288f530082512aff850585c61b1f"
+checksum = "02a2dfb3559d53e90b709376af1c379462f7fb3085a0177deb73e6ea0d99eff4"
 dependencies = [
  "mime",
  "unicase",
@@ -3219,29 +3216,29 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3307,7 +3304,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3514,7 +3511,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3535,7 +3532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
 ]
 
 [[package]]
@@ -3570,7 +3567,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3626,9 +3623,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -3643,7 +3643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3715,7 +3715,7 @@ checksum = "6ff7ff745a347b87471d859a377a9a404361e7efc2a971d73424a6d183c0fc77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3738,7 +3738,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3938,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4009,7 +4009,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "rpc-toolkit"
 version = "0.2.3"
-source = "git+https://github.com/Start9Labs/rpc-toolkit.git?branch=refactor/no-dyn-ctx#f608480034942f1f521ab95949ab33fbc51d99a9"
+source = "git+https://github.com/Start9Labs/rpc-toolkit.git?branch=refactor/no-dyn-ctx#60a974a29c5e6380f7bbfbc1b4716f6d2b20b189"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4217,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
  "base64 0.22.1",
  "rustls-pki-types",
@@ -4227,9 +4227,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -4273,9 +4273,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline-async"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6eb06391513b2184f0a5405c11a4a0a5302e8be442f4c5c35267187c2b37d5"
+checksum = "bc9396d834c31f9fddd716e7c279e7cb70207092a1e59767918610f5c560c6eb"
 dependencies = [
  "crossterm",
  "futures-channel",
@@ -4375,9 +4375,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -4401,23 +4401,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -4463,7 +4464,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4480,7 +4481,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -4489,7 +4490,7 @@ version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ce6afeda22f0b55dde2c34897bce76a629587348480384231205c14b59a01f"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "itoa",
  "libyml",
  "log",
@@ -4578,12 +4579,12 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio 0.8.11",
+ "mio",
  "signal-hook",
 ]
 
@@ -4724,7 +4725,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "log",
  "memchr",
  "once_cell",
@@ -4913,7 +4914,7 @@ dependencies = [
  "quote",
  "regex-syntax 0.6.29",
  "strsim 0.10.0",
- "syn 2.0.72",
+ "syn 2.0.74",
  "unicode-width",
 ]
 
@@ -5006,7 +5007,7 @@ dependencies = [
  "imbl",
  "imbl-value",
  "include_dir",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "indicatif",
  "integer-encoding",
  "ipnet",
@@ -5072,7 +5073,7 @@ dependencies = [
  "tokio-tar",
  "tokio-tungstenite 0.23.1",
  "tokio-util",
- "toml 0.8.16",
+ "toml 0.8.19",
  "torut",
  "tower-service",
  "tracing",
@@ -5150,9 +5151,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5211,14 +5212,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5279,7 +5281,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -5360,14 +5362,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio 1.0.1",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -5395,7 +5397,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -5421,9 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-socks"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
 dependencies = [
  "either",
  "futures-util",
@@ -5510,21 +5512,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.17",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -5535,7 +5537,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5548,22 +5550,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.17"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.16",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -5634,15 +5636,15 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -5664,7 +5666,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -5816,7 +5818,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
  "termcolor",
 ]
 
@@ -5876,7 +5878,7 @@ checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6074,34 +6076,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6111,9 +6114,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6121,22 +6124,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
@@ -6153,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6207,11 +6210,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6243,6 +6246,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6379,9 +6391,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.16"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -6470,6 +6482,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -6481,7 +6494,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6501,7 +6514,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6515,18 +6528,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/sdk/lib/types.ts
+++ b/sdk/lib/types.ts
@@ -476,12 +476,11 @@ export type MigrationRes = {
 }
 
 export type ActionResult = {
+  version: "0"
   message: string
-  value: null | {
-    value: string
-    copyable: boolean
-    qr: boolean
-  }
+  value: string | null
+  copyable: boolean
+  qr: boolean
 }
 export type SetResult = {
   dependsOn: DependsOn


### PR DESCRIPTION
## Why

I want to make all the routes for each of the service adapters for the embassy and start9 services use fn's instead of routes