### PR TITLE
Escape backslashes in /etc/issue to prevent unwanted newlines

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -26,7 +26,7 @@ if [ -f /etc/default/grub ]; then
 fi
 
 # set local and remote login prompt
-echo "StartOS v$(cat /usr/lib/startos/VERSION.txt) [\m] on \n.local (\l)" > /etc/issue
+echo "StartOS v$(cat /usr/lib/startos/VERSION.txt) [\\m] on \\n.local (\\l)" > /etc/issue
 echo "StartOS v$(cat /usr/lib/startos/VERSION.txt)" > /etc/issue.net
 
 # change timezone


### PR DESCRIPTION
Fixing this: 
![Screenshot 2024-12-06 at 13 02 17](https://github.com/user-attachments/assets/7f8e95e6-ae3d-4c6f-bdd2-928d834475a6)
to look like this:
![Screenshot 2024-12-06 at 13 03 22](https://github.com/user-attachments/assets/303e2e32-2fdf-47e6-8c24-777fdbb71714)
