### PR TITLE
Fix Safari hard refresh instructions

### DIFF
--- a/web/projects/ui/src/app/components/refresh-alert.component.ts
+++ b/web/projects/ui/src/app/components/refresh-alert.component.ts
@@ -48,8 +48,12 @@ import { DataModel } from 'src/app/services/patch-db/data-model'
         }}
         <ul>
           <li>
-            <b>On Mac</b>
+            <b>On Mac (Chrome/Firefox)</b>
             : cmd + shift + R
+          </li>
+          <li>
+            <b>On Mac (Safari)</b>
+            : option + cmd + R, or hold option and choose View > Reload Page from Origin
           </li>
           <li>
             <b>On Linux/Windows</b>


### PR DESCRIPTION
## Summary
- clarify that cmd + shift + R applies to Chrome/Firefox on macOS
- add the Safari hard refresh instruction: option + cmd + R
- include the Safari menu fallback: View > Reload Page from Origin

## Notes
- verified locally on macOS Safari
- this incorrect copy was already present in v0.3.5, so it is not specific to 0.4.0

## Testing
- manual verification of the shortcut copy only