### PR TITLE
chore: bump version to 0.4.0-beta.4

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6476,7 +6476,7 @@ dependencies = [
 
 [[package]]
 name = "start-os"
-version = "0.4.0-beta.3"
+version = "0.4.0-beta.4"
 dependencies = [
  "aes",
  "async-acme",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 name = "start-os"
 readme = "README.md"
 repository = "https://github.com/Start9Labs/start-os"
-version = "0.4.0-beta.3" # VERSION_BUMP
+version = "0.4.0-beta.4" # VERSION_BUMP
 
 [lib]
 name = "startos"

--- a/core/src/backup/backup_bulk.rs
+++ b/core/src/backup/backup_bulk.rs
@@ -289,9 +289,7 @@ async fn perform_backup(
             backup_report.insert(
                 id.clone(),
                 PackageBackupReport {
-                    error: Some(
-                        t!("backup.bulk.service-not-ready").to_string(),
-                    ),
+                    error: Some(t!("backup.bulk.service-not-ready").to_string()),
                 },
             );
         }

--- a/core/src/bins/startd.rs
+++ b/core/src/bins/startd.rs
@@ -152,9 +152,11 @@ pub fn main(args: impl IntoIterator<Item = OsString>) {
             // prevent tokio I/O driver starvation (all workers parked on
             // condvar with no driver).  See tokio-rs/tokio#4730.
             let rt_handle = tokio::runtime::Handle::current();
-            std::thread::spawn(move || loop {
-                std::thread::sleep(Duration::from_secs(30));
-                rt_handle.spawn(async {});
+            std::thread::spawn(move || {
+                loop {
+                    std::thread::sleep(Duration::from_secs(30));
+                    rt_handle.spawn(async {});
+                }
             });
 
             let mut server = WebServer::new(Acceptor::new(WildcardListener::new(80)?), refresher());

--- a/core/src/disk/main.rs
+++ b/core/src/disk/main.rs
@@ -441,7 +441,10 @@ pub async fn probe_package_data_fs(guid: &str) -> Result<Option<String>, Error> 
             // Already imported, that's fine
         }
         Err(e) => {
-            tracing::warn!("{}", t!("disk.main.could-not-import-vg", guid = guid, error = e));
+            tracing::warn!(
+                "{}",
+                t!("disk.main.could-not-import-vg", guid = guid, error = e)
+            );
             return Ok(None);
         }
     }
@@ -451,7 +454,10 @@ pub async fn probe_package_data_fs(guid: &str) -> Result<Option<String>, Error> 
         .invoke(ErrorKind::DiskManagement)
         .await
     {
-        tracing::warn!("{}", t!("disk.main.could-not-activate-vg", guid = guid, error = e));
+        tracing::warn!(
+            "{}",
+            t!("disk.main.could-not-activate-vg", guid = guid, error = e)
+        );
         return Ok(None);
     }
 

--- a/core/src/disk/mod.rs
+++ b/core/src/disk/mod.rs
@@ -7,12 +7,12 @@ use rpc_toolkit::{CallRemoteHandler, Context, Empty, HandlerExt, ParentHandler, 
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 
-use crate::{Error, ErrorKind};
 use crate::context::{CliContext, RpcContext};
 use crate::disk::util::DiskInfo;
 use crate::prelude::*;
 use crate::util::Invoke;
 use crate::util::serde::{HandlerExtSerde, WithIoFormat, display_serializable};
+use crate::{Error, ErrorKind};
 
 pub mod fsck;
 pub mod main;
@@ -150,11 +150,9 @@ async fn find_bios_boot_partition(known_part: &Path) -> Result<Option<PathBuf>, 
 /// canonical device path.
 async fn resolve_fstab_source(source: &str) -> Result<PathBuf, Error> {
     if source.starts_with('/') {
-        return Ok(
-            tokio::fs::canonicalize(source)
-                .await
-                .unwrap_or_else(|_| PathBuf::from(source)),
-        );
+        return Ok(tokio::fs::canonicalize(source)
+            .await
+            .unwrap_or_else(|_| PathBuf::from(source)));
     }
     // PARTUUID=, UUID=, LABEL= — resolve via blkid
     let output = Command::new("blkid")

--- a/core/src/disk/util.rs
+++ b/core/src/disk/util.rs
@@ -377,13 +377,12 @@ pub async fn list(os: &OsPartitionInfo) -> Result<Vec<DiskInfo>, Error> {
                 if let Some(g) = disk_guids.get(&disk_info.logicalname) {
                     disk_info.guid = g.clone();
                     if let Some(guid) = g {
-                        disk_info.filesystem =
-                            crate::disk::main::probe_package_data_fs(guid)
-                                .await
-                                .unwrap_or_else(|e| {
-                                    tracing::warn!("Failed to probe filesystem for {guid}: {e}");
-                                    None
-                                });
+                        disk_info.filesystem = crate::disk::main::probe_package_data_fs(guid)
+                            .await
+                            .unwrap_or_else(|e| {
+                                tracing::warn!("Failed to probe filesystem for {guid}: {e}");
+                                None
+                            });
                     }
                 } else {
                     disk_info.partitions = vec![part_info];
@@ -396,13 +395,12 @@ pub async fn list(os: &OsPartitionInfo) -> Result<Vec<DiskInfo>, Error> {
             if let Some(g) = disk_guids.get(&disk_info.logicalname) {
                 disk_info.guid = g.clone();
                 if let Some(guid) = g {
-                    disk_info.filesystem =
-                        crate::disk::main::probe_package_data_fs(guid)
-                            .await
-                            .unwrap_or_else(|e| {
-                                tracing::warn!("Failed to probe filesystem for {guid}: {e}");
-                                None
-                            });
+                    disk_info.filesystem = crate::disk::main::probe_package_data_fs(guid)
+                        .await
+                        .unwrap_or_else(|e| {
+                            tracing::warn!("Failed to probe filesystem for {guid}: {e}");
+                            None
+                        });
                 }
             } else {
                 for part in index.parts {
@@ -410,15 +408,12 @@ pub async fn list(os: &OsPartitionInfo) -> Result<Vec<DiskInfo>, Error> {
                     if let Some(g) = disk_guids.get(&part_info.logicalname) {
                         part_info.guid = g.clone();
                         if let Some(guid) = g {
-                            part_info.filesystem =
-                                crate::disk::main::probe_package_data_fs(guid)
-                                    .await
-                                    .unwrap_or_else(|e| {
-                                        tracing::warn!(
-                                            "Failed to probe filesystem for {guid}: {e}"
-                                        );
-                                        None
-                                    });
+                            part_info.filesystem = crate::disk::main::probe_package_data_fs(guid)
+                                .await
+                                .unwrap_or_else(|e| {
+                                    tracing::warn!("Failed to probe filesystem for {guid}: {e}");
+                                    None
+                                });
                         }
                     }
                     disk_info.partitions.push(part_info);

--- a/core/src/hostname.rs
+++ b/core/src/hostname.rs
@@ -272,7 +272,10 @@ pub async fn set_hostname_rpc(
             }
             if let Some(hostname) = &hostname {
                 hostname.save(server_info)?;
-                server_info.as_status_info_mut().as_restart_mut().ser(&Some(RestartReason::Mdns))?;
+                server_info
+                    .as_status_info_mut()
+                    .as_restart_mut()
+                    .ser(&Some(RestartReason::Mdns))?;
             }
             ServerHostnameInfo::load(server_info)
         })

--- a/core/src/net/host/binding.rs
+++ b/core/src/net/host/binding.rs
@@ -346,33 +346,21 @@ pub async fn set_address_enabled<Kind: HostApiKind>(
                         }
                         // Non-SSL Ipv4: cascade to PublicDomains on same gateway
                         if !address.ssl {
-                            if let HostnameMetadata::Ipv4 { gateway } =
-                                &address.metadata
-                            {
+                            if let HostnameMetadata::Ipv4 { gateway } = &address.metadata {
                                 let port = sa.port();
                                 for a in &bind.addresses.available {
                                     if a.ssl {
                                         continue;
                                     }
-                                    if let HostnameMetadata::PublicDomain {
-                                        gateway: gw,
-                                    } = &a.metadata
+                                    if let HostnameMetadata::PublicDomain { gateway: gw } =
+                                        &a.metadata
                                     {
-                                        if gw == gateway
-                                            && a.port.unwrap_or(80) == port
-                                        {
-                                            let k = (
-                                                a.hostname.clone(),
-                                                a.port.unwrap_or(80),
-                                            );
+                                        if gw == gateway && a.port.unwrap_or(80) == port {
+                                            let k = (a.hostname.clone(), a.port.unwrap_or(80));
                                             if enabled {
-                                                bind.addresses
-                                                    .disabled
-                                                    .remove(&k);
+                                                bind.addresses.disabled.remove(&k);
                                             } else {
-                                                bind.addresses
-                                                    .disabled
-                                                    .insert(k);
+                                                bind.addresses.disabled.insert(k);
                                             }
                                         }
                                     }
@@ -390,51 +378,35 @@ pub async fn set_address_enabled<Kind: HostApiKind>(
                         }
                         // Non-SSL PublicDomain: cascade to Ipv4 + other PublicDomains on same gateway
                         if !address.ssl {
-                            if let HostnameMetadata::PublicDomain { gateway } =
-                                &address.metadata
-                            {
+                            if let HostnameMetadata::PublicDomain { gateway } = &address.metadata {
                                 for a in &bind.addresses.available {
                                     if a.ssl {
                                         continue;
                                     }
                                     match &a.metadata {
                                         HostnameMetadata::Ipv4 { gateway: gw }
-                                            if a.public
-                                                && gw == gateway =>
+                                            if a.public && gw == gateway =>
                                         {
-                                            if let Some(sa) =
-                                                a.to_socket_addr()
-                                            {
+                                            if let Some(sa) = a.to_socket_addr() {
                                                 if sa.port() == port {
                                                     if enabled {
-                                                        bind.addresses
-                                                            .enabled
-                                                            .insert(sa);
+                                                        bind.addresses.enabled.insert(sa);
                                                     } else {
-                                                        bind.addresses
-                                                            .enabled
-                                                            .remove(&sa);
+                                                        bind.addresses.enabled.remove(&sa);
                                                     }
                                                 }
                                             }
                                         }
-                                        HostnameMetadata::PublicDomain {
-                                            gateway: gw,
-                                        } if gw == gateway => {
+                                        HostnameMetadata::PublicDomain { gateway: gw }
+                                            if gw == gateway =>
+                                        {
                                             let dp = a.port.unwrap_or(80);
                                             if dp == port {
-                                                let k = (
-                                                    a.hostname.clone(),
-                                                    dp,
-                                                );
+                                                let k = (a.hostname.clone(), dp);
                                                 if enabled {
-                                                    bind.addresses
-                                                        .disabled
-                                                        .remove(&k);
+                                                    bind.addresses.disabled.remove(&k);
                                                 } else {
-                                                    bind.addresses
-                                                        .disabled
-                                                        .insert(k);
+                                                    bind.addresses.disabled.insert(k);
                                                 }
                                             }
                                         }

--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -572,7 +572,7 @@ impl NetService {
                     // Handle host updates
                     if hosts_changed {
                         if let Err(e) = async {
-                            let hosts = watch.peek()?.de()?;
+                            let hosts = watch.peek()?.de().unwrap_or_default();
                             let mut data = thread_data.lock().await;
                             let ctrl = data.net_controller()?;
                             for (host_id, host) in hosts.0 {

--- a/core/src/net/ssl.rs
+++ b/core/src/net/ssl.rs
@@ -645,7 +645,8 @@ pub async fn generate_certificate(
     let root_cert = cert_store.as_root_cert().de()?.0;
     drop(peek);
 
-    let hostnames: BTreeSet<InternedString> = hostnames.into_iter().map(InternedString::from).collect();
+    let hostnames: BTreeSet<InternedString> =
+        hostnames.into_iter().map(InternedString::from).collect();
     let san_info = SANInfo::new(&hostnames);
 
     let (key, cert) = if ed25519 {
@@ -658,8 +659,7 @@ pub async fn generate_certificate(
         (key, cert)
     };
 
-    let key_pem =
-        String::from_utf8(key.private_key_to_pem_pkcs8()?).with_kind(ErrorKind::Utf8)?;
+    let key_pem = String::from_utf8(key.private_key_to_pem_pkcs8()?).with_kind(ErrorKind::Utf8)?;
     let fullchain_pem = String::from_utf8(
         [&cert, &int_cert, &root_cert]
             .into_iter()

--- a/core/src/os_install/mod.rs
+++ b/core/src/os_install/mod.rs
@@ -359,7 +359,9 @@ pub async fn install_os_to(
 
         crate::util::mok::sign_unsigned_modules(overlay.path()).await?;
 
-        let mok_pub = overlay.path().join(crate::util::mok::DKMS_MOK_PUB.trim_start_matches('/'));
+        let mok_pub = overlay
+            .path()
+            .join(crate::util::mok::DKMS_MOK_PUB.trim_start_matches('/'));
         match crate::util::mok::enroll_mok(&mok_pub).await {
             Ok(enrolled) => mok_enrolled = enrolled,
             Err(e) => tracing::warn!("MOK enrollment failed: {e}"),

--- a/core/src/registry/admin.rs
+++ b/core/src/registry/admin.rs
@@ -300,12 +300,7 @@ pub async fn remove_signer(
 ) -> Result<(), Error> {
     ctx.db
         .mutate(|db| {
-            if db
-                .as_index_mut()
-                .as_signers_mut()
-                .remove(&id)?
-                .is_none()
-            {
+            if db.as_index_mut().as_signers_mut().remove(&id)?.is_none() {
                 return Err(Error::new(
                     eyre!("{}", t!("registry.admin.unknown-signer")),
                     ErrorKind::NotFound,
@@ -327,9 +322,7 @@ pub async fn remove_signer(
                 .as_versions_mut()
                 .as_entries_mut()?
             {
-                version
-                    .as_authorized_mut()
-                    .mutate(|s| Ok(s.remove(&id)))?;
+                version.as_authorized_mut().mutate(|s| Ok(s.remove(&id)))?;
             }
 
             db.as_admins_mut().mutate(|a| Ok(a.remove(&id)))?;

--- a/core/src/registry/info.rs
+++ b/core/src/registry/info.rs
@@ -131,9 +131,7 @@ pub async fn cli_set_icon(
             .with_kind(ErrorKind::Network)?;
         DataUrl::from_response(res).await?
     } else {
-        let path = icon
-            .strip_prefix("file://")
-            .unwrap_or(&icon);
+        let path = icon.strip_prefix("file://").unwrap_or(&icon);
         DataUrl::from_path(path).await?
     };
     ctx.call_remote::<RegistryContext>(

--- a/core/src/registry/metrics.rs
+++ b/core/src/registry/metrics.rs
@@ -33,9 +33,7 @@ pub fn metrics_api<C: Context>() -> ParentHandler<C> {
             from_fn_async(get_downloads)
                 .with_metadata("admin", Value::Bool(true))
                 .with_display_serializable()
-                .with_custom_display_fn(|handle, result| {
-                    display_downloads(handle.params, result)
-                })
+                .with_custom_display_fn(|handle, result| display_downloads(handle.params, result))
                 .with_about("about.get-metrics-downloads")
                 .with_call_remote::<CliContext>(),
         )
@@ -350,10 +348,7 @@ fn display_downloads(
 
 // --- helpers ---
 
-fn query_count_entries(
-    conn: &rusqlite::Connection,
-    sql: &str,
-) -> Result<Vec<CountEntry>, Error> {
+fn query_count_entries(conn: &rusqlite::Connection, sql: &str) -> Result<Vec<CountEntry>, Error> {
     query_count_entries_with_params(conn, sql, &[])
 }
 
@@ -371,14 +366,10 @@ fn query_count_entries_with_params(
             })
         })
         .with_kind(ErrorKind::Database)?;
-    rows.map(|r| r.with_kind(ErrorKind::Database))
-        .collect()
+    rows.map(|r| r.with_kind(ErrorKind::Database)).collect()
 }
 
-fn time_range_where(
-    after: &Option<String>,
-    before: &Option<String>,
-) -> (String, Vec<String>) {
+fn time_range_where(after: &Option<String>, before: &Option<String>) -> (String, Vec<String>) {
     let mut conditions = Vec::new();
     let mut params = Vec::new();
 

--- a/core/src/registry/os/promote.rs
+++ b/core/src/registry/os/promote.rs
@@ -45,22 +45,15 @@ pub async fn cli_os_promote(
     let os_index: OsIndex = from_value(res)?;
 
     // Find the target version
-    let version_info = os_index
-        .versions
-        .0
-        .get(&version)
-        .ok_or_else(|| {
-            Error::new(
-                eyre!(
-                    "{}",
-                    t!(
-                        "registry.os.promote.version-not-found",
-                        version = &version
-                    )
-                ),
-                ErrorKind::NotFound,
-            )
-        })?;
+    let version_info = os_index.versions.0.get(&version).ok_or_else(|| {
+        Error::new(
+            eyre!(
+                "{}",
+                t!("registry.os.promote.version-not-found", version = &version)
+            ),
+            ErrorKind::NotFound,
+        )
+    })?;
 
     // Add the version to the target registry
     call_registry(
@@ -77,9 +70,30 @@ pub async fn cli_os_promote(
     .await?;
 
     // Promote all assets for each type and platform
-    promote_assets(&ctx, &to_url, &version, &version_info.iso, "os.asset.add.iso").await?;
-    promote_assets(&ctx, &to_url, &version, &version_info.squashfs, "os.asset.add.squashfs").await?;
-    promote_assets(&ctx, &to_url, &version, &version_info.img, "os.asset.add.img").await?;
+    promote_assets(
+        &ctx,
+        &to_url,
+        &version,
+        &version_info.iso,
+        "os.asset.add.iso",
+    )
+    .await?;
+    promote_assets(
+        &ctx,
+        &to_url,
+        &version,
+        &version_info.squashfs,
+        "os.asset.add.squashfs",
+    )
+    .await?;
+    promote_assets(
+        &ctx,
+        &to_url,
+        &version,
+        &version_info.img,
+        "os.asset.add.img",
+    )
+    .await?;
 
     Ok(())
 }
@@ -88,13 +102,19 @@ async fn promote_assets(
     ctx: &CliContext,
     to_url: &Url,
     version: &Version,
-    assets: &std::collections::BTreeMap<InternedString, crate::registry::asset::RegistryAsset<Blake3Commitment>>,
+    assets: &std::collections::BTreeMap<
+        InternedString,
+        crate::registry::asset::RegistryAsset<Blake3Commitment>,
+    >,
     method: &str,
 ) -> Result<(), Error> {
     for (platform, asset) in assets {
         let commitment = &asset.commitment;
-        let signature =
-            AnySignature::Ed25519(Ed25519.sign_commitment(ctx.developer_key()?, commitment, SIG_CONTEXT)?);
+        let signature = AnySignature::Ed25519(Ed25519.sign_commitment(
+            ctx.developer_key()?,
+            commitment,
+            SIG_CONTEXT,
+        )?);
 
         call_registry(
             ctx,

--- a/core/src/registry/package/add.rs
+++ b/core/src/registry/package/add.rs
@@ -285,13 +285,10 @@ pub async fn remove_package(
                         .as_idx_mut(&id)
                     {
                         if let Some(sighash) = sighash {
-                            if if let Some(package) =
-                                package.as_versions_mut().as_idx_mut(version)
+                            if if let Some(package) = package.as_versions_mut().as_idx_mut(version)
                             {
                                 package.as_s9pks_mut().mutate(|s| {
-                                    s.retain(|(_, asset)| {
-                                        asset.commitment.root_sighash != sighash
-                                    });
+                                    s.retain(|(_, asset)| asset.commitment.root_sighash != sighash);
                                     Ok(s.is_empty())
                                 })?
                             } else {

--- a/core/src/registry/package/get.rs
+++ b/core/src/registry/package/get.rs
@@ -1,16 +1,15 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
+use chrono::Utc;
 use clap::{Parser, ValueEnum};
 use exver::{ExtendedVersion, VersionRange};
 use imbl_value::{InternedString, json};
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
-use ts_rs::TS;
-
-use chrono::Utc;
 use rusqlite::params;
+use serde::{Deserialize, Serialize};
 use tracing::warn;
+use ts_rs::TS;
 
 use crate::PackageId;
 use crate::context::CliContext;

--- a/core/src/service/effects/action.rs
+++ b/core/src/service/effects/action.rs
@@ -258,11 +258,7 @@ async fn create_task(
                     .filter(|s| s.is_initialized())
                 {
                     service
-                        .get_action_input(
-                            procedure_id.clone(),
-                            task.action_id.clone(),
-                            Value::Null,
-                        )
+                        .get_action_input(procedure_id.clone(), task.action_id.clone(), Value::Null)
                         .await
                         .log_err()
                         .flatten()

--- a/core/src/service/effects/control.rs
+++ b/core/src/service/effects/control.rs
@@ -88,13 +88,7 @@ pub async fn get_status(
     let ptr = format!("/public/packageData/{}/statusInfo", id)
         .parse()
         .expect("valid json pointer");
-    let mut watch = context
-        .seed
-        .ctx
-        .db
-        .watch(ptr)
-        .await
-        .typed::<StatusInfo>();
+    let mut watch = context.seed.ctx.db.watch(ptr).await.typed::<StatusInfo>();
 
     let status = watch.peek_and_mark_seen()?.de().ok();
 

--- a/core/src/service/effects/dependency.rs
+++ b/core/src/service/effects/dependency.rs
@@ -409,13 +409,7 @@ pub async fn get_service_manifest(
     let ptr = format!("/public/packageData/{}/stateInfo", package_id)
         .parse()
         .expect("valid json pointer");
-    let mut watch = context
-        .seed
-        .ctx
-        .db
-        .watch(ptr)
-        .await
-        .typed::<PackageState>();
+    let mut watch = context.seed.ctx.db.watch(ptr).await.typed::<PackageState>();
 
     let manifest = watch
         .peek_and_mark_seen()?
@@ -424,15 +418,11 @@ pub async fn get_service_manifest(
 
     if let Some(callback) = callback {
         let callback = callback.register(&context.seed.persistent_container);
-        context
-            .seed
-            .ctx
-            .callbacks
-            .add_get_service_manifest(
-                package_id.clone(),
-                watch,
-                CallbackHandler::new(&context, callback),
-            );
+        context.seed.ctx.callbacks.add_get_service_manifest(
+            package_id.clone(),
+            watch,
+            CallbackHandler::new(&context, callback),
+        );
     }
 
     Ok(manifest)

--- a/core/src/service/effects/net/host.rs
+++ b/core/src/service/effects/net/host.rs
@@ -28,13 +28,7 @@ pub async fn get_host_info(
     let ptr = format!("/public/packageData/{}/hosts/{}", package_id, host_id)
         .parse()
         .expect("valid json pointer");
-    let mut watch = context
-        .seed
-        .ctx
-        .db
-        .watch(ptr)
-        .await
-        .typed::<Host>();
+    let mut watch = context.seed.ctx.db.watch(ptr).await.typed::<Host>();
 
     let res = watch.peek_and_mark_seen()?.de().ok();
 

--- a/core/src/service/effects/system.rs
+++ b/core/src/service/effects/system.rs
@@ -27,14 +27,10 @@ pub async fn get_system_smtp(
 
     if let Some(callback) = callback {
         let callback = callback.register(&context.seed.persistent_container);
-        context
-            .seed
-            .ctx
-            .callbacks
-            .add_get_system_smtp(
-                watch.typed::<Option<SmtpValue>>(),
-                CallbackHandler::new(&context, callback),
-            );
+        context.seed.ctx.callbacks.add_get_system_smtp(
+            watch.typed::<Option<SmtpValue>>(),
+            CallbackHandler::new(&context, callback),
+        );
     }
 
     Ok(res)

--- a/core/src/service/service_actor.rs
+++ b/core/src/service/service_actor.rs
@@ -114,7 +114,9 @@ async fn service_actor_loop<'a>(
         }
         StatusInfo {
             desired:
-                DesiredStatus::Stopped | DesiredStatus::Restarting { .. } | DesiredStatus::BackingUp { .. },
+                DesiredStatus::Stopped
+                | DesiredStatus::Restarting { .. }
+                | DesiredStatus::BackingUp { .. },
             started: Some(_),
             ..
         } => {

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -559,8 +559,7 @@ pub async fn execute_inner(
     let progress = &ctx.progress;
 
     if !crate::disk::mount::util::is_mountpoint(Path::new(DATA_DIR).join("main")).await? {
-        let mut disk_phase =
-            progress.add_phase(t!("setup.opening-data-drive").into(), Some(10));
+        let mut disk_phase = progress.add_phase(t!("setup.opening-data-drive").into(), Some(10));
         disk_phase.start();
         let requires_reboot = crate::disk::main::import(
             &*guid,

--- a/core/src/system/mod.rs
+++ b/core/src/system/mod.rs
@@ -354,7 +354,10 @@ pub fn kiosk<C: Context>() -> ParentHandler<C> {
                     .mutate(|db| {
                         let server_info = db.as_public_mut().as_server_info_mut();
                         server_info.as_kiosk_mut().ser(&Some(true))?;
-                        server_info.as_status_info_mut().as_restart_mut().ser(&Some(RestartReason::Kiosk))
+                        server_info
+                            .as_status_info_mut()
+                            .as_restart_mut()
+                            .ser(&Some(RestartReason::Kiosk))
                     })
                     .await
                     .result?;
@@ -371,7 +374,10 @@ pub fn kiosk<C: Context>() -> ParentHandler<C> {
                     .mutate(|db| {
                         let server_info = db.as_public_mut().as_server_info_mut();
                         server_info.as_kiosk_mut().ser(&Some(false))?;
-                        server_info.as_status_info_mut().as_restart_mut().ser(&Some(RestartReason::Kiosk))
+                        server_info
+                            .as_status_info_mut()
+                            .as_restart_mut()
+                            .ser(&Some(RestartReason::Kiosk))
                     })
                     .await
                     .result?;
@@ -1370,10 +1376,11 @@ pub async fn set_language(
     ctx.db
         .mutate(|db| {
             let server_info = db.as_public_mut().as_server_info_mut();
+            server_info.as_language_mut().ser(&Some(language.clone()))?;
             server_info
-                .as_language_mut()
-                .ser(&Some(language.clone()))?;
-            server_info.as_status_info_mut().as_restart_mut().ser(&Some(RestartReason::Language))
+                .as_status_info_mut()
+                .as_restart_mut()
+                .ser(&Some(RestartReason::Language))
         })
         .await
         .result?;

--- a/core/src/tunnel/migrations/mod.rs
+++ b/core/src/tunnel/migrations/mod.rs
@@ -13,9 +13,7 @@ pub trait TunnelMigration {
     fn action(&self, db: &mut Value) -> Result<(), Error>;
 }
 
-pub const MIGRATIONS: &[&dyn TunnelMigration] = &[
-    &m_00_port_forward_entry::PortForwardEntry,
-];
+pub const MIGRATIONS: &[&dyn TunnelMigration] = &[&m_00_port_forward_entry::PortForwardEntry];
 
 #[instrument(skip_all)]
 pub fn run_migrations(db: &mut Model<TunnelDatabase>) -> Result<(), Error> {

--- a/core/src/tunnel/web.rs
+++ b/core/src/tunnel/web.rs
@@ -521,7 +521,9 @@ pub async fn init_web(ctx: CliContext) -> Result<(), Error> {
                 .or_not_found("certificate in chain")?;
                 println!("📝 Root CA:");
                 print!("{cert}\n");
-                println!("Follow instructions to trust your Root CA (recommended): https://docs.start9.com/start-tunnel/installing.html#trust-your-root-ca");
+                println!(
+                    "Follow instructions to trust your Root CA (recommended): https://docs.start9.com/start-tunnel/installing.html#trust-your-root-ca"
+                );
 
                 return Ok(());
             }

--- a/core/src/version/mod.rs
+++ b/core/src/version/mod.rs
@@ -67,8 +67,9 @@ mod v0_4_0_beta_0;
 mod v0_4_0_beta_1;
 mod v0_4_0_beta_2;
 mod v0_4_0_beta_3;
+mod v0_4_0_beta_4;
 
-pub type Current = v0_4_0_beta_3::Version; // VERSION_BUMP
+pub type Current = v0_4_0_beta_4::Version; // VERSION_BUMP
 
 impl Current {
     #[instrument(skip(self, db))]
@@ -203,7 +204,8 @@ enum Version {
     V0_4_0_beta_0(Wrapper<v0_4_0_beta_0::Version>),
     V0_4_0_beta_1(Wrapper<v0_4_0_beta_1::Version>),
     V0_4_0_beta_2(Wrapper<v0_4_0_beta_2::Version>),
-    V0_4_0_beta_3(Wrapper<v0_4_0_beta_3::Version>), // VERSION_BUMP
+    V0_4_0_beta_3(Wrapper<v0_4_0_beta_3::Version>),
+    V0_4_0_beta_4(Wrapper<v0_4_0_beta_4::Version>), // VERSION_BUMP
     Other(exver::Version),
 }
 
@@ -273,7 +275,8 @@ impl Version {
             Self::V0_4_0_beta_0(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_1(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_2(v) => DynVersion(Box::new(v.0)),
-            Self::V0_4_0_beta_3(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
+            Self::V0_4_0_beta_3(v) => DynVersion(Box::new(v.0)),
+            Self::V0_4_0_beta_4(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
             Self::Other(v) => {
                 return Err(Error::new(
                     eyre!("unknown version {v}"),
@@ -335,7 +338,8 @@ impl Version {
             Version::V0_4_0_beta_0(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_1(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_2(Wrapper(x)) => x.semver(),
-            Version::V0_4_0_beta_3(Wrapper(x)) => x.semver(), // VERSION_BUMP
+            Version::V0_4_0_beta_3(Wrapper(x)) => x.semver(),
+            Version::V0_4_0_beta_4(Wrapper(x)) => x.semver(), // VERSION_BUMP
             Version::Other(x) => x.clone(),
         }
     }

--- a/core/src/version/v0_3_6_alpha_0.rs
+++ b/core/src/version/v0_3_6_alpha_0.rs
@@ -194,9 +194,13 @@ impl VersionT for Version {
                 "Found /home/start9/PGDB_DO_NOT_MIGRATE — \
                  skipping PostgreSQL migration, generating fresh account data"
             );
-            let account =
-                AccountInfo::new("embassy", std::time::SystemTime::now(), None)?;
-            return Ok((account, SshKeys::new(), CifsTargets::default(), BTreeMap::new()));
+            let account = AccountInfo::new("embassy", std::time::SystemTime::now(), None)?;
+            return Ok((
+                account,
+                SshKeys::new(),
+                CifsTargets::default(),
+                BTreeMap::new(),
+            ));
         }
 
         let pg = init_postgres(DATA_DIR).await?;
@@ -555,17 +559,23 @@ impl VersionT for Version {
         }
 
         if !failures.is_empty() {
-            ctx.db.mutate(|db| {
-                let services = failures.iter().map(|(id, title)| title.as_ref().copied().unwrap_or(id)).join(", ");
-                notify(
-                    db,
-                    None,
-                    NotificationLevel::Error,
-                    t!("migration.services-failed-title").to_string(),
-                    t!("migration.services-failed-message", services = services).to_string(),
-                    (),
-                )
-            }).await.result?;
+            ctx.db
+                .mutate(|db| {
+                    let services = failures
+                        .iter()
+                        .map(|(id, title)| title.as_ref().copied().unwrap_or(id))
+                        .join(", ");
+                    notify(
+                        db,
+                        None,
+                        NotificationLevel::Error,
+                        t!("migration.services-failed-title").to_string(),
+                        t!("migration.services-failed-message", services = services).to_string(),
+                        (),
+                    )
+                })
+                .await
+                .result?;
         }
 
         progress_logger.abort();

--- a/core/src/version/v0_4_0_beta_4.rs
+++ b/core/src/version/v0_4_0_beta_4.rs
@@ -1,13 +1,13 @@
 use exver::{PreReleaseSegment, VersionRange};
 
 use super::v0_3_5::V0_3_0_COMPAT;
-use super::{VersionT, v0_4_0_alpha_22};
+use super::{VersionT, v0_4_0_beta_3};
 use crate::prelude::*;
 
 lazy_static::lazy_static! {
-    static ref V0_4_0_alpha_23: exver::Version = exver::Version::new(
+    static ref V0_4_0_beta_4: exver::Version = exver::Version::new(
         [0, 4, 0],
-        [PreReleaseSegment::String("alpha".into()), 23.into()]
+        [PreReleaseSegment::String("beta".into()), 4.into()]
     );
 }
 
@@ -15,26 +15,20 @@ lazy_static::lazy_static! {
 pub struct Version;
 
 impl VersionT for Version {
-    type Previous = v0_4_0_alpha_22::Version;
+    type Previous = v0_4_0_beta_3::Version;
     type PreUpRes = ();
 
     async fn pre_up(self) -> Result<Self::PreUpRes, Error> {
         Ok(())
     }
     fn semver(self) -> exver::Version {
-        V0_4_0_alpha_23.clone()
+        V0_4_0_beta_4.clone()
     }
     fn compat(self) -> &'static VersionRange {
         &V0_3_0_COMPAT
     }
     #[instrument(skip_all)]
-    fn up(self, db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
-        let status_info = db["public"]["serverInfo"]["statusInfo"].as_object_mut();
-        if let Some(m) = status_info {
-            m.remove("updated");
-            m.insert("restart".into(), Value::Null);
-        }
-
+    fn up(self, _db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
         Ok(Value::Null)
     }
     fn down(self, _db: &mut Value) -> Result<(), Error> {

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -2,12 +2,10 @@ use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
 
-use crate::PackageId;
 pub use crate::VolumeId;
 use crate::prelude::*;
-use crate::util::Invoke;
-use crate::util::VersionString;
-use crate::DATA_DIR;
+use crate::util::{Invoke, VersionString};
+use crate::{DATA_DIR, PackageId};
 
 pub const PKG_VOLUME_DIR: &str = "package-data/volumes";
 pub const BACKUP_DIR: &str = "/media/startos/backups";

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startos-ui",
-      "version": "0.4.0-beta.3",
+      "version": "0.4.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^21.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "author": "Start9 Labs, Inc",
   "homepage": "https://start9.com/",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump StartOS version from 0.4.0-beta.3 to 0.4.0-beta.4
- Includes rustfmt formatting fixes across core