### PR TITLE
feat(core): limited os update via diagnostic api

### DIFF
--- a/core/src/context/diagnostic.rs
+++ b/core/src/context/diagnostic.rs
@@ -17,10 +17,7 @@ pub struct DiagnosticContextSeed {
     pub error: Arc<RpcError>,
     pub disk_guid: Option<InternedString>,
     pub rpc_continuations: RpcContinuations,
-    /// Held by an in-flight `diagnostic.update`. The strong count is `1`
-    /// when no update is running; the update task holds a clone for its
-    /// entire lifetime, and dropping the clone (success, failure, or
-    /// cancellation) automatically frees the slot.
+    /// Single-flight token for `diagnostic.update`; strong count > 1 means an update is running.
     pub update_in_progress: SyncMutex<Arc<()>>,
 }
 

--- a/core/src/context/diagnostic.rs
+++ b/core/src/context/diagnostic.rs
@@ -10,12 +10,14 @@ use crate::context::config::ServerConfig;
 use crate::prelude::*;
 use crate::rpc_continuations::RpcContinuations;
 use crate::shutdown::Shutdown;
+use crate::util::sync::SyncMutex;
 
 pub struct DiagnosticContextSeed {
     pub shutdown: Sender<Shutdown>,
     pub error: Arc<RpcError>,
     pub disk_guid: Option<InternedString>,
     pub rpc_continuations: RpcContinuations,
+    pub update_in_progress: SyncMutex<bool>,
 }
 
 #[derive(Clone)]
@@ -40,6 +42,7 @@ impl DiagnosticContext {
             disk_guid,
             error: Arc::new(error.into()),
             rpc_continuations: RpcContinuations::new(),
+            update_in_progress: SyncMutex::new(false),
         })))
     }
 }

--- a/core/src/context/diagnostic.rs
+++ b/core/src/context/diagnostic.rs
@@ -17,7 +17,11 @@ pub struct DiagnosticContextSeed {
     pub error: Arc<RpcError>,
     pub disk_guid: Option<InternedString>,
     pub rpc_continuations: RpcContinuations,
-    pub update_in_progress: SyncMutex<bool>,
+    /// Held by an in-flight `diagnostic.update`. The strong count is `1`
+    /// when no update is running; the update task holds a clone for its
+    /// entire lifetime, and dropping the clone (success, failure, or
+    /// cancellation) automatically frees the slot.
+    pub update_in_progress: SyncMutex<Arc<()>>,
 }
 
 #[derive(Clone)]
@@ -42,7 +46,7 @@ impl DiagnosticContext {
             disk_guid,
             error: Arc::new(error.into()),
             rpc_continuations: RpcContinuations::new(),
-            update_in_progress: SyncMutex::new(false),
+            update_in_progress: SyncMutex::new(Arc::new(())),
         })))
     }
 }

--- a/core/src/diagnostic.rs
+++ b/core/src/diagnostic.rs
@@ -10,6 +10,7 @@ use crate::disk::repair;
 use crate::init::SYSTEM_REBUILD_PATH;
 use crate::prelude::*;
 use crate::shutdown::Shutdown;
+use crate::update::diagnostic as update;
 use crate::util::io::delete_file;
 
 pub fn diagnostic<C: Context>() -> ParentHandler<C> {
@@ -58,6 +59,13 @@ pub fn diagnostic<C: Context>() -> ParentHandler<C> {
                 .no_display()
                 .with_about("about.teardown-rebuild-containers")
                 .with_call_remote::<CliContext>(),
+        )
+        .subcommand("update", from_fn_async(update::update_system).no_cli())
+        .subcommand(
+            "update",
+            from_fn_async(update::cli_update_system)
+                .no_display()
+                .with_about("about.check-update-startos"),
         )
 }
 

