### PR TITLE
perf(net/vhost): skip cert resolution for TLS passthrough

### DIFF
--- a/core/src/net/tls.rs
+++ b/core/src/net/tls.rs
@@ -82,43 +82,6 @@ where
     }
 }
 
-#[derive(Clone)]
-pub struct TlsHandlerWrapper<I, W> {
-    pub inner: I,
-    pub wrapper: W,
-}
-
-pub trait WrapTlsHandler<A: Accept> {
-    fn wrap<'a>(
-        &'a mut self,
-        prev: ServerConfig,
-        hello: &'a ClientHello<'a>,
-        metadata: &'a <A as Accept>::Metadata,
-    ) -> impl Future<Output = Option<TlsHandlerAction>> + Send + 'a
-    where
-        Self: 'a;
-}
-
-impl<'a, A, I, W> TlsHandler<'a, A> for TlsHandlerWrapper<I, W>
-where
-    A: Accept + 'a,
-    <A as Accept>::Metadata: Send + Sync,
-    I: TlsHandler<'a, A> + Send,
-    W: WrapTlsHandler<A> + Send,
-{
-    async fn get_config(
-        &'a mut self,
-        hello: &'a ClientHello<'a>,
-        metadata: &'a <A as Accept>::Metadata,
-    ) -> Option<TlsHandlerAction> {
-        let action = self.inner.get_config(hello, metadata).await?;
-        match action {
-            TlsHandlerAction::Tls(cfg) => self.wrapper.wrap(cfg, hello, metadata).await,
-            other => Some(other),
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct SingleCertResolver(pub Arc<CertifiedKey>);
 impl ResolvesServerCert for SingleCertResolver {

--- a/core/src/net/vhost.rs
+++ b/core/src/net/vhost.rs
@@ -980,20 +980,7 @@ where
         hello: &'a ClientHello<'a>,
         metadata: &'a <A as Accept>::Metadata,
     ) -> Option<TlsHandlerAction> {
-        // ACME `acme-tls/1` challenge must be answered locally with the
-        // challenge cert produced by `AcmeTlsHandler` in the inner chain;
-        // skip the routing/passthrough decision entirely so we don't
-        // accidentally tunnel the challenge to a backend.
-        if hello
-            .alpn()
-            .into_iter()
-            .flatten()
-            .any(|a| a == ACME_TLS_ALPN_NAME)
-        {
-            return self.inner.get_config(hello, metadata).await;
-        }
-
-        let (target, rc) = self.mapping.peek(|m| {
+        let routed = self.mapping.peek(|m| {
             m.get(&hello.server_name().map(InternedString::from))
                 .or_else(|| m.get(&None))
                 .into_iter()
@@ -1001,24 +988,36 @@ where
                 .filter(|(_, rc)| rc.strong_count() > 0)
                 .find(|(t, _)| t.0.filter(metadata))
                 .map(|(t, rc)| (t.clone(), rc.clone()))
-        })?;
+        });
 
-        if target.0.is_passthrough() {
-            // The `ServerConfig` handed to `preprocess` is discarded by the
-            // caller for passthrough — `preprocess`'s only side effect we
-            // care about is the TCP connect to the backend. Use a cheap
-            // stub config (no keygen, no DB I/O) instead of running the
-            // cert chain, which would otherwise pay a write-locked
-            // patch-db transaction and possibly an ed25519+nistp256
-            // keygen + double leaf-cert signature on cold-tuple connects.
+        let acme_alpn = hello
+            .alpn()
+            .into_iter()
+            .flatten()
+            .any(|a| a == ACME_TLS_ALPN_NAME);
+
+        // Passthroughs should not intermediate ACME challenges — the
+        // backend is the ACME client and holds the challenge cert.
+        if let Some((target, rc)) = routed.as_ref().filter(|(t, _)| t.0.is_passthrough()) {
             let stub = passthrough_stub_config(&self.crypto_provider).log_err()?;
-            let (_, store) = target.into_preprocessed(rc, stub, hello, metadata).await?;
+            let (_, store) = target
+                .clone()
+                .into_preprocessed(rc.clone(), stub, hello, metadata)
+                .await?;
             self.preprocessed = Some(store);
             return Some(TlsHandlerAction::Passthrough);
         }
 
-        // Terminating: now we actually need a real cert. Run the inner
-        // chain (AcmeTlsHandler → RootCaTlsHandler).
+        // ACME challenge for a terminating target (or for one with no
+        // explicit vhost mapping): answer locally from the inner chain.
+        if acme_alpn {
+            return self.inner.get_config(hello, metadata).await;
+        }
+
+        let Some((target, rc)) = routed else {
+            return None;
+        };
+
         let action = self.inner.get_config(hello, metadata).await?;
         let cfg = match action {
             TlsHandlerAction::Tls(cfg) => cfg,

--- a/core/src/net/vhost.rs
+++ b/core/src/net/vhost.rs
@@ -37,7 +37,7 @@ use crate::net::gateway::{
 };
 use crate::net::ssl::{CertStore, RootCaTlsHandler};
 use crate::net::tls::{
-    ChainedHandler, TlsHandlerAction, TlsHandlerWrapper, TlsListener, TlsMetadata, WrapTlsHandler,
+    ChainedHandler, TlsHandler, TlsHandlerAction, TlsListener, TlsMetadata,
 };
 use crate::net::utils::{ipv6_is_link_local, is_private_ip};
 use crate::net::web_server::{Accept, AcceptStream, ExtractVisitor, TcpMetadata, extract};
@@ -910,38 +910,90 @@ impl<A: Accept + 'static> GetAcmeProvider for GetVHostAcmeProvider<A> {
     }
 }
 
-pub struct VHostConnector<A: Accept + 'static>(Watch<Mapping<A>>, Option<Preprocessed<A>>);
-impl<A: Accept + 'static> Clone for VHostConnector<A> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone(), None)
+/// No-op cert resolver used to build a cheap [`ServerConfig`] for the
+/// passthrough path. The config is fed to [`ProxyTarget::preprocess`] so it
+/// can satisfy the [`VHostTarget`] trait signature, but the caller discards
+/// it before any handshake runs against it — the resolver is never asked
+/// to produce a certificate.
+#[derive(Debug)]
+struct NoCertResolver;
+impl tokio_rustls::rustls::server::ResolvesServerCert for NoCertResolver {
+    fn resolve(
+        &self,
+        _: ClientHello,
+    ) -> Option<Arc<tokio_rustls::rustls::sign::CertifiedKey>> {
+        None
     }
 }
 
-impl<A> WrapTlsHandler<A> for VHostConnector<A>
+fn passthrough_stub_config(
+    crypto_provider: &Arc<CryptoProvider>,
+) -> Result<ServerConfig, Error> {
+    Ok(ServerConfig::builder_with_provider(crypto_provider.clone())
+        .with_safe_default_protocol_versions()
+        .with_kind(ErrorKind::OpenSsl)?
+        .with_no_client_auth()
+        .with_cert_resolver(Arc::new(NoCertResolver)))
+}
+
+/// Routes incoming TLS connections by SNI. For passthrough targets the
+/// expensive cert-resolution chain (`AcmeTlsHandler` + `RootCaTlsHandler`,
+/// the latter of which goes through a write-locked patch-db transaction
+/// and can lazily generate a keypair plus sign two leaf certs) is skipped
+/// entirely — a passthrough connection only needs to TCP-connect to the
+/// backend so the client's TLS handshake can complete against it, and any
+/// `ServerConfig` we built locally would be discarded.
+///
+/// The handler holds the cert-resolution chain as `inner` and only invokes
+/// it when the matched target terminates TLS, or when the connection is the
+/// ACME `acme-tls/1` ALPN challenge (which has to be answered locally).
+pub struct VHostTlsHandler<I, A: Accept + 'static> {
+    inner: I,
+    crypto_provider: Arc<CryptoProvider>,
+    mapping: Watch<Mapping<A>>,
+    preprocessed: Option<Preprocessed<A>>,
+}
+impl<I: Clone, A: Accept + 'static> Clone for VHostTlsHandler<I, A> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            crypto_provider: self.crypto_provider.clone(),
+            mapping: self.mapping.clone(),
+            // Per-connection state — never carried across clones; each
+            // accepted connection clones the handler before populating it.
+            preprocessed: None,
+        }
+    }
+}
+
+impl<'a, A, I> TlsHandler<'a, A> for VHostTlsHandler<I, A>
 where
