### PR TITLE
fix: address URL whitespace and blank tab on Open UI

### DIFF
--- a/web/projects/ui/src/app/routes/portal/components/interfaces/addresses/item.component.ts
+++ b/web/projects/ui/src/app/routes/portal/components/interfaces/addresses/item.component.ts
@@ -77,10 +77,8 @@ import { DomainHealthService } from './domain-health.service'
             <span>{{ address.url | tuiObfuscate: 'mask' }}</span>
           } @else {
             <span [title]="address.url">
-              @if (urlParts(); as parts) {
-                {{ parts.prefix }}
-                <b>{{ parts.hostname }}</b>
-                {{ parts.suffix }}
+              @if (urlHtml(); as html) {
+                <span [innerHTML]="html"></span>
               } @else {
                 {{ address.url }}
               }
@@ -246,15 +244,14 @@ export class InterfaceAddressItemComponent {
     this.address()?.masked && this.currentlyMasked() ? 'mask' : 'none',
   )
 
-  readonly urlParts = computed(() => {
+  readonly urlHtml = computed(() => {
     const { url, hostnameInfo } = this.address()
     const idx = url.indexOf(hostnameInfo.hostname)
     if (idx === -1) return null
-    return {
-      prefix: url.slice(0, idx),
-      hostname: hostnameInfo.hostname,
-      suffix: url.slice(idx + hostnameInfo.hostname.length),
-    }
+    const prefix = url.slice(0, idx)
+    const hostname = hostnameInfo.hostname
+    const suffix = url.slice(idx + hostname.length)
+    return `${prefix}<b>${hostname}</b>${suffix}`
   })
 
   typeAppearance(kind: string): string {

--- a/web/projects/ui/src/app/routes/portal/components/interfaces/interface.service.ts
+++ b/web/projects/ui/src/app/routes/portal/components/interfaces/interface.service.ts
@@ -291,11 +291,25 @@ export class InterfaceService {
         matching = mdns.format('urlstring')[0]
         onLan = true
         break
+      case 'domain':
+        matching = publicDomains.format('urlstring')[0]
+        break
+      case 'tor':
+        matching = addresses
+          .filter({
+            pluginId: 'tor',
+          })
+          .format('urlstring')[0]
+        break
+      case 'wan-ipv4':
+        matching = wanIp.format('urlstring')[0]
+        break
     }
 
     if (matching) return matching
     if (onLan && bestPrivate) return bestPrivate
     if (bestPublic) return bestPublic
+    if (bestPrivate) return bestPrivate
     return ''
   }
 }

--- a/web/projects/ui/src/app/routes/portal/routes/services/components/controls.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/services/components/controls.component.ts
@@ -49,6 +49,7 @@ import { InterfaceService } from '../../../components/interfaces/interface.servi
             tuiChevron
             tuiDropdownAuto
             tuiDropdownLimitWidth="fixed"
+            [disabled]="!hasAnyHref()"
             [tuiDropdown]="content"
           >
             {{ 'Open UI' | i18n }}
@@ -62,6 +63,7 @@ import { InterfaceService } from '../../../components/interfaces/interface.servi
                   rel="noreferrer"
                   iconEnd="@tui.external-link"
                   [attr.href]="getHref(i)"
+                  [class.disabled]="!getHref(i)"
                   (click)="close()"
                 >
                   {{ i.name }}
@@ -69,12 +71,13 @@ import { InterfaceService } from '../../../components/interfaces/interface.servi
               }
             </tui-data-list>
           </ng-template>
-        } @else if (interfaces()[0]) {
+        } @else if (interfaces()[0]; as ui) {
           <button
             tuiButton
             appearance="primary-grayscale"
             iconStart="@tui.external-link"
-            (click)="openUI(interfaces()[0]!)"
+            [disabled]="!getHref(ui)"
+            (click)="openUI(ui)"
           >
             {{ 'Open UI' | i18n }}
           </button>
@@ -163,6 +166,10 @@ export class ServiceControlsComponent {
     ),
   )
 
+  readonly hasAnyHref = computed(() =>
+    this.interfaces().some(i => !!this.getHref(i)),
+  )
+
   getHref(ui: T.ServiceInterface): string {
     const host = this.pkg().hosts[ui.addressInfo.hostId]
     if (!host) return ''
@@ -170,6 +177,9 @@ export class ServiceControlsComponent {
   }
 
   openUI(ui: T.ServiceInterface) {
-    this.document.defaultView?.open(this.getHref(ui), '_blank', 'noreferrer')
+    const href = this.getHref(ui)
+    if (href) {
+      this.document.defaultView?.open(href, '_blank', 'noreferrer')
+    }
   }
 }

--- a/web/projects/ui/src/app/services/api/embassy-mock-api.service.ts
+++ b/web/projects/ui/src/app/services/api/embassy-mock-api.service.ts
@@ -1224,8 +1224,8 @@ export class MockApiService extends ApiService {
               },
               'p2p-interface': {
                 name: 'P2P Interface',
-                result: 'waiting',
-                message: 'Chain State',
+                result: 'success',
+                message: null,
               },
               'rpc-interface': {
                 name: 'RPC Interface',

--- a/web/projects/ui/src/app/services/api/mock-patch.ts
+++ b/web/projects/ui/src/app/services/api/mock-patch.ts
@@ -497,6 +497,21 @@ export const mockPatchData: DataModel = {
             suffix: '',
           },
         },
+        'admin-ui': {
+          id: 'admin-ui',
+          masked: false,
+          name: 'Admin UI',
+          description: 'An admin panel for managing your Bitcoin node',
+          type: 'ui',
+          addressInfo: {
+            username: null,
+            hostId: 'abcdefg',
+            internalPort: 80,
+            scheme: 'http',
+            sslScheme: 'https',
+            suffix: '/admin',
+          },
+        },
         rpc: {
           id: 'rpc',
           masked: true,


### PR DESCRIPTION
## Summary
- **URL whitespace**: Address item template had whitespace between protocol, hostname, and port due to Angular template interpolation across newlines. Fixed by using `[innerHTML]` with a computed HTML string.
- **Blank tab on Open UI**: `launchableAddress()` was missing `domain`, `tor`, and `wan-ipv4` access type cases, so clicking "Open UI" when accessing StartOS from a clearnet domain (and the service has no clearnet address) opened `window.open('')` — a blank tab. Added the missing cases and a final fallback to private addresses. The button is now disabled when no launchable address exists.
- **Mock fix**: `startPackage` mock never reached "running" state because a health check stayed in `waiting`.
- **Mock enhancement**: Added second UI interface to bitcoin mock for testing multi-UI dropdown.

## Test plan
- [x] Access mock UI via mDNS (`maskAs: "mdns"`) — Open UI resolves to `.local` address
- [x] Change `maskAs` to `"domain"` — Open UI resolves to public domain or disables if none
- [x] Start bitcoin service — transitions from "starting" to "running"
- [x] Verify multi-UI dropdown shows both "Web UI" and "Admin UI" with correct hrefs
- [x] Verify address URLs display without extra whitespace between protocol/hostname/port

🤖 Generated with [Claude Code](https://claude.com/claude-code)