### PR TITLE
Fallback DNS/NTP server privacy enhancements

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -62,7 +62,7 @@ ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime
 echo "#" > /etc/network/interfaces
 if ! [ -f /etc/resolv.conf ]; then
   rm -f /etc/resolv.conf
-  echo "nameserver 8.8.8.8" > /etc/resolv.conf # Google DNS Fallback
+  echo "nameserver 1.1.1.1" > /etc/resolv.conf # Cloudflare DNS Fallback
 fi
 if ! [ -f /run/systemd/resolve/stub-resolv.conf ]; then
     mkdir -p /run/systemd/resolve
@@ -112,6 +112,7 @@ sed -i '/\(^\|#\)\s*unqualified-search-registries\s*=\s*/c\unqualified-search-re
 sed -i 's/\(#\|\^\)\s*\([^=]\+\)=\(suspend\|hibernate\)\s*$/\2=ignore/g' /etc/systemd/logind.conf
 sed -i '/\(^\|#\)MulticastDNS=/c\MulticastDNS=no' /etc/systemd/resolved.conf
 sed -i 's/\[Service\]/[Service]\nEnvironment=SYSTEMD_LOG_LEVEL=debug/' /lib/systemd/system/systemd-timesyncd.service
+sed -i "s/\.debian\./\./g;s/#FallbackNTP=/FallbackNTP=/"  /etc/systemd/timesyncd.conf
 sed -i '/\(^\|#\)RootDistanceMaxSec=/c\RootDistanceMaxSec=10' /etc/systemd/timesyncd.conf
 
 mkdir -p /etc/nginx/ssl


### PR DESCRIPTION
Changing fallback DNS from Google's 8.8.8.8 to Cloudflare's 1.1.1.1:

* Cloudflare's DNS is mirrored and anycast from ~330 localities globally vs Google's ~200

* Cloudflare's DNS does not transmit the [EDNS Client Subnet](https://en.wikipedia.org/wiki/EDNS_Client_Subnet) while Google does.  EDNS is a DNS extension that forwards the anonymized (removal the last octet for ipv4) client's IP address to all DNS servers in the recursive resolution chain -- including the server that controls the target name, so that CDN systems can give out the best-performing answer based on a geoip database.  While that's good for maximum performance, it's bad for privacy.  With this fallback DNS option, presumably we just want something that works while retaining more privacy.  The IP address from which Cloudflare makes its upstream queries are geolocated to the datacenter where you hit cloudflare's 1.1.1.1, which should be the closest large city to the client anyway, so answers should be roughly just as good without ECS privacy forfeiture, and 100% as good when the DNS answer resolves to a Cloudflare CDN IP address anyway.

* Cloudflare omits the client's IP address from their permanent log whereas Google "anonymizes" it.

* An auditing firm ensures yearly that Cloudflare is doing what they claim wrt not logging client IPs, and not sharing/selling DNS log data.