### PR TITLE
Update pro-privacy settings for Firefox in kiosk mode

### DIFF
--- a/build/lib/scripts/enable-kiosk
+++ b/build/lib/scripts/enable-kiosk
@@ -27,7 +27,6 @@ user_pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false);
 user_pref("browser.newtabpage.activity-stream.feeds.asrouterfeed", false);
 user_pref("browser.newtabpage.activity-stream.feeds.topsites", false);
 user_pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);
-user_pref("browser.onboarding.enabled", false);
 user_pref("browser.ping-centre.telemetry", false);
 user_pref("browser.pocket.enabled",	false);
 user_pref("browser.safebrowsing.blockedURIs.enabled", false);
@@ -43,7 +42,7 @@ user_pref("browser.startup.homepage_override.mstone", "ignore");
 user_pref("browser.theme.content-theme", 0);
 user_pref("browser.theme.toolbar-theme", 0);
 user_pref("browser.urlbar.groupLabels.enabled", false);
-user_pref("browser.urlbar.suggest.searches" false);
+user_pref("browser.urlbar.suggest.searches", false);
 user_pref("datareporting.policy.firstRunURL", "");
 user_pref("datareporting.healthreport.service.enabled", false);
 user_pref("datareporting.healthreport.uploadEnabled", false);
@@ -52,12 +51,10 @@ user_pref("dom.securecontext.allowlist_onions", true);
 user_pref("dom.securecontext.whitelist_onions", true);
 user_pref("experiments.enabled", false);
 user_pref("experiments.activeExperiment", false);
-user_pref("experiments.supported", false);
 user_pref("extensions.activeThemeID", "firefox-compact-dark@mozilla.org");
 user_pref("extensions.blocklist.enabled", false);
-user_pref("extensions.getAddons.cache.enabled", false);
+user_pref("extensions.htmlaboutaddons.recommendations.enabled", false);
 user_pref("extensions.pocket.enabled", false);
-user_pref("extensions.update.enabled", false);
 user_pref("extensions.shield-recipe-client.enabled", false);
 user_pref("extensions.shield-recipe-client.user_id", "");
 user_pref("extensions.shield-recipe-client.api_url", "");
@@ -69,6 +66,9 @@ user_pref("network.connectivity-service.enabled", false);
 user_pref("network.proxy.autoconfig_url", "file:///usr/lib/startos/proxy.pac");
 user_pref("network.proxy.socks_remote_dns", true);
 user_pref("network.proxy.type", 2);
+user_pref("privacy.resistFingerprinting", true);
+user_pref("privacy.resistFingerprinting.letterboxing", true);
+user_pref("privacy.trackingprotection.enabled", true);
 user_pref("signon.rememberSignons", false);
 user_pref("toolkit.telemetry.archive.enabled", false);
 user_pref("toolkit.telemetry.bhrPing.enabled", false);
@@ -81,6 +81,17 @@ user_pref("toolkit.telemetry.shutdownPingSender.enabled", false);
 user_pref("toolkit.telemetry.unified", false);
 user_pref("toolkit.telemetry.updatePing.enabled", false);
 user_pref("toolkit.telemetry.cachedClientID", "");
+//Blocking automatic Mozilla CDN server requests
+user_pref("extensions.getAddons.showPane", false);
+user_pref("extensions.getAddons.cache.enabled", false);
+//user_pref("services.settings.server", ""); // Remote settings server (HSTS preload updates and Cerfiticate Revocation Lists are fetched)
+user_pref("browser.aboutHomeSnippets.updateUrl", "");
+user_pref("browser.newtabpage.activity-stream.feeds.snippets", false);
+user_pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
+user_pref("browser.newtabpage.activity-stream.feeds.system.topstories", false);
+user_pref("browser.newtabpage.activity-stream.feeds.discoverystreamfeed", false);
+user_pref("browser.safebrowsing.provider.mozilla.updateURL", "");
+user_pref("browser.safebrowsing.provider.mozilla.gethashURL", "");
 EOF
 
 ln -sf /usr/lib/$(uname -m)-linux-gnu/pkcs11/p11-kit-trust.so /usr/lib/firefox-esr/libnssckbi.so


### PR DESCRIPTION
Remove some outdated (as of v120) settings and add more, including some mozilla call-home blocks