### PR TITLE
fix: miscellaneous fixes

### DIFF
--- a/.github/workflows/start-registry.yaml
+++ b/.github/workflows/start-registry.yaml
@@ -166,7 +166,7 @@ jobs:
 
           VOLUME /var/lib/startos
 
-          ENV RUST_LOG=startos=debug
+          ENV RUST_LOG=warn,startos=debug
 
           ENTRYPOINT ["start-registryd"]
 

--- a/build/lib/scripts/enable-kiosk
+++ b/build/lib/scripts/enable-kiosk
@@ -4,7 +4,7 @@ set -e
 
 # install dependencies
 /usr/bin/apt update
-/usr/bin/apt install --no-install-recommends -y xserver-xorg x11-xserver-utils xinit firefox-esr matchbox-window-manager libnss3-tools p11-kit-modules
+/usr/bin/apt install --no-install-recommends -y xserver-xorg x11-xserver-utils xinit firefox-esr matchbox-window-manager libnss3-tools p11-kit-modules libgl1-mesa-dri
 
 #Change a default preference set by stock debian firefox-esr
 sed -i 's|^pref("extensions.update.enabled", true);$|pref("extensions.update.enabled", false);|' /etc/firefox-esr/firefox-esr.js

--- a/container-runtime/container-runtime.service
+++ b/container-runtime/container-runtime.service
@@ -4,7 +4,7 @@ OnFailure=container-runtime-failure.service
 
 [Service]
 Type=simple
-Environment=RUST_LOG=startos=debug
+Environment=RUST_LOG=warn,startos=debug
 ExecStart=/usr/bin/start-container pipe-wrap /usr/bin/node --experimental-detect-module --trace-warnings /usr/lib/startos/init/index.js
 Restart=no
 

--- a/core/src/context/setup.rs
+++ b/core/src/context/setup.rs
@@ -190,8 +190,10 @@ impl SetupContext {
                         }
                         .await
                         {
-                            tracing::error!("{}", t!("context.setup.error-in-setup-progress-websocket", error = e));
-                            tracing::debug!("{e:?}");
+                            if !crate::util::net::is_ws_reset_without_close(&e) {
+                                tracing::error!("{}", t!("context.setup.error-in-setup-progress-websocket", error = e));
+                                tracing::debug!("{e:?}");
+                            }
                         }
                     },
                     Duration::from_secs(30),

--- a/core/src/db/mod.rs
+++ b/core/src/db/mod.rs
@@ -248,8 +248,10 @@ pub async fn subscribe(
                     }
                     .await
                     {
-                        tracing::error!("Error in db websocket: {e}");
-                        tracing::debug!("{e:?}");
+                        if !crate::util::net::is_ws_reset_without_close(&e) {
+                            tracing::error!("Error in db websocket: {e}");
+                            tracing::debug!("{e:?}");
+                        }
                     }
                 },
                 Duration::from_secs(30),

--- a/core/src/init.rs
+++ b/core/src/init.rs
@@ -501,8 +501,10 @@ pub async fn init_progress(ctx: InitContext) -> Result<InitProgressRes, Error> {
                     );
 
                     if let Err(e) = ws.close_result(res.map(|_| "complete")).await {
-                        tracing::error!("{}", t!("init.error-closing-websocket", error = e));
-                        tracing::debug!("{e:?}");
+                        if !crate::util::net::is_ws_reset_without_close(&e) {
+                            tracing::error!("{}", t!("init.error-closing-websocket", error = e));
+                            tracing::debug!("{e:?}");
+                        }
                     }
                 },
                 Duration::from_secs(30),

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -1141,8 +1141,10 @@ pub async fn attach(
                     )
                     .await
                     {
-                        tracing::error!("Error in attach websocket: {e}");
-                        tracing::debug!("{e:?}");
+                        if !crate::util::net::is_ws_reset_without_close(&e) {
+                            tracing::error!("Error in attach websocket: {e}");
+                            tracing::debug!("{e:?}");
+                        }
                         ws.close_result(Err::<&str, _>(e)).await.log_err();
                     } else {
                         ws.normal_close("exit").await.log_err();

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -701,17 +701,21 @@ impl Service {
             })
             .await
             .result?;
