### PR TITLE
chore: bump version to 0.4.0-beta.3

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6476,7 +6476,7 @@ dependencies = [
 
 [[package]]
 name = "start-os"
-version = "0.4.0-beta.2"
+version = "0.4.0-beta.3"
 dependencies = [
  "aes",
  "async-acme",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 name = "start-os"
 readme = "README.md"
 repository = "https://github.com/Start9Labs/start-os"
-version = "0.4.0-beta.2" # VERSION_BUMP
+version = "0.4.0-beta.3" # VERSION_BUMP
 
 [lib]
 name = "startos"

--- a/core/src/version/mod.rs
+++ b/core/src/version/mod.rs
@@ -66,8 +66,9 @@ mod v0_4_0_alpha_23;
 mod v0_4_0_beta_0;
 mod v0_4_0_beta_1;
 mod v0_4_0_beta_2;
+mod v0_4_0_beta_3;
 
-pub type Current = v0_4_0_beta_2::Version; // VERSION_BUMP
+pub type Current = v0_4_0_beta_3::Version; // VERSION_BUMP
 
 impl Current {
     #[instrument(skip(self, db))]
@@ -201,7 +202,8 @@ enum Version {
     V0_4_0_alpha_23(Wrapper<v0_4_0_alpha_23::Version>),
     V0_4_0_beta_0(Wrapper<v0_4_0_beta_0::Version>),
     V0_4_0_beta_1(Wrapper<v0_4_0_beta_1::Version>),
-    V0_4_0_beta_2(Wrapper<v0_4_0_beta_2::Version>), // VERSION_BUMP
+    V0_4_0_beta_2(Wrapper<v0_4_0_beta_2::Version>),
+    V0_4_0_beta_3(Wrapper<v0_4_0_beta_3::Version>), // VERSION_BUMP
     Other(exver::Version),
 }
 
@@ -270,7 +272,8 @@ impl Version {
             Self::V0_4_0_alpha_23(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_0(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_1(v) => DynVersion(Box::new(v.0)),
-            Self::V0_4_0_beta_2(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
+            Self::V0_4_0_beta_2(v) => DynVersion(Box::new(v.0)),
+            Self::V0_4_0_beta_3(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
             Self::Other(v) => {
                 return Err(Error::new(
                     eyre!("unknown version {v}"),
@@ -331,7 +334,8 @@ impl Version {
             Version::V0_4_0_alpha_23(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_0(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_1(Wrapper(x)) => x.semver(),
-            Version::V0_4_0_beta_2(Wrapper(x)) => x.semver(), // VERSION_BUMP
+            Version::V0_4_0_beta_2(Wrapper(x)) => x.semver(),
+            Version::V0_4_0_beta_3(Wrapper(x)) => x.semver(), // VERSION_BUMP
             Version::Other(x) => x.clone(),
         }
     }

--- a/core/src/version/v0_4_0_beta_3.rs
+++ b/core/src/version/v0_4_0_beta_3.rs
@@ -1,0 +1,37 @@
+use exver::{PreReleaseSegment, VersionRange};
+
+use super::v0_3_5::V0_3_0_COMPAT;
+use super::{VersionT, v0_4_0_beta_2};
+use crate::prelude::*;
+
+lazy_static::lazy_static! {
+    static ref V0_4_0_beta_3: exver::Version = exver::Version::new(
+        [0, 4, 0],
+        [PreReleaseSegment::String("beta".into()), 3.into()]
+    );
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Version;
+
+impl VersionT for Version {
+    type Previous = v0_4_0_beta_2::Version;
+    type PreUpRes = ();
+
+    async fn pre_up(self) -> Result<Self::PreUpRes, Error> {
+        Ok(())
+    }
+    fn semver(self) -> exver::Version {
+        V0_4_0_beta_3.clone()
+    }
+    fn compat(self) -> &'static VersionRange {
+        &V0_3_0_COMPAT
+    }
+    #[instrument(skip_all)]
+    fn up(self, _db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+        Ok(Value::Null)
+    }
+    fn down(self, _db: &mut Value) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/docs/VERSION_BUMP.md
+++ b/docs/VERSION_BUMP.md
@@ -130,9 +130,11 @@ Remove `// VERSION_BUMP`, add new match arm, add comment:
             Version::Other(x) => x.clone(),
 ```
 
-### 4. SDK TypeScript Version
+### 4. SDK TypeScript Version (only on breaking SDK changes)
 
 **File: `sdk/package/lib/StartSdk.ts`**
+
+**Only update this when the version bump includes breaking changes to the SDK.** The SDK `OSVersion` tracks compatibility for service developers, not the OS release cadence. Routine version bumps should skip this file.
 
 Update the OSVersion constant (~line 64):
 
@@ -180,7 +182,7 @@ This pattern helps you quickly find all the places that need updating in the nex
 - [ ] Create new `core/src/version/vX_Y_Z_alpha_N+1.rs` file
 - [ ] Update `core/src/version/mod.rs` in 5 locations
 - [ ] Run `cargo check` to update `core/Cargo.lock`
-- [ ] Update `sdk/package/lib/StartSdk.ts` OSVersion
+- [ ] Update `sdk/package/lib/StartSdk.ts` OSVersion (only if breaking SDK changes)
 - [ ] Update `web/package.json` and `web/package-lock.json` version
 - [ ] Verify all changes compile/build successfully
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startos-ui",
-      "version": "0.4.0-beta.2",
+      "version": "0.4.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^21.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "author": "Start9 Labs, Inc",
   "homepage": "https://start9.com/",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump StartOS version from 0.4.0-beta.2 to 0.4.0-beta.3 across core, web, and docs
- Add new version migration file (`v0_4_0_beta_3.rs`) with no-op migration
- Update `VERSION_BUMP.md` to clarify SDK OSVersion should only be bumped on breaking SDK changes

## Test plan
- [x] `cargo check -p start-os` passes