### PR TITLE
allow updating grub from chroot-and-upgrade

### DIFF
--- a/build/lib/scripts/chroot-and-upgrade
+++ b/build/lib/scripts/chroot-and-upgrade
@@ -43,6 +43,8 @@ if [ -z "$NO_SYNC" ]; then
     mount -t overlay \
 		  -olowerdir=/media/startos/current,upperdir=/media/startos/upper/data,workdir=/media/startos/upper/work \
 		  overlay /media/startos/next
+    mkdir -p /media/startos/next/media/startos/root
+    mount --bind /media/startos/root /media/startos/next/media/startos/root
 fi
 
 if [ -n "$ONLY_CREATE" ]; then


### PR DESCRIPTION
By binding the rootfs into the chroot, grub-probe can successfully run inside the chroot