--- a/core/src/update/diagnostic.rs
+++ b/core/src/update/diagnostic.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use color_eyre::eyre::eyre;
@@ -51,26 +52,25 @@ pub async fn update_system(
         progress: report_progress,
     }: UpdateSystemParams,
 ) -> Result<UpdateSystemRes, Error> {
-    let claimed = ctx.update_in_progress.mutate(|in_progress| {
-        if *in_progress {
-            false
+    // Reserve the single-flight slot by cloning the context's `Arc<()>`. If
+    // another update is already running, its task is holding a clone, so the
+    // strong count is >1 and we bail. Otherwise the clone we take here gets
+    // moved into the update task and lives until it finishes.
+    let guard = ctx.update_in_progress.mutate(|slot| {
+        if Arc::strong_count(slot) > 1 {
+            None
         } else {
-            *in_progress = true;
-            true
+            Some(slot.clone())
         }
     });
-    if !claimed {
+    let Some(guard) = guard else {
         return Err(Error::new(
             eyre!("{}", t!("update.already-updating")),
             ErrorKind::InvalidRequest,
         ));
-    }
+    };
 
-    let result = run_update(ctx.clone(), target, registry, report_progress).await;
-    if result.as_ref().map_or(true, |r| r.target.is_none()) {
-        ctx.update_in_progress.mutate(|p| *p = false);
-    }
-    result
+    run_update(ctx, target, registry, report_progress, guard).await
 }
 
 async fn run_update(
@@ -78,6 +78,7 @@ async fn run_update(
     target: Option<VersionRange>,
     registry: Url,
     report_progress: bool,
+    guard: Arc<()>,
 ) -> Result<UpdateSystemRes, Error> {
     let target_range = target.unwrap_or(VersionRange::Any);
     let client = Client::new();
@@ -112,8 +113,10 @@ async fn run_update(
 
     let (done_tx, done_rx) = oneshot::channel();
     let tracker_for_task = tracker.clone();
-    let ctx_for_task = ctx.clone();
     tokio::spawn(async move {
+        // `guard` is moved in here; dropping it at task exit (success,
+        // failure, or panic) releases the single-flight slot.
+        let _guard = guard;
         let res = do_update(
             client,
             asset,
@@ -130,7 +133,6 @@ async fn run_update(
             tracing::error!("{}", t!("update.not-successful", error = e.to_string()));
             tracing::debug!("{e:?}");
         }
-        ctx_for_task.update_in_progress.mutate(|p| *p = false);
         let _ = done_tx.send(res);
     });
 

--- a/core/src/update/diagnostic.rs
+++ b/core/src/update/diagnostic.rs
@@ -25,9 +25,7 @@ use crate::sign::AnySigningKey;
 use crate::update::{UpdateProgressHandles, UpdateSystemParams, UpdateSystemRes, do_update};
 use crate::version::{Current, VersionT};
 
-/// Wrapper that exposes a one-off `Client` to `signature::call_remote` while
-/// always failing to produce a signing key (registry version-lookup is
-/// unauthenticated, so the request just goes out unsigned).
+/// `SigningContext` for unauthenticated registry calls in diagnostic mode.
 struct UnsignedRegistry(Client);
 impl AsRef<Client> for UnsignedRegistry {
     fn as_ref(&self) -> &Client {
@@ -52,10 +50,6 @@ pub async fn update_system(
         progress: report_progress,
     }: UpdateSystemParams,
 ) -> Result<UpdateSystemRes, Error> {
-    // Reserve the single-flight slot by cloning the context's `Arc<()>`. If
-    // another update is already running, its task is holding a clone, so the
-    // strong count is >1 and we bail. Otherwise the clone we take here gets
-    // moved into the update task and lives until it finishes.
     let guard = ctx.update_in_progress.mutate(|slot| {
         if Arc::strong_count(slot) > 1 {
             None
@@ -114,8 +108,6 @@ async fn run_update(
     let (done_tx, done_rx) = oneshot::channel();
     let tracker_for_task = tracker.clone();
     tokio::spawn(async move {
-        // `guard` is moved in here; dropping it at task exit (success,
-        // failure, or panic) releases the single-flight slot.
         let _guard = guard;
         let res = do_update(
             client,

--- a/core/src/update/diagnostic.rs
+++ b/core/src/update/diagnostic.rs
@@ -1,0 +1,307 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use color_eyre::eyre::eyre;
+use exver::{Version, VersionRange};
+use futures::{StreamExt, TryStreamExt};
+use http::HeaderMap;
+use imbl_value::json;
+use itertools::Itertools;
+use reqwest::{Client, Url};
+use rpc_toolkit::HandlerArgs;
+use tokio::sync::oneshot;
+use tracing::instrument;
+
+use crate::PLATFORM;
+use crate::context::{CliContext, DiagnosticContext};
+use crate::middleware::auth::signature::{self, SigningContext};
+use crate::prelude::*;
+use crate::progress::{FullProgress, FullProgressTracker, PhasedProgressBar, ProgressUnits};
+use crate::registry::os::SIG_CONTEXT;
+use crate::registry::os::index::OsVersionInfo;
+use crate::rpc_continuations::{Guid, RpcContinuation};
+use crate::sign::AnySigningKey;
+use crate::update::{UpdateProgressHandles, UpdateSystemParams, UpdateSystemRes, do_update};
+use crate::version::{Current, VersionT};
+
+/// Wrapper that exposes a one-off `Client` to `signature::call_remote` while
+/// always failing to produce a signing key (registry version-lookup is
+/// unauthenticated, so the request just goes out unsigned).
+struct UnsignedRegistry(Client);
+impl AsRef<Client> for UnsignedRegistry {
+    fn as_ref(&self) -> &Client {
+        &self.0
+    }
+}
+impl SigningContext for UnsignedRegistry {
+    fn signing_key(&self) -> Result<AnySigningKey, Error> {
+        Err(Error::new(
+            eyre!("diagnostic mode has no signing key"),
+            ErrorKind::Authorization,
+        ))
+    }
+}
+
+#[instrument(skip_all)]
+pub async fn update_system(
+    ctx: DiagnosticContext,
+    UpdateSystemParams {
+        target,
+        registry,
+        progress: report_progress,
+    }: UpdateSystemParams,
+) -> Result<UpdateSystemRes, Error> {
+    let claimed = ctx.update_in_progress.mutate(|in_progress| {
+        if *in_progress {
+            false
+        } else {
+            *in_progress = true;
+            true
+        }
+    });
+    if !claimed {
+        return Err(Error::new(
+            eyre!("{}", t!("update.already-updating")),
+            ErrorKind::InvalidRequest,
+        ));
+    }
+
+    let result = run_update(ctx.clone(), target, registry, report_progress).await;
+    if result.as_ref().map_or(true, |r| r.target.is_none()) {
+        ctx.update_in_progress.mutate(|p| *p = false);
+    }
+    result
+}
+
+async fn run_update(
+    ctx: DiagnosticContext,
+    target: Option<VersionRange>,
+    registry: Url,
+    report_progress: bool,
+) -> Result<UpdateSystemRes, Error> {
+    let target_range = target.unwrap_or(VersionRange::Any);
+    let client = Client::new();
+
+    let current_version = Current::default().semver();
+    let mut available =
+        get_versions(&client, registry, &current_version, &target_range).await?;
+    let Some((target_version, asset)) = available
+        .pop_last()
+        .and_then(|(v, mut info)| info.squashfs.remove(&**PLATFORM).map(|a| (v, a)))
+    else {
+        return Ok(UpdateSystemRes {
+            target: None,
+            progress: None,
+        });
+    };
+    if !target_version.satisfies(&target_range) {
+        return Err(Error::new(
+            eyre!("got back version from registry that does not satisfy {target_range}"),
+            ErrorKind::Registry,
+        ));
+    }
+    asset.validate(SIG_CONTEXT, asset.all_signers())?;
+
+    let tracker = FullProgressTracker::new();
+    let prune_phase = tracker.add_phase("Pruning Old OS Images".into(), Some(2));
+    let mut download_phase = tracker.add_phase("Downloading File".into(), Some(100));
+    download_phase.set_total(asset.commitment.size);
+    download_phase.set_units(Some(ProgressUnits::Bytes));
+    let reverify_phase = tracker.add_phase("Reverifying File".into(), Some(10));
+    let finalize_phase = tracker.add_phase("Finalizing Update".into(), Some(1));
+
+    let (done_tx, done_rx) = oneshot::channel();
+    let tracker_for_task = tracker.clone();
+    let ctx_for_task = ctx.clone();
+    tokio::spawn(async move {
+        let res = do_update(
+            client,
+            asset,
+            UpdateProgressHandles {
+                progress: tracker_for_task,
+                prune_phase,
+                download_phase,
+                reverify_phase,
+                finalize_phase,
+            },
+        )
+        .await;
+        if let Err(e) = &res {
+            tracing::error!("{}", t!("update.not-successful", error = e.to_string()));
+            tracing::debug!("{e:?}");
+        }
+        ctx_for_task.update_in_progress.mutate(|p| *p = false);
+        let _ = done_tx.send(res);
+    });
+
+    let progress = if report_progress {
+        let guid = Guid::new();
+        let tracker = tracker.clone();
+        ctx.rpc_continuations
+            .add(
+                guid.clone(),
+                RpcContinuation::ws(
+                    move |ws| async move {
+                        if let Err(e) = stream_progress(ws, tracker, done_rx).await {
+                            tracing::error!(
+                                "{}",
+                                t!("update.error-returning-progress", error = e.to_string())
+                            );
+                            tracing::debug!("{e:?}");
+                        }
+                    },
+                    Duration::from_secs(30),
+                ),
+            )
+            .await;
+        Some(guid)
+    } else {
+        None
+    };
+    Ok(UpdateSystemRes {
+        target: Some(target_version),
+        progress,
+    })
+}
+
+async fn stream_progress(
+    mut ws: crate::util::net::WebSocket,
+    tracker: FullProgressTracker,
+    mut done_rx: oneshot::Receiver<Result<(), Error>>,
+) -> Result<(), Error> {
+    use axum::extract::ws::Message;
+
+    let mut stream = tracker.stream(Some(Duration::from_millis(300)));
+    let result: Result<(), Error> = loop {
+        tokio::select! {
+            snap = stream.next() => {
+                let Some(snap) = snap else { break Ok(()); };
+                ws.send(Message::Text(
+                    serde_json::to_string(&Some(&snap))
+                        .with_kind(ErrorKind::Serialization)?
+                        .into(),
+                ))
+                .await
+                .with_kind(ErrorKind::Network)?;
+            }
+            res = &mut done_rx => {
+                break res.unwrap_or_else(|_| Err(Error::new(eyre!("update task aborted"), ErrorKind::Cancelled)));
+            }
+        }
+    };
+    let mut final_snap = tracker.snapshot();
+    if result.is_ok() {
+        for phase in &mut final_snap.phases {
+            phase.progress.set_complete();
+        }
+        final_snap.overall.set_complete();
+    }
+    ws.send(Message::Text(
+        serde_json::to_string(&Some(&final_snap))
+            .with_kind(ErrorKind::Serialization)?
+            .into(),
+    ))
+    .await
+    .with_kind(ErrorKind::Network)?;
+    ws.send(Message::Text(
+        serde_json::to_string::<Option<&FullProgress>>(&None)
+            .with_kind(ErrorKind::Serialization)?
+            .into(),
+    ))
+    .await
+    .with_kind(ErrorKind::Network)?;
+    let close_msg: Result<&str, String> = match &result {
+        Ok(()) => Ok("complete"),
+        Err(e) => Err(e.to_string()),
+    };
+    ws.close_result(close_msg).await.log_err();
+    result
+}
+
+async fn get_versions(
+    client: &Client,
+    mut registry: Url,
+    source: &Version,
+    target: &VersionRange,
+) -> Result<BTreeMap<Version, OsVersionInfo>, Error> {
+    registry
+        .path_segments_mut()
+        .map_err(|_| Error::new(eyre!("cannot extend URL path"), ErrorKind::ParseUrl))?
+        .push("rpc")
+        .push("v0");
+    let sig_context = registry.host_str().map(|s| s.to_string());
+    let ctx = UnsignedRegistry(client.clone());
+    let res = signature::call_remote(
+        &ctx,
+        registry,
+        HeaderMap::new(),
+        sig_context.as_deref(),
+        "os.version.get",
+        json!({
+            "sourceVersion": source,
+            "targetVersion": target,
+            "platform": &**PLATFORM,
+        }),
+    )
+    .await
+    .map_err(Error::from)?;
+    from_value::<BTreeMap<Version, OsVersionInfo>>(res)
+}
+
+pub async fn cli_update_system(
+    HandlerArgs {
+        context,
+        parent_method,
+        method,
+        raw_params,
+        ..
+    }: HandlerArgs<CliContext, UpdateSystemParams>,
+) -> Result<(), Error> {
+    let res = from_value::<UpdateSystemRes>(
+        context
+            .call_remote::<DiagnosticContext>(
+                &parent_method.into_iter().chain(method).join("."),
+                raw_params,
+            )
+            .await?,
+    )?;
+    match res.target {
+        None => println!("{}", t!("update.no-updates-available")),
+        Some(v) => {
+            if let Some(progress) = res.progress {
+                let mut ws = context.ws_continuation(progress).await?;
+                let mut bar = PhasedProgressBar::new(&t!(
+                    "update.updating-to-version",
+                    version = v.to_string()
+                ));
+                let mut prev = None;
+                while let Some(msg) = ws.try_next().await.with_kind(ErrorKind::Network)? {
+                    if let tokio_tungstenite::tungstenite::Message::Text(msg) = msg {
+                        if let Some(snap) = serde_json::from_str::<Option<FullProgress>>(&msg)
+                            .with_kind(ErrorKind::Deserialization)?
+                        {
+                            bar.update(&snap);
+                            prev = Some(snap);
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                if let Some(mut prev) = prev {
+                    for phase in &mut prev.phases {
+                        phase.progress.set_complete();
+                    }
+                    prev.overall.set_complete();
+                    bar.update(&prev);
+                }
+                println!("{}", t!("update.complete-restart-to-apply"))
+            } else {
+                println!(
+                    "{}",
+                    t!("update.updating-to-version", version = v.to_string())
+                )
+            }
+        }
+    }
+    Ok(())
+}

--- a/core/src/update/mod.rs
+++ b/core/src/update/mod.rs
@@ -10,12 +10,14 @@ use imbl::OrdMap;
 use imbl_value::json;
 use itertools::Itertools;
 use patch_db::json_ptr::JsonPointer;
-use reqwest::Url;
+use reqwest::{Client, Url};
 use rpc_toolkit::HandlerArgs;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::instrument;
 use ts_rs::TS;
+
+pub mod diagnostic;
 
 use crate::PLATFORM;
 use crate::context::{CliContext, RpcContext};
@@ -323,7 +325,7 @@ async fn maybe_do_update(
 
     tokio::spawn(async move {
         let res = do_update(
-            ctx.clone(),
+            ctx.client.clone(),
             asset,
             UpdateProgressHandles {
                 progress,
@@ -386,17 +388,17 @@ async fn maybe_do_update(
     Ok(Some(target_version))
 }
 
-struct UpdateProgressHandles {
-    progress: FullProgressTracker,
-    prune_phase: PhaseProgressTrackerHandle,
-    download_phase: PhaseProgressTrackerHandle,
-    reverify_phase: PhaseProgressTrackerHandle,
-    finalize_phase: PhaseProgressTrackerHandle,
+pub(crate) struct UpdateProgressHandles {
+    pub progress: FullProgressTracker,
+    pub prune_phase: PhaseProgressTrackerHandle,
+    pub download_phase: PhaseProgressTrackerHandle,
+    pub reverify_phase: PhaseProgressTrackerHandle,
+    pub finalize_phase: PhaseProgressTrackerHandle,
 }
 
 #[instrument(skip_all)]
-async fn do_update(
-    ctx: RpcContext,
+pub(crate) async fn do_update(
+    client: Client,
     asset: RegistryAsset<Blake3Commitment>,
     UpdateProgressHandles {
         progress,
@@ -420,9 +422,7 @@ async fn do_update(
     let path = Path::new("/media/startos/images/next.squashfs");
     let mut dst = AtomicFile::new(&path, None::<&Path>).await?;
     let mut download_writer = download_phase.writer(&mut *dst);
-    asset
-        .download(ctx.client.clone(), &mut download_writer)
-        .await?;
+    asset.download(client, &mut download_writer).await?;
     let (_, mut download_phase) = download_writer.into_inner();
     dst.sync_all().await?;
     download_phase.complete();

--- a/core/src/update/mod.rs
+++ b/core/src/update/mod.rs
@@ -251,8 +251,8 @@ async fn maybe_do_update(
             "os.version.get",
             OrdMap::new(),
             json!({
-                "source": current_version,
-                "target": target,
+                "sourceVersion": current_version,
+                "targetVersion": target,
             }),
             RegistryUrlParams { registry },
         )


### PR DESCRIPTION
## Summary

- Adds `diagnostic.update` RPC, mirroring `server.update`'s shape (`UpdateSystemParams` in, `UpdateSystemRes` out with a WS continuation guid for progress). Lets users recover from broken state without reinstalling.
- Refactors `do_update` to take `reqwest::Client` instead of `RpcContext` — it only ever used the client. The diagnostic path reuses it directly.
- Fixes a latent registry-call bug in `server.update`: `os.version.get` was sent `{source, target}` but the registry deserializes `{sourceVersion, targetVersion}` (camelCase). The normal flow only worked because the registry falls back to the `DeviceInfo` header. Diagnostic mode has no such fallback, so the field names had to be correct anyway — fixing it in both spots.

## Constraints in diagnostic mode

- **No patch-db**: progress streams from `FullProgressTracker.stream()` straight into the WS instead of mirroring to `/public/serverInfo/statusInfo/updateProgress`.
- **No signing key**: `os.version.get` goes out unsigned via a one-off `reqwest::Client` and an `UnsignedRegistry` shim around `signature::call_remote`. The endpoint is public.
- **No DeviceInfo header**: source/target/platform passed explicitly in the JSON params.
- **Single-flight**: `SyncMutex<bool>` on `DiagnosticContext` prevents concurrent updates; collisions error with `update.already-updating`.
- **No auto-restart**: caller invokes `diagnostic.restart` afterward, matching the rest of the diagnostic surface.

## Test plan

- [ ] `cargo check -p start-os` (passes locally)
- [ ] Boot into diagnostic mode, run `start-cli diagnostic update --registry <url>` against a registry with a newer version available — verify download/verify/apply works and progress streams to the CLI
- [ ] Verify `diagnostic.restart` after success boots into the new version
- [ ] Concurrent `diagnostic.update` call returns `update.already-updating` error
- [ ] Normal-mode `server.update` still works end-to-end (regression check on the registry call field rename)