### PR TITLE
sdk: fix piping stdio of Daemons, support onStdOut/onStderr

### DIFF
--- a/container-runtime/src/Adapters/Systems/SystemForEmbassy/DockerProcedureContainer.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForEmbassy/DockerProcedureContainer.ts
@@ -151,7 +151,7 @@ export class DockerProcedureContainer {
     }
   }
 
-  async spawn(commands: string[]): Promise<cp.ChildProcessWithoutNullStreams> {
+  async spawn(commands: string[]): Promise<cp.ChildProcess> {
     return await this.subcontainer.spawn(commands)
   }
 }

--- a/sdk/package/lib/mainFn/Daemon.ts
+++ b/sdk/package/lib/mainFn/Daemon.ts
@@ -37,8 +37,8 @@ export class Daemon {
           | undefined
         cwd?: string | undefined
         user?: string | undefined
-        onStdout?: (x: Buffer) => null
-        onStderr?: (x: Buffer) => null
+        onStdout?: (chunk: Buffer | string | any) => void
+        onStderr?: (chunk: Buffer | string | any) => void
         sigtermTimeout?: number
       },
     ) => {

--- a/sdk/package/lib/mainFn/Daemons.ts
+++ b/sdk/package/lib/mainFn/Daemons.ts
@@ -39,6 +39,8 @@ type DaemonsParams<
   ready: Ready
   requires: Exclude<Ids, Id>[]
   sigtermTimeout?: number
+  onStdout?: (chunk: Buffer | string | any) => void
+  onStderr?: (chunk: Buffer | string | any) => void
 }
 
 type ErrorDuplicateId<Id extends string> = `The id '${Id}' is already used`

--- a/sdk/package/lib/util/SubContainer.ts
+++ b/sdk/package/lib/util/SubContainer.ts
@@ -35,8 +35,8 @@ export interface ExecSpawnable {
   ): Promise<ExecResults>
   spawn(
     command: string[],
-    options?: CommandOptions,
-  ): Promise<cp.ChildProcessWithoutNullStreams>
+    options?: CommandOptions & StdioOptions,
+  ): Promise<cp.ChildProcess>
 }
 /**
  * Want to limit what we can do in a container, so we want to launch a container with a specific image and the mounts.
@@ -332,8 +332,8 @@ export class SubContainer implements ExecSpawnable {
 
   async spawn(
     command: string[],
-    options?: CommandOptions,
-  ): Promise<cp.ChildProcessWithoutNullStreams> {
+    options: CommandOptions & StdioOptions = { stdio: "inherit" },
+  ): Promise<cp.ChildProcess> {
     await this.waitProc()
     const imageMeta: any = await fs
       .readFile(`/media/startos/images/${this.imageId}.json`, {
@@ -342,12 +342,12 @@ export class SubContainer implements ExecSpawnable {
       .catch(() => "{}")
       .then(JSON.parse)
     let extra: string[] = []
-    if (options?.user) {
+    if (options.user) {
       extra.push(`--user=${options.user}`)
       delete options.user
     }
     let workdir = imageMeta.workdir || "/"
-    if (options?.cwd) {
+    if (options.cwd) {
       workdir = options.cwd
       delete options.cwd
     }
@@ -387,8 +387,8 @@ export class SubContainerHandle implements ExecSpawnable {
   }
   spawn(
     command: string[],
-    options?: CommandOptions,
-  ): Promise<cp.ChildProcessWithoutNullStreams> {
+    options: CommandOptions & StdioOptions = { stdio: "inherit" },
+  ): Promise<cp.ChildProcess> {
     return this.subContainer.spawn(command, options)
   }
 }
@@ -397,6 +397,10 @@ export type CommandOptions = {
   env?: { [variable: string]: string }
   cwd?: string
   user?: string
+}
+
+export type StdioOptions = {
+  stdio?: cp.IOType
 }
 
 export type MountOptions =


### PR DESCRIPTION
The default 'stdio' option of a node ChildProcess is 'pipe', causing no logs to be captured from service daemons.

Added an option 'stdio', defaulting to 'inherit' (this pipes stdio to the parent process, causing the logs to appear again).
If onStdout/onStderr hooks are used, then we switch to 'pipe' and it is the responsibility of whoever uses those to deal with logging.