-    A: Accept + 'static,
-    <A as Accept>::Metadata:
-        Visit<ExtractVisitor<GatewayInfo>> + Visit<ExtractVisitor<TcpMetadata>> + Send + Sync,
+    A: Accept + 'a,
+    <A as Accept>::Metadata: Visit<ExtractVisitor<GatewayInfo>>
+        + Visit<ExtractVisitor<TcpMetadata>>
+        + Send
+        + Sync,
+    I: TlsHandler<'a, A> + Send,
 {
-    async fn wrap<'a>(
+    async fn get_config(
         &'a mut self,
-        prev: ServerConfig,
         hello: &'a ClientHello<'a>,
         metadata: &'a <A as Accept>::Metadata,
-    ) -> Option<TlsHandlerAction>
-    where
-        Self: 'a,
-    {
+    ) -> Option<TlsHandlerAction> {
+        // ACME `acme-tls/1` challenge must be answered locally with the
+        // challenge cert produced by `AcmeTlsHandler` in the inner chain;
+        // skip the routing/passthrough decision entirely so we don't
+        // accidentally tunnel the challenge to a backend.
         if hello
             .alpn()
             .into_iter()
             .flatten()
             .any(|a| a == ACME_TLS_ALPN_NAME)
         {
-            return Some(TlsHandlerAction::Tls(prev));
+            return self.inner.get_config(hello, metadata).await;
         }
 
-        let (target, rc) = self.0.peek(|m| {
+        let (target, rc) = self.mapping.peek(|m| {
             m.get(&hello.server_name().map(InternedString::from))
                 .or_else(|| m.get(&None))
                 .into_iter()
@@ -951,25 +1003,39 @@ where
                 .map(|(t, rc)| (t.clone(), rc.clone()))
         })?;
 
-        let is_pt = target.0.is_passthrough();
-        let (prev, store) = target.into_preprocessed(rc, prev, hello, metadata).await?;
-
-        self.1 = Some(store);
-
-        if is_pt {
-            Some(TlsHandlerAction::Passthrough)
-        } else {
-            Some(TlsHandlerAction::Tls(prev))
+        if target.0.is_passthrough() {
+            // The `ServerConfig` handed to `preprocess` is discarded by the
+            // caller for passthrough — `preprocess`'s only side effect we
+            // care about is the TCP connect to the backend. Use a cheap
+            // stub config (no keygen, no DB I/O) instead of running the
+            // cert chain, which would otherwise pay a write-locked
+            // patch-db transaction and possibly an ed25519+nistp256
+            // keygen + double leaf-cert signature on cold-tuple connects.
+            let stub = passthrough_stub_config(&self.crypto_provider).log_err()?;
+            let (_, store) = target.into_preprocessed(rc, stub, hello, metadata).await?;
+            self.preprocessed = Some(store);
+            return Some(TlsHandlerAction::Passthrough);
         }
+
+        // Terminating: now we actually need a real cert. Run the inner
+        // chain (AcmeTlsHandler → RootCaTlsHandler).
+        let action = self.inner.get_config(hello, metadata).await?;
+        let cfg = match action {
+            TlsHandlerAction::Tls(cfg) => cfg,
+            other => return Some(other),
+        };
+        let (prev, store) = target.into_preprocessed(rc, cfg, hello, metadata).await?;
+        self.preprocessed = Some(store);
+        Some(TlsHandlerAction::Tls(prev))
     }
 }
 
 struct VHostListener<M, A>(
     TlsListener<
         A,
-        TlsHandlerWrapper<
+        VHostTlsHandler<
             ChainedHandler<Arc<AcmeTlsHandler<M, GetVHostAcmeProvider<A>>>, RootCaTlsHandler<M>>,
-            VHostConnector<A>,
+            A,
         >,
     >,
 )
@@ -1023,7 +1089,7 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(Self::Metadata, AcceptStream), Error>> {
         let (metadata, stream) = ready!(self.0.poll_accept(cx)?);
-        let preprocessed = self.0.tls_handler.wrapper.1.take();
+        let preprocessed = self.0.tls_handler.preprocessed.take();
         Poll::Ready(Ok((
             VHostListenerMetadata {
                 inner: metadata,
@@ -1102,7 +1168,7 @@ impl<A: Accept> VHostServer<A> {
             _thread: tokio::spawn(async move {
                 let mut listener = VHostListener(TlsListener::new(
                     listener,
-                    TlsHandlerWrapper {
+                    VHostTlsHandler {
                         inner: ChainedHandler(
                             Arc::new(AcmeTlsHandler {
                                 db: db.clone(),
@@ -1113,10 +1179,12 @@ impl<A: Accept> VHostServer<A> {
                             }),
                             RootCaTlsHandler {
                                 db,
-                                crypto_provider,
+                                crypto_provider: crypto_provider.clone(),
                             },
                         ),
-                        wrapper: VHostConnector(mapping, None),
+                        crypto_provider,
+                        mapping,
+                        preprocessed: None,
                     },
                 ));
                 loop {


### PR DESCRIPTION
## Summary

Cuts vhost passthrough TLS handshake latency from ~2.7s down to ~1×RTT-to-backend by reordering the per-connection TLS pipeline so the routing decision (passthrough vs terminate) runs **before** cert resolution, instead of after.

## Diagnosis

For every incoming TLS connection on a vhost port, the listener was built as `TlsHandlerWrapper { inner: ChainedHandler(AcmeTlsHandler, RootCaTlsHandler), wrapper: VHostConnector }`. `TlsHandlerWrapper::get_config` ran the inner cert chain first, then asked `VHostConnector::wrap` whether the SNI mapped to a passthrough. For passthrough hits, the freshly produced `ServerConfig` was **discarded** — but the work to build it was not free:

- `RootCaTlsHandler::get_config` calls `db.mutate(|db| cert_for(...))`, which serializes through the single patch-db writer queue and pays the fsync cost on commit.
- Inside `Model<CertStore>::cert_for`, on a cold tuple `{SNI, local_addr.ip(), wan_ip}` (happens whenever the WAN IP wasn't populated last time, on dual-stack/IPv6 temp-addr connections, on first hits, etc.), it generates an ed25519 keypair + an nistp256 keypair, signs two leaf certs against the intermediate, and writes the new entry back into `leaves`.

With any concurrent DB write activity, this comfortably lands in the seconds range — observed as ~2.7s client-visible TLS handshake latency on a vhost passthrough between two StartOS servers.

## Fix

Promote `VHostConnector` from a `WrapTlsHandler` (post-processor) into a real `TlsHandler` (`VHostTlsHandler`) that owns the cert chain as its `inner`:

- On each `get_config`, look up the SNI in the mapping immediately. If the matched target is a passthrough, build a cheap stub `ServerConfig` (no keygen, no DB I/O — uses a `NoCertResolver`) just to satisfy the `VHostTarget::preprocess` signature, and skip the inner cert chain entirely.
- Only invoke `inner.get_config` for terminating-TLS targets where the cert is actually consumed.
- Keep ACME `acme-tls/1` ALPN challenges going straight to the inner chain so they're answered locally and never tunneled.

The remaining latency on a passthrough is dominated by the TCP connect to the backend plus the real TLS handshake against it — i.e. roughly 1×RTT-to-backend on top of a normal handshake.

Drops the now-unused `WrapTlsHandler` / `TlsHandlerWrapper` abstractions from `net::tls` (only consumer was `VHostConnector`).

## Tests

- `cargo check --lib -p start-os`: clean
- `cargo test --lib -p start-os net::`: 64/64 pass