### PR TITLE
feat: Adding in the effects to the startSdk

### DIFF
--- a/sdk/lib/StartSdk.ts
+++ b/sdk/lib/StartSdk.ts
@@ -139,7 +139,51 @@ export class StartSdk<Manifest extends T.Manifest, Store> {
       }]?: Dependency
     }
 
+    type NestedEffects = "subcontainer" | "store"
+    type InterfaceEffects =
+      | "getServiceInterface"
+      | "listServiceInterfaces"
+      | "exportServiceInterface"
+      | "clearServiceInterfaces"
+      | "bind"
+      | "getHostInfo"
+      | "getPrimaryUrl"
+    type MainUsedEffects = "setMainStatus" | "setHealth"
+    type AlreadyExposed = "getSslCertificate" | "getSystemSmtp"
+
+    // prettier-ignore
+    type StartSdkEffectWrapper = {
+      [K in keyof Omit<Effects, NestedEffects | InterfaceEffects | MainUsedEffects| AlreadyExposed>]: (effects: Effects, ...args: Parameters<Effects[K]>) => ReturnType<Effects[K]>
+    }
+    const startSdkEffectWrapper: StartSdkEffectWrapper = {
+      executeAction: (effects, ...args) => effects.executeAction(...args),
+      exportAction: (effects, ...args) => effects.exportAction(...args),
+      clearActions: (effects, ...args) => effects.clearActions(...args),
+      getConfigured: (effects, ...args) => effects.getConfigured(...args),
+      setConfigured: (effects, ...args) => effects.setConfigured(...args),
+      restart: (effects, ...args) => effects.restart(...args),
+      setDependencies: (effects, ...args) => effects.setDependencies(...args),
+      checkDependencies: (effects, ...args) =>
+        effects.checkDependencies(...args),
+      mount: (effects, ...args) => effects.mount(...args),
+      getInstalledPackages: (effects, ...args) =>
+        effects.getInstalledPackages(...args),
+      exposeForDependents: (effects, ...args) =>
+        effects.exposeForDependents(...args),
+      getServicePortForward: (effects, ...args) =>
+        effects.getServicePortForward(...args),
+      clearBindings: (effects, ...args) => effects.clearBindings(...args),
+      getContainerIp: (effects, ...args) => effects.getContainerIp(...args),
+      getSslKey: (effects, ...args) => effects.getSslKey(...args),
+      setDataVersion: (effects, ...args) => effects.setDataVersion(...args),
+      getDataVersion: (effects, ...args) => effects.getDataVersion(...args),
+      shutdown: (effects, ...args) => effects.shutdown(...args),
+      getDependencies: (effects, ...args) => effects.getDependencies(...args),
+    }
+
     return {
+      ...startSdkEffectWrapper,
+
       checkDependencies: checkDependencies as <
         DependencyId extends keyof Manifest["dependencies"] &
           PackageId = keyof Manifest["dependencies"] & PackageId,

--- a/sdk/lib/types.ts
+++ b/sdk/lib/types.ts
@@ -382,7 +382,7 @@ export type Effects = {
     hostId: HostId
     internalPort: number
   }): Promise<LanInfo>
-  /** Removes all network bindings */
+  /** Removes all network bindings, called in the setupConfig */
   clearBindings(): Promise<void>
   // host
   /** Returns information about the specified host, if it exists */


### PR DESCRIPTION
Currently the start sdk that we expose calls some of the effects. And there are others that need to be called via the effects object. The idea is that all the effects that could and should be called are from the startsdk side