### PR TITLE
Fix/startos UI empty interface

### DIFF
--- a/web/projects/ui/src/app/routes/portal/routes/system/routes/startos-ui/startos-ui.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/system/routes/startos-ui/startos-ui.component.ts
@@ -54,7 +54,7 @@ export default class StartOsUiComponent {
   private readonly i18n = inject(i18nPipe)
 
   readonly iface: T.ServiceInterface = {
-    id: '',
+    id: 'startos-ui',
     name: 'StartOS UI',
     description: this.i18n.transform(
       'The web user interface for your StartOS server, accessible from any browser.',


### PR DESCRIPTION
`StartOsUiComponent` creates a synthetic service interface for the StartOS UI with `id: ''` (empty string). Plugins that call `sdk.serviceInterface.get()` with that empty id trigger a host RPC with an empty `serviceInterfaceId`, which Rust rejects because it fails the ID regex.

The error that bubbles up is misleading:

> Action Failed: Deserialization Error: Invalid ID: @get-service-interface

The `@get-service-interface` part is not a literal action ID, it's the empty-string failure message concatenated with `@get-service-interface` (the RPC method name), because the container runtime formats all errors as `${message}@${method}`.

**Fix:** `id: ''` → `id: 'startos-ui'` — one character change, valid identifier, consistent with the `hostId` already on the same object.