### PR TITLE
fix: pass --allow-discards to luksOpen for trim support

### DIFF
--- a/core/startos/src/disk/main.rs
+++ b/core/startos/src/disk/main.rs
@@ -287,6 +287,7 @@ pub async fn mount_fs<P: AsRef<Path>>(
         Command::new("cryptsetup")
             .arg("-q")
             .arg("luksOpen")
+            .arg("--allow-discards")
             .arg(format!("--key-file={}", PASSWORD_PATH))
             .arg(format!("--keyfile-size={}", password.len()))
             .arg(&blockdev_path)


### PR DESCRIPTION
It was already passed when creating the fs here: https://github.com/remcoros/start-os/blob/9fb1773637e763b8094978b1b4fdc7ba42fd6742/core/startos/src/disk/main.rs#L129 
but not when mounting