### PR TITLE
Fix file permissions for developer key and auth cookie

### DIFF
--- a/core/startos/src/developer/mod.rs
+++ b/core/startos/src/developer/mod.rs
@@ -31,7 +31,7 @@ pub async fn write_developer_key(
         secret_key: secret.to_bytes(),
         public_key: Some(PublicKeyBytes(VerifyingKey::from(secret).to_bytes())),
     };
-    let mut file = create_file_mod(path, 0o046).await?;
+    let mut file = create_file_mod(path, 0o600).await?;
     file.write_all(
         keypair_bytes
             .to_pkcs8_pem(base64ct::LineEnding::default())

--- a/core/startos/src/developer/mod.rs
+++ b/core/startos/src/developer/mod.rs
@@ -31,7 +31,7 @@ pub async fn write_developer_key(
         secret_key: secret.to_bytes(),
         public_key: Some(PublicKeyBytes(VerifyingKey::from(secret).to_bytes())),
     };
-    let mut file = create_file_mod(path, 0o600).await?;
+    let mut file = create_file_mod(path, 0o640).await?;
     file.write_all(
         keypair_bytes
             .to_pkcs8_pem(base64ct::LineEnding::default())

--- a/core/startos/src/middleware/auth.rs
+++ b/core/startos/src/middleware/auth.rs
@@ -43,7 +43,7 @@ pub trait AuthContext: SignatureAuthContext {
     const LOCAL_AUTH_COOKIE_OWNERSHIP: &str;
     fn init_auth_cookie() -> impl Future<Output = Result<(), Error>> + Send {
         async {
-            let mut file = create_file_mod(Self::LOCAL_AUTH_COOKIE_PATH, 0o600).await?;
+            let mut file = create_file_mod(Self::LOCAL_AUTH_COOKIE_PATH, 0o640).await?;
             file.write_all(BASE64.encode(random::<[u8; 32]>()).as_bytes())
                 .await?;
             file.sync_all().await?;

--- a/core/startos/src/middleware/auth.rs
+++ b/core/startos/src/middleware/auth.rs
@@ -43,7 +43,7 @@ pub trait AuthContext: SignatureAuthContext {
     const LOCAL_AUTH_COOKIE_OWNERSHIP: &str;
     fn init_auth_cookie() -> impl Future<Output = Result<(), Error>> + Send {
         async {
-            let mut file = create_file_mod(Self::LOCAL_AUTH_COOKIE_PATH, 0o046).await?;
+            let mut file = create_file_mod(Self::LOCAL_AUTH_COOKIE_PATH, 0o600).await?;
             file.write_all(BASE64.encode(random::<[u8; 32]>()).as_bytes())
                 .await?;
             file.sync_all().await?;


### PR DESCRIPTION
Was this a typo? Perhaps `0o640` was the intention, which would allow the owner to read/write and the group to read. For a private key, the most secure standard is `0o600` to restrict all access to the owner.