### PR TITLE
fix: skip postgres migration when PGDB_DO_NOT_MIGRATE sentinel exists

### DIFF
--- a/core/src/version/v0_3_6_alpha_0.rs
+++ b/core/src/version/v0_3_6_alpha_0.rs
@@ -182,6 +182,23 @@ impl VersionT for Version {
         &V0_3_0_COMPAT
     }
     async fn pre_up(self) -> Result<Self::PreUpRes, Error> {
+        // Contingency for customers with corrupted PostgreSQL databases:
+        // if this sentinel file exists, skip the database entirely and
+        // regenerate fresh account data.  Tor keys, SSH keys, and CIFS
+        // backup targets will be lost.
+        if tokio::fs::metadata("/home/start9/PGDB_DO_NOT_MIGRATE")
+            .await
+            .is_ok()
+        {
+            tracing::warn!(
+                "Found /home/start9/PGDB_DO_NOT_MIGRATE — \
+                 skipping PostgreSQL migration, generating fresh account data"
+            );
+            let account =
+                AccountInfo::new("embassy", std::time::SystemTime::now(), None)?;
+            return Ok((account, SshKeys::new(), CifsTargets::default(), BTreeMap::new()));
+        }
+
         let pg = init_postgres(DATA_DIR).await?;
         let account = previous_account_info(&pg).await?;
 

--- a/core/src/version/v0_3_6_alpha_0.rs
+++ b/core/src/version/v0_3_6_alpha_0.rs
@@ -288,10 +288,13 @@ impl VersionT for Version {
             value["keyStore"] = to_value(&keystore)?;
             // Preserve tor onion keys so later migrations (v0_4_0_alpha_20) can
             // include them in onion-migration.json for the tor service.
+            // Always write torMigration (even if empty) so that
+            // v0_4_0_alpha_20 takes the pre-built path and doesn't fall
+            // back to looking up keys in the onion store.
+            let mut onion_map: Value = json!({});
+            let mut tor_migration = imbl::Vector::<Value>::new();
             if !tor_keys.is_empty() {
-                let mut onion_map: Value = json!({});
                 let onion_obj = onion_map.as_object_mut().unwrap();
-                let mut tor_migration = imbl::Vector::<Value>::new();
                 for ((package_id, host_id), key_bytes) in &tor_keys {
                     let onion_addr = onion_address_from_key(key_bytes);
                     let encoded_key =
@@ -308,8 +311,8 @@ impl VersionT for Version {
                     }));
                 }
                 value["keyStore"]["onion"] = onion_map;
-                value["torMigration"] = Value::Array(tor_migration);
             }
+            value["torMigration"] = Value::Array(tor_migration);
             value["password"] = to_value(&account.password)?;
             value["compatS9pkKey"] =
                 to_value(&crate::db::model::private::generate_developer_key())?;


### PR DESCRIPTION
## Summary
- Adds a contingency for customers with corrupted PostgreSQL databases during the 0.3.6-alpha.0 migration
- If `/home/start9/PGDB_DO_NOT_MIGRATE` exists on the device, the migration skips all PostgreSQL operations and generates fresh account data instead
- The setup wizard password override still applies after migration, so the placeholder password is never user-facing

**Data lost when using this escape hatch:** tor onion addresses, SSH authorized keys, CIFS backup targets, root CA certificate. All other data (packages, volumes, UI settings) is preserved.

## Test plan
- [x] Verify normal migration (no sentinel file) still works as before
- [x] Create `/home/start9/PGDB_DO_NOT_MIGRATE` on a device with a corrupted PG database and confirm migration completes successfully
- [x] Confirm the user-provided password from the setup wizard is applied (not the placeholder)
- [x] Confirm the warning is logged when the sentinel file is detected