### PR TITLE
fix: use Tls::Required for STARTTLS in test_smtp

### DIFF
--- a/core/src/system/mod.rs
+++ b/core/src/system/mod.rs
@@ -1233,12 +1233,15 @@ pub async fn test_smtp(
         .header(ContentType::TEXT_PLAIN)
         .body("This is a test email sent from your StartOS Server".to_owned())?;
 
+    let tls_parameters = TlsParameters::new(host.clone())?;
     let transport = match security {
-        SmtpSecurity::Starttls => AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&host)?,
-        SmtpSecurity::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(&host)?,
+        SmtpSecurity::Starttls => AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&host)?
+            .port(port)
+            .tls(Tls::Required(tls_parameters)),
+        SmtpSecurity::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(&host)?
+            .port(port)
+            .tls(Tls::Wrapper(tls_parameters)),
     }
-    .port(port)
-    .tls(Tls::Wrapper(TlsParameters::new(host.clone())?))
     .credentials(creds)
     .build();
 

--- a/sdk/base/lib/actions/input/inputSpecConstants.ts
+++ b/sdk/base/lib/actions/input/inputSpecConstants.ts
@@ -120,7 +120,7 @@ export const smtpProviderVariants = Variants.of({
     name: 'Proton Mail',
     spec: smtpFields({
       host: 'smtp.protonmail.ch',
-      security: 'tls',
+      security: 'starttls',
       hostDisabled: true,
     }),
   },

--- a/web/projects/ui/src/app/routes/portal/routes/system/routes/smtp/smtp.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/system/routes/smtp/smtp.component.ts
@@ -121,6 +121,7 @@ function detectProviderKey(host: string | undefined): string {
           <footer>
             <button
               tuiButton
+              type="button"
               size="l"
               [disabled]="
                 !testEmailControl.value || isEmailInvalid || data.form.invalid

--- a/web/projects/ui/src/app/routes/portal/routes/updates/item.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/updates/item.component.ts
@@ -9,7 +9,6 @@ import {
 import { RouterLink } from '@angular/router'
 import { MarketplacePkg } from '@start9labs/marketplace'
 import {
-  DialogService,
   i18nPipe,
   LocalizePipe,
   MarkdownPipe,
@@ -30,11 +29,9 @@ import {
   TuiFade,
   TuiProgressCircle,
 } from '@taiga-ui/kit'
-import { PatchDB } from 'patch-db-client'
 import { InstallingProgressPipe } from 'src/app/routes/portal/routes/services/pipes/install-progress.pipe'
 import { MarketplaceService } from 'src/app/services/marketplace.service'
 import {
-  DataModel,
   InstalledState,
   PackageDataEntry,
   UpdatingState,
@@ -256,10 +253,7 @@ import UpdatesComponent from './updates.component'
   ],
 })
 export class UpdatesItemComponent {
-  private readonly dialog = inject(DialogService)
-  private readonly patch = inject<PatchDB<DataModel>>(PatchDB)
   private readonly service = inject(MarketplaceService)
-  private readonly i18n = inject(i18nPipe)
 
   readonly parent = inject(UpdatesComponent)
   readonly expanded = signal(false)
@@ -274,12 +268,14 @@ export class UpdatesItemComponent {
     const { id, version } = this.item()
     const url = this.parent.current()?.url || ''
 
+    this.ready.set(false)
+
     try {
       await this.service.installPackage(id, version, url)
-      this.ready.set(true)
     } catch (e: any) {
-      this.ready.set(true)
       this.error.set(e.message)
+    } finally {
+      this.ready.set(true)
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixed `test_smtp` using `Tls::Wrapper` (immediate TLS) for both STARTTLS and TLS modes
- STARTTLS now correctly uses `Tls::Required`, which connects plaintext first then upgrades via the STARTTLS command
- `Tls::Wrapper` on port 587 caused the TLS handshake to fail (server sends a plaintext SMTP banner instead of TLS ServerHello), crashing the server and dropping the PatchDB WebSocket — the UI showed the reconnection/loading screen

## Test plan
- [x] Configure System SMTP with Protonmail (STARTTLS, port 587) and send a test email
- [x] Configure System SMTP with a TLS provider (port 465) and send a test email
- [x] Verify errors are shown as toasts instead of crashing the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)