### PR TITLE
postinit adjustments

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -37,6 +37,7 @@ cat << EOF > /etc/os-release
 NAME=StartOS
 VERSION="${VERSION_ENV}"
 ID=start-os
+ID_LIKE=debian
 VERSION_ID="${VERSION}"
 PRETTY_NAME="StartOS v${VERSION_ENV}"
 HOME_URL="https://start9.com/"


### PR DESCRIPTION
`ID_LIKE` is intended for downstream software, automation tools, or scripts to infer behavior or compatibility when they don't recognize the main ID directly.
