### PR TITLE
do not mute logs of subcontainer launch dummy

### DIFF
--- a/sdk/package/lib/util/SubContainer.ts
+++ b/sdk/package/lib/util/SubContainer.ts
@@ -57,7 +57,7 @@ export class SubContainer implements ExecSpawnable {
     this.leaderExited = false
     this.leader = cp.spawn("start-cli", ["subcontainer", "launch", rootfs], {
       killSignal: "SIGKILL",
-      stdio: "ignore",
+      stdio: "inherit",
     })
     this.leader.on("exit", () => {
       this.leaderExited = true


### PR DESCRIPTION
We've seen "subcontainer failed to launch" but additional information was unavailable because the launch command is muted. This unmutes the command