### PR TITLE
fix: use correct key for old DB schema in migration

### DIFF
--- a/core/src/version/v0_3_6_alpha_0.rs
+++ b/core/src/version/v0_3_6_alpha_0.rs
@@ -484,8 +484,8 @@ impl VersionT for Version {
                     // InitKind::Update instead of InitKind::Install.
                     if let Some(data_version) = input
                         .get(&*id)
-                        .and_then(|pde| pde.get("stateInfo"))
-                        .and_then(|si| si.get("manifest"))
+                        .and_then(|pde| pde.get("installed"))
+                        .and_then(|i| i.get("manifest"))
                         .and_then(|m| m.get("version"))
                         .and_then(|v| v.as_str())
                     {
@@ -542,8 +542,8 @@ impl VersionT for Version {
                             id.clone(),
                             input
                                 .get(&*id)
-                                .and_then(|pde| pde.get("stateInfo"))
-                                .and_then(|si| si.get("manifest"))
+                                .and_then(|pde| pde.get("installed"))
+                                .and_then(|i| i.get("manifest"))
                                 .and_then(|m| m.get("title"))
                                 .and_then(|v| v.as_str()),
                         );


### PR DESCRIPTION
## Summary
- The `v0_3_6_alpha_0` post_up migration was using `pde["stateInfo"]["manifest"]` to look up the package version and title from the old 0.3.x database schema. `stateInfo` doesn't exist in that schema — the correct key is `"installed"` (the `InstalledPackageInfo` field on `PackageDataEntryInstalled`).
- This caused `.version` to never be written, so failed service installs on retry were treated as fresh installs (`InitKind::Install`) instead of updates (`InitKind::Update`), triggering first-run tasks like `initializeWallet`.
- Also fixes the failure notification title lookup which had the same bug.