-        let mut file =
-            AtomicFile::new(guard.path().join(id).with_extension("s9pk"), None::<&str>).await?;
-        self.seed
-            .persistent_container
-            .s9pk
-            .clone()
-            .serialize(&mut *file, true)
-            .await?;
-        file.save().await?;
+        let s9pk_res = async {
+            let mut file =
+                AtomicFile::new(guard.path().join(id).with_extension("s9pk"), None::<&str>).await?;
+            self.seed
+                .persistent_container
+                .s9pk
+                .clone()
+                .serialize(&mut *file, true)
+                .await?;
+            file.save().await
+        }
+        .await;
 
-        backup.await
+        backup.await?;
+        s9pk_res
     }
 
     pub fn container_id(&self) -> Result<ContainerId, Error> {

--- a/core/src/tunnel/db.rs
+++ b/core/src/tunnel/db.rs
@@ -375,8 +375,10 @@ pub async fn subscribe(
                     }
                     .await
                     {
-                        tracing::error!("Error in db websocket: {e}");
-                        tracing::debug!("{e:?}");
+                        if !crate::util::net::is_ws_reset_without_close(&e) {
+                            tracing::error!("Error in db websocket: {e}");
+                            tracing::debug!("{e:?}");
+                        }
                     }
                 },
                 Duration::from_secs(30),

--- a/core/src/util/net.rs
+++ b/core/src/util/net.rs
@@ -205,6 +205,15 @@ impl Sink<Message> for WebSocket {
     }
 }
 
+/// Check if an error is a benign websocket "connection reset without closing handshake"
+/// error from tungstenite. This happens normally when clients disconnect without
+/// sending a close frame (e.g. closing a browser tab).
+pub fn is_ws_reset_without_close(e: &Error) -> bool {
+    e.source
+        .to_string()
+        .contains("Connection reset without closing handshake")
+}
+
 pub struct SyncBody(Mutex<axum::body::BodyDataStream>);
 impl From<axum::body::Body> for SyncBody {
     fn from(value: axum::body::Body) -> Self {

--- a/core/start-registryd.service
+++ b/core/start-registryd.service
@@ -3,7 +3,7 @@ Description=StartOS Registry
 
 [Service]
 Type=simple
-Environment=RUST_LOG=startos=debug,patch_db=warn
+Environment=RUST_LOG=warn,startos=debug
 ExecStart=/usr/bin/start-registryd
 Restart=always
 RestartSec=3

--- a/core/start-tunneld.service
+++ b/core/start-tunneld.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Environment=RUST_LOG=startos=debug,patch_db=warn
+Environment=RUST_LOG=warn,startos=debug
 ExecStart=/usr/bin/start-tunneld
 Restart=always
 RestartSec=3

--- a/core/startd.service
+++ b/core/startd.service
@@ -3,7 +3,7 @@ Description=StartOS Daemon
 
 [Service]
 Type=simple
-Environment=RUST_LOG=startos=debug,patch_db=warn
+Environment=RUST_LOG=warn,startos=debug
 ExecStart=/usr/bin/startd
 Restart=always
 RestartSec=3


### PR DESCRIPTION
## Summary
- Standardize `RUST_LOG=warn,startos=debug` across all service files (startd, start-tunneld, start-registryd, container-runtime, registry workflow)
- Suppress benign websocket "connection reset without closing handshake" errors that occur when clients disconnect without a close frame (e.g. closing a browser tab)
- Fix backup s9pk serialization to ensure backup task completes before returning s9pk error
- Add `libgl1-mesa-dri` to kiosk dependencies