### PR TITLE
fix(setup): deduplicate install-os calls via shared future

### DIFF
--- a/core/locales/i18n.yaml
+++ b/core/locales/i18n.yaml
@@ -1057,6 +1057,29 @@ disk.mount.binding:
   fr_FR: "Liaison de %{src} à %{dst}"
   pl_PL: "Wiązanie %{src} do %{dst}"
 
+# os_install/gpt.rs
+os-install.no-free-space-for-os-root:
+  en_US: "No free space left on device for OS root partition"
+  de_DE: "Kein freier Speicherplatz auf dem Gerät für die OS-Root-Partition"
+  es_ES: "No queda espacio libre en el dispositivo para la partición raíz del sistema operativo"
+  fr_FR: "Plus d'espace libre sur le périphérique pour la partition racine du système"
+  pl_PL: "Brak wolnego miejsca na urządzeniu dla partycji głównej systemu"
+
+os-install.protected-partition-overlaps-os-root-bytes:
+  en_US: "Protected partition %{path} starts at sector %{first_lba}, leaving only %{available_bytes} bytes for the OS root partition (minimum is %{min_bytes} bytes)"
+  de_DE: "Geschützte Partition %{path} beginnt bei Sektor %{first_lba} und lässt nur %{available_bytes} Bytes für die OS-Root-Partition übrig (Minimum ist %{min_bytes} Bytes)"
+  es_ES: "La partición protegida %{path} comienza en el sector %{first_lba}, dejando solo %{available_bytes} bytes para la partición raíz del sistema operativo (mínimo es %{min_bytes} bytes)"
+  fr_FR: "La partition protégée %{path} commence au secteur %{first_lba}, ne laissant que %{available_bytes} octets pour la partition racine du système (minimum %{min_bytes} octets)"
+  pl_PL: "Chroniona partycja %{path} zaczyna się w sektorze %{first_lba}, pozostawiając tylko %{available_bytes} bajtów na partycję główną systemu (minimum to %{min_bytes} bajtów)"
+
+# os_install/mbr.rs
+os-install.protected-partition-overlaps-os-root-sectors:
+  en_US: "Protected partition %{path} starts at sector %{first_lba}, leaving less than the minimum room for the OS root partition (must end at or before sector %{first_lba}, minimum end sector is %{min_end_sector})"
+  de_DE: "Geschützte Partition %{path} beginnt bei Sektor %{first_lba} und lässt weniger als den Mindestplatz für die OS-Root-Partition (muss am oder vor Sektor %{first_lba} enden, Mindest-Endsektor ist %{min_end_sector})"
+  es_ES: "La partición protegida %{path} comienza en el sector %{first_lba}, dejando menos del espacio mínimo para la partición raíz del sistema operativo (debe terminar en o antes del sector %{first_lba}, sector final mínimo es %{min_end_sector})"
+  fr_FR: "La partition protégée %{path} commence au secteur %{first_lba}, laissant moins que la place minimale pour la partition racine du système (doit se terminer au plus tard au secteur %{first_lba}, secteur de fin minimum %{min_end_sector})"
+  pl_PL: "Chroniona partycja %{path} zaczyna się w sektorze %{first_lba}, pozostawiając mniej niż minimalne miejsce na partycję główną systemu (musi kończyć się w sektorze %{first_lba} lub wcześniej, minimalny sektor końcowy to %{min_end_sector})"
+
 hostname.empty:
   en_US: "Hostname cannot be empty"
   de_DE: "Der Hostname darf nicht leer sein"

--- a/core/src/context/setup.rs
+++ b/core/src/context/setup.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::future::{BoxFuture, Shared};
 use futures::{Future, StreamExt};
 use imbl_value::InternedString;
 use josekit::jwk::Jwk;
@@ -25,7 +26,7 @@ use crate::net::web_server::{WebServer, WebServerAcceptorSetter};
 use crate::prelude::*;
 use crate::progress::FullProgressTracker;
 use crate::rpc_continuations::{Guid, RpcContinuation, RpcContinuations};
-use crate::setup::SetupProgress;
+use crate::setup::{SetupInfo, SetupProgress};
 use crate::shutdown::Shutdown;
 use crate::system::KeyboardOptions;
 use crate::util::future::NonDetachingJoinHandle;
@@ -61,6 +62,8 @@ pub struct SetupContextSeed {
     pub shutdown: Sender<Option<Shutdown>>,
     pub rpc_continuations: RpcContinuations,
     pub install_rootfs: SyncMutex<Option<(TmpMountGuard, MountGuard)>>,
+    pub install_os_future:
+        SyncMutex<Option<Shared<BoxFuture<'static, Result<SetupInfo, Arc<Error>>>>>>,
     pub keyboard: SyncMutex<Option<KeyboardOptions>>,
     pub language: SyncMutex<Option<InternedString>>,
 }
@@ -87,6 +90,7 @@ impl SetupContext {
             shutdown,
             rpc_continuations: RpcContinuations::new(),
             install_rootfs: SyncMutex::new(None),
+            install_os_future: SyncMutex::new(None),
             language: SyncMutex::new(None),
             keyboard: SyncMutex::new(None),
         })))

--- a/core/src/os_install/gpt.rs
+++ b/core/src/os_install/gpt.rs
@@ -2,12 +2,18 @@ use std::path::{Path, PathBuf};
 
 use gpt::GptConfig;
 use gpt::disk::LogicalBlockSize;
-use tokio::process::Command;
 
 use crate::disk::OsPartitionInfo;
 use crate::os_install::partition_for;
+use crate::os_install::quiesce::{quiesce_disk, update_partition_table};
 use crate::prelude::*;
-use crate::util::Invoke;
+
+/// Target size for the OS root (rootfs) partition. We try to allocate this much.
+const ROOT_TARGET_BYTES: u64 = 14 * 1024 * 1024 * 1024;
+/// Minimum size we will accept for the OS root partition before erroring out. If a
+/// protected data partition's `first_lba` sits inside the planned root region we will
+/// shrink root down to (but not below) this floor.
+const ROOT_MIN_BYTES: u64 = 12 * 1024 * 1024 * 1024;
 
 pub async fn partition(
     disk_path: &Path,
@@ -27,6 +33,11 @@ pub async fn partition(
             ));
         }
     }
+
+    // Drop every kernel-side reference to partitions on this disk before rewriting the
+    // table. Quiesce is best-effort; partx --update afterwards is what actually makes
+    // the kernel see the new layout, and it tolerates a still-busy protected partition.
+    quiesce_disk(disk_path).await?;
 
     let disk_path = disk_path.to_owned();
     let disk_path_clone = disk_path.clone();
@@ -100,9 +111,56 @@ pub async fn partition(
             0,
             None,
         )?;
+
+        // Compute the root size, shrinking it within [ROOT_MIN_BYTES, ROOT_TARGET_BYTES]
+        // when a protected partition's `first_lba` would otherwise be overwritten. This
+        // tolerates a few MiB of geometry drift on legacy hardware where the protected
+        // partition isn't quite aligned the way the gpt crate would lay it out today.
+        let lb_size: u64 = (*gpt.logical_block_size()).into();
+        let target_root_lba = ROOT_TARGET_BYTES.div_ceil(lb_size);
+        let min_root_lba = ROOT_MIN_BYTES.div_ceil(lb_size);
+        let root_size_bytes = if let Some((protect_first_lba, _, ref path)) =
+            protected_partition_info
+        {
+            // The next add_partition() will pick the lowest free block that fits, so the
+            // earliest free LBA is where root would land. Find it, and clamp root's
+            // length so it ends strictly before the protected partition.
+            let earliest_free_start = gpt
+                .find_free_sectors()
+                .into_iter()
+                .filter(|(start, _)| *start < protect_first_lba)
+                .map(|(start, _)| start)
+                .min()
+                .ok_or_else(|| {
+                    Error::new(
+                        eyre!("No free space left on device for OS root partition"),
+                        crate::ErrorKind::BlockDevice,
+                    )
+                })?;
+            let available_lba = protect_first_lba.saturating_sub(earliest_free_start);
+            if available_lba < min_root_lba {
+                let available_bytes = available_lba.saturating_mul(lb_size);
+                return Err(Error::new(
+                    eyre!(
+                        concat!(
+                            "Protected partition {} starts at sector {}, leaving only ",
+                            "{} bytes for the OS root partition (minimum is {} bytes)"
+                        ),
+                        path.display(),
+                        protect_first_lba,
+                        available_bytes,
+                        ROOT_MIN_BYTES
+                    ),
+                    crate::ErrorKind::DiskManagement,
+                ));
+            }
+            available_lba.min(target_root_lba).saturating_mul(lb_size)
+        } else {
+            ROOT_TARGET_BYTES
+        };
         gpt.add_partition(
             "root",
-            14 * 1024 * 1024 * 1024,
+            root_size_bytes,
             match crate::ARCH {
                 "x86_64" => gpt::partition_types::LINUX_ROOT_X64,
                 "aarch64" => gpt::partition_types::LINUX_ROOT_ARM_64,
@@ -111,27 +169,6 @@ pub async fn partition(
             0,
             None,
         )?;
-
-        // Check if protected partition would be overwritten by OS partitions
-        if let Some((first_lba, _, ref path)) = protected_partition_info {
-            // Get the actual end sector of the last OS partition (root = partition 3)
-            let os_partitions_end_sector =
-                gpt.partitions().get(&3).map(|p| p.last_lba).unwrap_or(0);
-            if first_lba <= os_partitions_end_sector {
-                return Err(Error::new(
-                    eyre!(
-                        concat!(
-                            "Protected partition {} starts at sector {}",
-                            " which would be overwritten by OS partitions ending at sector {}"
-                        ),
-                        path.display(),
-                        first_lba,
-                        os_partitions_end_sector
-                    ),
-                    crate::ErrorKind::DiskManagement,
-                ));
-            }
-        }
 
         let data_part = if let Some((first_lba, last_lba, path)) = protected_partition_info {
             // Re-create the data partition entry at the same location
@@ -175,48 +212,11 @@ pub async fn partition(
     .await
     .unwrap()?;
 
-    // Re-read partition table and wait for udev to create device nodes
-    Command::new("vgchange")
-        .arg("-an")
-        .invoke(crate::ErrorKind::DiskManagement)
-        .await
-        .ok();
-    Command::new("dmsetup")
-        .arg("remove_all")
-        .arg("--force")
-        .invoke(crate::ErrorKind::DiskManagement)
-        .await
-        .ok();
-    // BLKRRPART can fail with "Device or resource busy" if the kernel still
-    // holds references to old partitions.  Retry a few times with a delay.
-    let mut last_err = None;
-    for attempt in 0..5u32 {
-        if attempt > 0 {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        }
-        match Command::new("blockdev")
-            .arg("--rereadpt")
-            .arg(&disk_path)
-            .invoke(crate::ErrorKind::DiskManagement)
-            .await
-        {
-            Ok(_) => {
-                last_err = None;
-                break;
-            }
-            Err(e) => {
-                tracing::warn!("blockdev --rereadpt attempt {} failed: {e}", attempt + 1);
-                last_err = Some(e);
-            }
-        }
-    }
-    if let Some(e) = last_err {
-        return Err(e);
-    }
-    Command::new("udevadm")
-        .arg("settle")
-        .invoke(crate::ErrorKind::DiskManagement)
-        .await?;
+    // Make the kernel see the new layout via per-entry BLKPG ioctls. This works even
+    // when a protected partition on this disk is still claimed by something we
+    // couldn't tear down in quiesce_disk, because partx updates entries individually
+    // rather than asking the kernel to re-read the whole table.
+    update_partition_table(&disk_path).await?;
 
     let mut extra_boot = std::collections::BTreeMap::new();
     let bios;

--- a/core/src/os_install/gpt.rs
+++ b/core/src/os_install/gpt.rs
@@ -145,7 +145,7 @@ pub async fn partition(
                 .min()
                 .ok_or_else(|| {
                     Error::new(
-                        eyre!("No free space left on device for OS root partition"),
+                        eyre!("{}", t!("os-install.no-free-space-for-os-root")),
                         crate::ErrorKind::BlockDevice,
                     )
                 })?;
@@ -155,14 +155,14 @@ pub async fn partition(
                 let available_bytes = available_lba.saturating_mul(lb_size);
                 return Err(Error::new(
                     eyre!(
-                        concat!(
-                            "Protected partition {} starts at sector {}, leaving only ",
-                            "{} bytes for the OS root partition (minimum is {} bytes)"
-                        ),
-                        path.display(),
-                        protect_first_lba,
-                        available_bytes,
-                        ROOT_MIN_BYTES
+                        "{}",
+                        t!(
+                            "os-install.protected-partition-overlaps-os-root-bytes",
+                            path = path.display(),
+                            first_lba = protect_first_lba,
+                            available_bytes = available_bytes,
+                            min_bytes = ROOT_MIN_BYTES,
+                        )
                     ),
                     crate::ErrorKind::DiskManagement,
                 ));

--- a/core/src/os_install/gpt.rs
+++ b/core/src/os_install/gpt.rs
@@ -14,6 +14,10 @@ const ROOT_TARGET_BYTES: u64 = 14 * 1024 * 1024 * 1024;
 /// protected data partition's `first_lba` sits inside the planned root region we will
 /// shrink root down to (but not below) this floor.
 const ROOT_MIN_BYTES: u64 = 12 * 1024 * 1024 * 1024;
+/// Sector alignment for OS partitions. 2048 sectors at 512 bytes per sector = 1 MiB,
+/// which matches what util-linux fdisk/gdisk default to and what SSDs/NVMe expect for
+/// efficient writes.
+const PARTITION_ALIGNMENT_LBA: u64 = 2048;
 
 pub async fn partition(
     disk_path: &Path,
@@ -92,7 +96,13 @@ pub async fn partition(
         gpt.update_partitions(Default::default())?;
 
         let efi = if use_efi {
-            gpt.add_partition("efi", 100 * 1024 * 1024, gpt::partition_types::EFI, 0, None)?;
+            gpt.add_partition(
+                "efi",
+                100 * 1024 * 1024,
+                gpt::partition_types::EFI,
+                0,
+                Some(PARTITION_ALIGNMENT_LBA),
+            )?;
             true
         } else {
             gpt.add_partition(
@@ -100,7 +110,7 @@ pub async fn partition(
                 8 * 1024 * 1024,
                 gpt::partition_types::BIOS,
                 0,
-                None,
+                Some(PARTITION_ALIGNMENT_LBA),
             )?;
             false
         };
@@ -109,7 +119,7 @@ pub async fn partition(
             2 * 1024 * 1024 * 1024,
             gpt::partition_types::LINUX_FS,
             0,
-            None,
+            Some(PARTITION_ALIGNMENT_LBA),
         )?;
 
         // Compute the root size, shrinking it within [ROOT_MIN_BYTES, ROOT_TARGET_BYTES]
@@ -123,8 +133,10 @@ pub async fn partition(
             protected_partition_info
         {
             // The next add_partition() will pick the lowest free block that fits, so the
-            // earliest free LBA is where root would land. Find it, and clamp root's
-            // length so it ends strictly before the protected partition.
+            // earliest free LBA is where root would land. Find it, then bump it up to
+            // the next 2048-sector alignment boundary (which is what add_partition will
+            // do internally) before computing how much room is left before the
+            // protected partition.
             let earliest_free_start = gpt
                 .find_free_sectors()
                 .into_iter()
@@ -137,7 +149,8 @@ pub async fn partition(
                         crate::ErrorKind::BlockDevice,
                     )
                 })?;
-            let available_lba = protect_first_lba.saturating_sub(earliest_free_start);
+            let aligned_start = earliest_free_start.next_multiple_of(PARTITION_ALIGNMENT_LBA);
+            let available_lba = protect_first_lba.saturating_sub(aligned_start);
             if available_lba < min_root_lba {
                 let available_bytes = available_lba.saturating_mul(lb_size);
                 return Err(Error::new(
@@ -167,7 +180,7 @@ pub async fn partition(
                 _ => gpt::partition_types::LINUX_FS,
             },
             0,
-            None,
+            Some(PARTITION_ALIGNMENT_LBA),
         )?;
 
         let data_part = if let Some((first_lba, last_lba, path)) = protected_partition_info {
@@ -184,21 +197,33 @@ pub async fn partition(
             )?;
             Some(path)
         } else {
+            // Pick the largest free block and ask for the post-alignment size, so that
+            // add_partition's `length >= alignment_offset + size_lba` check passes even
+            // when the block's start isn't already 2048-aligned.
+            let lb_size_bytes: u64 = (*gpt.logical_block_size()).into();
+            let data_size_bytes = gpt
+                .find_free_sectors()
+                .iter()
+                .map(|(start, length_lba)| {
+                    let alignment_offset =
+                        (PARTITION_ALIGNMENT_LBA - (start % PARTITION_ALIGNMENT_LBA))
+                            % PARTITION_ALIGNMENT_LBA;
+                    length_lba.saturating_sub(alignment_offset) * lb_size_bytes
+                })
+                .max()
+                .filter(|s| *s > 0)
+                .ok_or_else(|| {
+                    Error::new(
+                        eyre!("No free space left on device"),
+                        crate::ErrorKind::BlockDevice,
+                    )
+                })?;
             gpt.add_partition(
                 "data",
-                gpt.find_free_sectors()
-                    .iter()
-                    .map(|(_, size)| *size * u64::from(*gpt.logical_block_size()))
-                    .max()
-                    .ok_or_else(|| {
-                        Error::new(
-                            eyre!("No free space left on device"),
-                            crate::ErrorKind::BlockDevice,
-                        )
-                    })?,
+                data_size_bytes,
                 gpt::partition_types::LINUX_LVM,
                 0,
-                None,
+                Some(PARTITION_ALIGNMENT_LBA),
             )?;
             gpt.partitions()
                 .last_key_value()

--- a/core/src/os_install/gpt.rs
+++ b/core/src/os_install/gpt.rs
@@ -8,15 +8,10 @@ use crate::os_install::partition_for;
 use crate::os_install::quiesce::{quiesce_disk, update_partition_table};
 use crate::prelude::*;
 
-/// Target size for the OS root (rootfs) partition. We try to allocate this much.
 const ROOT_TARGET_BYTES: u64 = 14 * 1024 * 1024 * 1024;
-/// Minimum size we will accept for the OS root partition before erroring out. If a
-/// protected data partition's `first_lba` sits inside the planned root region we will
-/// shrink root down to (but not below) this floor.
+/// Floor for elastic-root shrink when a protected partition is in the way.
 const ROOT_MIN_BYTES: u64 = 12 * 1024 * 1024 * 1024;
-/// Sector alignment for OS partitions. 2048 sectors at 512 bytes per sector = 1 MiB,
-/// which matches what util-linux fdisk/gdisk default to and what SSDs/NVMe expect for
-/// efficient writes.
+/// 1 MiB at 512-byte sectors.
 const PARTITION_ALIGNMENT_LBA: u64 = 2048;
 
 pub async fn partition(
@@ -38,9 +33,6 @@ pub async fn partition(
         }
     }
 
-    // Drop every kernel-side reference to partitions on this disk before rewriting the
-    // table. Quiesce is best-effort; partx --update afterwards is what actually makes
-    // the kernel see the new layout, and it tolerates a still-busy protected partition.
     quiesce_disk(disk_path).await?;
 
     let disk_path = disk_path.to_owned();
@@ -122,21 +114,14 @@ pub async fn partition(
             Some(PARTITION_ALIGNMENT_LBA),
         )?;
 
-        // Compute the root size, shrinking it within [ROOT_MIN_BYTES, ROOT_TARGET_BYTES]
-        // when a protected partition's `first_lba` would otherwise be overwritten. This
-        // tolerates a few MiB of geometry drift on legacy hardware where the protected
-        // partition isn't quite aligned the way the gpt crate would lay it out today.
+        // Elastic root: shrink within [ROOT_MIN_BYTES, ROOT_TARGET_BYTES] if a
+        // protected partition's first_lba sits inside the planned root region.
         let lb_size: u64 = (*gpt.logical_block_size()).into();
         let target_root_lba = ROOT_TARGET_BYTES.div_ceil(lb_size);
         let min_root_lba = ROOT_MIN_BYTES.div_ceil(lb_size);
         let root_size_bytes = if let Some((protect_first_lba, _, ref path)) =
             protected_partition_info
         {
-            // The next add_partition() will pick the lowest free block that fits, so the
-            // earliest free LBA is where root would land. Find it, then bump it up to
-            // the next 2048-sector alignment boundary (which is what add_partition will
-            // do internally) before computing how much room is left before the
-            // protected partition.
             let earliest_free_start = gpt
                 .find_free_sectors()
                 .into_iter()
@@ -197,9 +182,8 @@ pub async fn partition(
             )?;
             Some(path)
         } else {
-            // Pick the largest free block and ask for the post-alignment size, so that
-            // add_partition's `length >= alignment_offset + size_lba` check passes even
-            // when the block's start isn't already 2048-aligned.
+            // Account for alignment offset so add_partition's length check passes
+            // when the largest free block isn't already 2048-aligned.
             let lb_size_bytes: u64 = (*gpt.logical_block_size()).into();
             let data_size_bytes = gpt
                 .find_free_sectors()
@@ -237,10 +221,6 @@ pub async fn partition(
     .await
     .unwrap()?;
 
-    // Make the kernel see the new layout via per-entry BLKPG ioctls. This works even
-    // when a protected partition on this disk is still claimed by something we
-    // couldn't tear down in quiesce_disk, because partx updates entries individually
-    // rather than asking the kernel to re-read the whole table.
     update_partition_table(&disk_path).await?;
 
     let mut extra_boot = std::collections::BTreeMap::new();

--- a/core/src/os_install/mbr.rs
+++ b/core/src/os_install/mbr.rs
@@ -8,15 +8,11 @@ use crate::os_install::partition_for;
 use crate::os_install::quiesce::{quiesce_disk, update_partition_table};
 use crate::prelude::*;
 
-/// Boot partition starts at sector 2048 and ends at this sector (exclusive).
-/// 2 GiB at 512-byte sectors.
+/// Boot end (exclusive). 2 GiB at 512-byte sectors.
 const BOOT_END_SECTOR: u32 = 4196352;
-/// Target end sector for the OS root partition (i.e. start of the data region in the
-/// happy path). 14 GiB of root + 2 GiB of boot.
+/// Happy-path root end. 14 GiB of root after boot.
 const ROOT_TARGET_END_SECTOR: u32 = 33556480;
-/// Minimum acceptable end sector for the OS root partition. We let the protected
-/// partition push root's end up to this floor, but no further. 12 GiB at 512-byte
-/// sectors = 25_165_824 sectors of root.
+/// Floor for elastic-root shrink. 12 GiB of root after boot.
 const ROOT_MIN_END_SECTOR: u32 = BOOT_END_SECTOR + 12 * 1024 * 1024 * 2;
 
 pub async fn partition(
@@ -37,9 +33,6 @@ pub async fn partition(
         }
     }
 
-    // Drop every kernel-side reference to partitions on this disk before rewriting the
-    // table. partx --update afterwards is what actually makes the kernel see the new
-    // layout, and it tolerates a still-busy protected partition.
     quiesce_disk(disk_path).await?;
 
     let disk_path = disk_path.to_owned();
@@ -80,13 +73,9 @@ pub async fn partition(
                 None
             };
 
-        // MBR partition layout:
-        // Partition 1 (boot): starts at 2048, ends at BOOT_END_SECTOR (2 GiB)
-        // Partition 2 (root): starts at BOOT_END_SECTOR, ends at root_end_sector
-        //
-        // root_end_sector defaults to ROOT_TARGET_END_SECTOR (14 GiB of root) but may
-        // shrink to as low as ROOT_MIN_END_SECTOR if a protected partition sits in the
-        // way. Below the floor we error out.
+        // Layout: boot 2048..BOOT_END_SECTOR, root BOOT_END_SECTOR..root_end_sector,
+        // data root_end_sector..end. root shrinks toward ROOT_MIN_END_SECTOR if a
+        // protected partition sits in the way.
         let root_end_sector: u32 = if let Some((starting_lba, _, ref path)) =
             protected_partition_info
         {
@@ -161,8 +150,6 @@ pub async fn partition(
     .await
     .unwrap()?;
 
-    // Make the kernel see the new layout via per-entry BLKPG ioctls instead of
-    // BLKRRPART, so a still-busy protected partition doesn't block the update.
     update_partition_table(&disk_path).await?;
 
     Ok(OsPartitionInfo {

--- a/core/src/os_install/mbr.rs
+++ b/core/src/os_install/mbr.rs
@@ -2,12 +2,22 @@ use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::eyre;
 use mbrman::{CHS, MBR, MBRPartitionEntry};
-use tokio::process::Command;
 
 use crate::disk::OsPartitionInfo;
 use crate::os_install::partition_for;
+use crate::os_install::quiesce::{quiesce_disk, update_partition_table};
 use crate::prelude::*;
-use crate::util::Invoke;
+
+/// Boot partition starts at sector 2048 and ends at this sector (exclusive).
+/// 2 GiB at 512-byte sectors.
+const BOOT_END_SECTOR: u32 = 4196352;
+/// Target end sector for the OS root partition (i.e. start of the data region in the
+/// happy path). 14 GiB of root + 2 GiB of boot.
+const ROOT_TARGET_END_SECTOR: u32 = 33556480;
+/// Minimum acceptable end sector for the OS root partition. We let the protected
+/// partition push root's end up to this floor, but no further. 12 GiB at 512-byte
+/// sectors = 25_165_824 sectors of root.
+const ROOT_MIN_END_SECTOR: u32 = BOOT_END_SECTOR + 12 * 1024 * 1024 * 2;
 
 pub async fn partition(
     disk_path: &Path,
@@ -26,6 +36,11 @@ pub async fn partition(
             ));
         }
     }
+
+    // Drop every kernel-side reference to partitions on this disk before rewriting the
+    // table. partx --update afterwards is what actually makes the kernel see the new
+    // layout, and it tolerates a still-busy protected partition.
+    quiesce_disk(disk_path).await?;
 
     let disk_path = disk_path.to_owned();
     let disk_path_clone = disk_path.clone();
@@ -66,28 +81,35 @@ pub async fn partition(
             };
 
         // MBR partition layout:
-        // Partition 1 (boot): starts at 2048, ends at 4196352 (sectors: 4194304 = 2GB)
-        // Partition 2 (root): starts at 4196352, ends at 33556480 (sectors: 29360128 = 14GB)
-        // OS partitions end at sector 33556480
-        let os_partitions_end_sector: u32 = 33556480;
-
-        // Check if protected partition would be overwritten
-        if let Some((starting_lba, _, ref path)) = protected_partition_info {
-            if starting_lba < os_partitions_end_sector {
+        // Partition 1 (boot): starts at 2048, ends at BOOT_END_SECTOR (2 GiB)
+        // Partition 2 (root): starts at BOOT_END_SECTOR, ends at root_end_sector
+        //
+        // root_end_sector defaults to ROOT_TARGET_END_SECTOR (14 GiB of root) but may
+        // shrink to as low as ROOT_MIN_END_SECTOR if a protected partition sits in the
+        // way. Below the floor we error out.
+        let root_end_sector: u32 = if let Some((starting_lba, _, ref path)) =
+            protected_partition_info
+        {
+            if starting_lba < ROOT_MIN_END_SECTOR {
                 return Err(Error::new(
                     eyre!(
                         concat!(
-                            "Protected partition {} starts at sector {}",
-                            " which would be overwritten by OS partitions ending at sector {}"
+                            "Protected partition {} starts at sector {}, leaving less ",
+                            "than the minimum room for the OS root partition (must end ",
+                            "at or before sector {}, minimum is sector {})"
                         ),
                         path.display(),
                         starting_lba,
-                        os_partitions_end_sector
+                        starting_lba,
+                        ROOT_MIN_END_SECTOR
                     ),
                     crate::ErrorKind::DiskManagement,
                 ));
             }
-        }
+            std::cmp::min(starting_lba, ROOT_TARGET_END_SECTOR)
+        } else {
+            ROOT_TARGET_END_SECTOR
+        };
 
         let mut file = std::fs::File::options()
             .read(true)
@@ -101,15 +123,15 @@ pub async fn partition(
             sys: 0x0b,
             last_chs: CHS::empty(),
             starting_lba: 2048,
-            sectors: 4196352 - 2048,
+            sectors: BOOT_END_SECTOR - 2048,
         };
         mbr[2] = MBRPartitionEntry {
             boot: 0,
             first_chs: CHS::empty(),
             sys: 0x83,
             last_chs: CHS::empty(),
-            starting_lba: 4196352,
-            sectors: 33556480 - 4196352,
+            starting_lba: BOOT_END_SECTOR,
+            sectors: root_end_sector - BOOT_END_SECTOR,
         };
 
         let data_part = if let Some((starting_lba, part_sectors, path)) = protected_partition_info {
@@ -129,8 +151,8 @@ pub async fn partition(
                 first_chs: CHS::empty(),
                 sys: 0x8e,
                 last_chs: CHS::empty(),
-                starting_lba: 33556480,
-                sectors: sectors - 33556480,
+                starting_lba: root_end_sector,
+                sectors: sectors - root_end_sector,
             };
             Some(partition_for(&disk_path, 3))
         };
@@ -141,48 +163,9 @@ pub async fn partition(
     .await
     .unwrap()?;
 
-    // Re-read partition table and wait for udev to create device nodes
-    Command::new("vgchange")
-        .arg("-an")
-        .invoke(crate::ErrorKind::DiskManagement)
-        .await
-        .ok();
-    Command::new("dmsetup")
-        .arg("remove_all")
-        .arg("--force")
-        .invoke(crate::ErrorKind::DiskManagement)
-        .await
-        .ok();
-    // BLKRRPART can fail with "Device or resource busy" if the kernel still
-    // holds references to old partitions.  Retry a few times with a delay.
-    let mut last_err = None;
-    for attempt in 0..5u32 {
-        if attempt > 0 {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        }
-        match Command::new("blockdev")
-            .arg("--rereadpt")
-            .arg(&disk_path)
-            .invoke(crate::ErrorKind::DiskManagement)
-            .await
-        {
-            Ok(_) => {
-                last_err = None;
-                break;
-            }
-            Err(e) => {
-                tracing::warn!("blockdev --rereadpt attempt {} failed: {e}", attempt + 1);
-                last_err = Some(e);
-            }
-        }
-    }
-    if let Some(e) = last_err {
-        return Err(e);
-    }
-    Command::new("udevadm")
-        .arg("settle")
-        .invoke(crate::ErrorKind::DiskManagement)
-        .await?;
+    // Make the kernel see the new layout via per-entry BLKPG ioctls instead of
+    // BLKRRPART, so a still-busy protected partition doesn't block the update.
+    update_partition_table(&disk_path).await?;
 
     Ok(OsPartitionInfo {
         bios: None,

--- a/core/src/os_install/mbr.rs
+++ b/core/src/os_install/mbr.rs
@@ -93,15 +93,13 @@ pub async fn partition(
             if starting_lba < ROOT_MIN_END_SECTOR {
                 return Err(Error::new(
                     eyre!(
-                        concat!(
-                            "Protected partition {} starts at sector {}, leaving less ",
-                            "than the minimum room for the OS root partition (must end ",
-                            "at or before sector {}, minimum is sector {})"
-                        ),
-                        path.display(),
-                        starting_lba,
-                        starting_lba,
-                        ROOT_MIN_END_SECTOR
+                        "{}",
+                        t!(
+                            "os-install.protected-partition-overlaps-os-root-sectors",
+                            path = path.display(),
+                            first_lba = starting_lba,
+                            min_end_sector = ROOT_MIN_END_SECTOR,
+                        )
                     ),
                     crate::ErrorKind::DiskManagement,
                 ));

--- a/core/src/os_install/mod.rs
+++ b/core/src/os_install/mod.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use clap::Parser;
 use color_eyre::eyre::eyre;
+use futures::FutureExt;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use ts_rs::TS;
@@ -418,6 +420,29 @@ pub async fn install_os_to(
 }
 
 pub async fn install_os(
+    ctx: SetupContext,
+    params: InstallOsParams,
+) -> Result<SetupInfo, Error> {
+    let fut = ctx.install_os_future.mutate(|slot| {
+        if let Some(existing) = slot.as_ref() {
+            if existing.peek().is_none() {
+                return existing.clone();
+            }
+        }
+        let ctx = ctx.clone();
+        let new_fut = async move { install_os_inner(ctx, params).await.map_err(Arc::new) }
+            .boxed()
+            .shared();
+        // Drive the future even if all RPC callers drop their await
+        // (e.g. browser HTTP timeout aborts the request).
+        tokio::spawn(new_fut.clone());
+        *slot = Some(new_fut.clone());
+        new_fut
+    });
+    fut.await.map_err(|e| e.clone_output())
+}
+
+async fn install_os_inner(
     ctx: SetupContext,
     InstallOsParams {
         os_drive,

--- a/core/src/os_install/mod.rs
+++ b/core/src/os_install/mod.rs
@@ -23,6 +23,7 @@ use crate::prelude::*;
 use crate::s9pk::merkle_archive::source::multi_cursor_file::MultiCursorFile;
 use crate::setup::SetupInfo;
 use crate::util::Invoke;
+use crate::util::future::NonDetachingJoinHandle;
 use crate::util::io::{TmpDir, delete_dir, delete_file, open_file, write_file_atomic};
 use crate::util::serde::IoFormat;
 
@@ -430,13 +431,30 @@ pub async fn install_os(
                 return existing.clone();
             }
         }
+        // Spawn the install on its own task so it makes progress even when no
+        // caller is awaiting (e.g. browser HTTP timeout dropped the RPC). Wrap
+        // the JoinHandle in a NonDetachingJoinHandle so the task is aborted
+        // when the last reference to the Shared future drops -- this makes the
+        // "no leaked installs" property correct-by-construction: while the
+        // SetupContext slot holds a clone of the Shared, the handle (and thus
+        // the task) is alive; once the slot is cleared and any in-flight
+        // awaiters drop, the handle drops with them and aborts the task.
         let ctx = ctx.clone();
-        let new_fut = async move { install_os_inner(ctx, params).await.map_err(Arc::new) }
-            .boxed()
-            .shared();
-        // Drive the future even if all RPC callers drop their await
-        // (e.g. browser HTTP timeout aborts the request).
-        tokio::spawn(new_fut.clone());
+        let handle: NonDetachingJoinHandle<Result<SetupInfo, Arc<Error>>> = tokio::spawn(
+            async move { install_os_inner(ctx, params).await.map_err(Arc::new) },
+        )
+        .into();
+        let new_fut = async move {
+            match handle.await {
+                Ok(res) => res,
+                Err(join_err) => Err(Arc::new(Error::new(
+                    eyre!("install_os task did not complete: {join_err}"),
+                    ErrorKind::Unknown,
+                ))),
+            }
+        }
+        .boxed()
+        .shared();
         *slot = Some(new_fut.clone());
         new_fut
     });

--- a/core/src/os_install/mod.rs
+++ b/core/src/os_install/mod.rs
@@ -28,6 +28,7 @@ use crate::util::serde::IoFormat;
 
 mod gpt;
 mod mbr;
+mod quiesce;
 
 /// Probe a squashfs image to determine its target architecture
 async fn probe_squashfs_arch(squashfs_path: &Path) -> Result<InternedString, Error> {

--- a/core/src/os_install/mod.rs
+++ b/core/src/os_install/mod.rs
@@ -431,14 +431,8 @@ pub async fn install_os(
                 return existing.clone();
             }
         }
-        // Spawn the install on its own task so it makes progress even when no
-        // caller is awaiting (e.g. browser HTTP timeout dropped the RPC). Wrap
-        // the JoinHandle in a NonDetachingJoinHandle so the task is aborted
-        // when the last reference to the Shared future drops -- this makes the
-        // "no leaked installs" property correct-by-construction: while the
-        // SetupContext slot holds a clone of the Shared, the handle (and thus
-        // the task) is alive; once the slot is cleared and any in-flight
-        // awaiters drop, the handle drops with them and aborts the task.
+        // Own the task via NonDetachingJoinHandle inside the Shared so it survives
+        // dropped awaiters but is aborted when the last reference goes away.
         let ctx = ctx.clone();
         let handle: NonDetachingJoinHandle<Result<SetupInfo, Arc<Error>>> = tokio::spawn(
             async move { install_os_inner(ctx, params).await.map_err(Arc::new) },
@@ -468,11 +462,8 @@ async fn install_os_inner(
         data_drive,
     }: InstallOsParams,
 ) -> Result<SetupInfo, Error> {
-    // If a previous install attempt left mounts pinned in `ctx.install_rootfs` (e.g.
-    // a successful run whose result was lost to a browser HTTP timeout, prompting the
-    // wizard to invoke install_os again), tear them down before re-entering the
-    // partition/mkfs/mount path. Otherwise the live rootfs/config bind would keep the
-    // target partition busy and the new install would race against itself.
+    // Drop any rootfs/config mounts a prior install left pinned, so a retry
+    // doesn't fight itself for the target partition.
     let prior = ctx.install_rootfs.mutate(|s| s.take());
     if let Some((rootfs, config)) = prior {
         if let Err(e) = config.unmount(false).await {

--- a/core/src/os_install/mod.rs
+++ b/core/src/os_install/mod.rs
@@ -449,6 +449,21 @@ async fn install_os_inner(
         data_drive,
     }: InstallOsParams,
 ) -> Result<SetupInfo, Error> {
+    // If a previous install attempt left mounts pinned in `ctx.install_rootfs` (e.g.
+    // a successful run whose result was lost to a browser HTTP timeout, prompting the
+    // wizard to invoke install_os again), tear them down before re-entering the
+    // partition/mkfs/mount path. Otherwise the live rootfs/config bind would keep the
+    // target partition busy and the new install would race against itself.
+    let prior = ctx.install_rootfs.mutate(|s| s.take());
+    if let Some((rootfs, config)) = prior {
+        if let Err(e) = config.unmount(false).await {
+            tracing::warn!("failed to unmount stale install config bind: {e}");
+        }
+        if let Err(e) = rootfs.unmount().await {
+            tracing::warn!("failed to unmount stale install rootfs: {e}");
+        }
+    }
+
     let mut disks = crate::disk::util::list(&Default::default()).await?;
     let disk = disks
         .iter_mut()

--- a/core/src/os_install/quiesce.rs
+++ b/core/src/os_install/quiesce.rs
@@ -1,0 +1,159 @@
+use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::eyre;
+use tokio::process::Command;
+
+use crate::prelude::*;
+use crate::util::Invoke;
+
+/// List `/dev/<part>` paths for every partition currently exposed on `disk_path`.
+///
+/// Walks `/sys/block/<disk>/` and picks entries that have a `partition` attribute file
+/// (the kernel's marker for "this is a partition of the parent block device").
+pub async fn list_partitions(disk_path: &Path) -> Result<Vec<PathBuf>, Error> {
+    let disk_name = disk_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| {
+            Error::new(
+                eyre!("invalid disk path: {}", disk_path.display()),
+                ErrorKind::BlockDevice,
+            )
+        })?;
+    let sys_block = Path::new("/sys/block").join(disk_name);
+    let mut out = Vec::new();
+    let mut entries = match tokio::fs::read_dir(&sys_block).await {
+        Ok(e) => e,
+        Err(_) => return Ok(out),
+    };
+    while let Some(entry) = entries.next_entry().await.map_err(|e| {
+        Error::new(
+            eyre!("reading {}: {e}", sys_block.display()),
+            ErrorKind::Filesystem,
+        )
+    })? {
+        if tokio::fs::metadata(entry.path().join("partition"))
+            .await
+            .is_ok()
+        {
+            out.push(Path::new("/dev").join(entry.file_name()));
+        }
+    }
+    Ok(out)
+}
+
+/// Best-effort teardown of every kernel-side reference to the partitions on `disk_path`,
+/// so the on-disk partition table can be rewritten and `partx --update` will accept the
+/// new layout.
+///
+/// This is intentionally aggressive: VGs are deactivated, dm/md devices torn down, all
+/// mountpoints of every partition on the target disk are unmounted, and the kernel's
+/// btrfs scan cache is forgotten. None of these touches the *bytes* on the disk, so a
+/// `protect`-style preserved partition is safe — only the OS-level claims on it are
+/// dropped (and they need to be: a mounted partition keeps the kernel from seeing
+/// partition-table updates around it).
+///
+/// Failures are logged at WARN and ignored. The next step (`partx --update`) is what
+/// actually decides whether the new layout took, and surfaces the precise per-entry
+/// reason if it didn't.
+pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
+    let partitions = list_partitions(disk_path).await?;
+
+    // Unmount any swap that might be backed by these partitions. `swapoff -a` is broad
+    // but on the install medium nothing else legitimately uses swap.
+    if let Err(e) = Command::new("swapoff")
+        .arg("-a")
+        .invoke(ErrorKind::DiskManagement)
+        .await
+    {
+        tracing::warn!("swapoff -a failed during quiesce: {e}");
+    }
+
+    // Unmount every mountpoint of every partition on the target disk. `umount -A`
+    // unmounts all mountpoints that have this source; fall back to lazy unmount if the
+    // kernel says it's busy (we're about to overwrite the partition anyway).
+    for part in &partitions {
+        if Command::new("umount")
+            .arg("-A")
+            .arg(part)
+            .invoke(ErrorKind::Filesystem)
+            .await
+            .is_err()
+        {
+            if let Err(e) = Command::new("umount")
+                .arg("-A")
+                .arg("-l")
+                .arg(part)
+                .invoke(ErrorKind::Filesystem)
+                .await
+            {
+                tracing::warn!("lazy umount of {} failed: {e}", part.display());
+            }
+        }
+    }
+
+    // Deactivate any LVM VG, then any remaining device-mapper holders.
+    if let Err(e) = Command::new("vgchange")
+        .arg("-an")
+        .invoke(ErrorKind::DiskManagement)
+        .await
+    {
+        tracing::warn!("vgchange -an failed during quiesce: {e}");
+    }
+    if let Err(e) = Command::new("dmsetup")
+        .arg("remove_all")
+        .arg("--force")
+        .invoke(ErrorKind::DiskManagement)
+        .await
+    {
+        tracing::warn!("dmsetup remove_all failed during quiesce: {e}");
+    }
+
+    // Drop the kernel's btrfs device-scan cache. Without this, mounting a freshly
+    // mkfs'd btrfs over a partition the kernel previously scanned can race with the
+    // pending re-scan and surface as `mount` exit 32.
+    if let Err(e) = Command::new("btrfs")
+        .arg("device")
+        .arg("scan")
+        .arg("--forget")
+        .invoke(ErrorKind::DiskManagement)
+        .await
+    {
+        tracing::warn!("btrfs device scan --forget failed during quiesce: {e}");
+    }
+
+    Ok(())
+}
+
+/// Tell the kernel about the new partition table on `disk_path` without requiring an
+/// exclusive open of the whole disk.
+///
+/// `partx --update` issues per-entry `BLKPG_*` ioctls (add/delete/resize) and tolerates
+/// other partitions on the same disk being in use, so it works even when a protected
+/// data partition is still claimed by something we couldn't tear down. This replaces
+/// the old `blockdev --rereadpt` (BLKRRPART) path which fails with EBUSY whenever any
+/// partition on the disk is still held.
+pub async fn update_partition_table(disk_path: &Path) -> Result<(), Error> {
+    Command::new("partx")
+        .arg("--update")
+        .arg(disk_path)
+        .invoke(ErrorKind::DiskManagement)
+        .await?;
+    Command::new("udevadm")
+        .arg("settle")
+        .invoke(ErrorKind::DiskManagement)
+        .await?;
+    // udev re-runs blkid/btrfs scan against the freshly-announced partitions. Forget
+    // any scan refs it may have just installed, so the next mount of the new rootfs
+    // partition isn't racing the kernel's btrfs cache.
+    if let Err(e) = Command::new("btrfs")
+        .arg("device")
+        .arg("scan")
+        .arg("--forget")
+        .invoke(ErrorKind::DiskManagement)
+        .await
+    {
+        tracing::warn!("btrfs device scan --forget after partx failed: {e}");
+    }
+    Ok(())
+}

--- a/core/src/os_install/quiesce.rs
+++ b/core/src/os_install/quiesce.rs
@@ -6,10 +6,7 @@ use tokio::process::Command;
 use crate::prelude::*;
 use crate::util::Invoke;
 
-/// List `/dev/<part>` paths for every partition currently exposed on `disk_path`.
-///
-/// Walks `/sys/block/<disk>/` and picks entries that have a `partition` attribute file
-/// (the kernel's marker for "this is a partition of the parent block device").
+/// `/dev/<part>` paths for every partition currently exposed on `disk_path`.
 pub async fn list_partitions(disk_path: &Path) -> Result<Vec<PathBuf>, Error> {
     let disk_name = disk_path
         .file_name()
@@ -42,25 +39,13 @@ pub async fn list_partitions(disk_path: &Path) -> Result<Vec<PathBuf>, Error> {
     Ok(out)
 }
 
-/// Best-effort teardown of every kernel-side reference to the partitions on `disk_path`,
-/// so the on-disk partition table can be rewritten and `partx --update` will accept the
-/// new layout.
-///
-/// This is intentionally aggressive: VGs are deactivated, dm/md devices torn down, all
-/// mountpoints of every partition on the target disk are unmounted, and the kernel's
-/// btrfs scan cache is forgotten. None of these touches the *bytes* on the disk, so a
-/// `protect`-style preserved partition is safe — only the OS-level claims on it are
-/// dropped (and they need to be: a mounted partition keeps the kernel from seeing
-/// partition-table updates around it).
-///
-/// Failures are logged at WARN and ignored. The next step (`partx --update`) is what
-/// actually decides whether the new layout took, and surfaces the precise per-entry
-/// reason if it didn't.
+/// Best-effort teardown of OS-level claims (mounts, swap, LVM, dm, btrfs scan
+/// cache) on every partition of `disk_path`. Doesn't touch on-disk bytes, so
+/// `protect`ed partitions stay intact. Failures are logged and ignored — the
+/// subsequent `partx --update` is the source of truth.
 pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
     let partitions = list_partitions(disk_path).await?;
 
-    // Unmount any swap that might be backed by these partitions. `swapoff -a` is broad
-    // but on the install medium nothing else legitimately uses swap.
     if let Err(e) = Command::new("swapoff")
         .arg("-a")
         .invoke(ErrorKind::DiskManagement)
@@ -69,9 +54,7 @@ pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
         tracing::warn!("swapoff -a failed during quiesce: {e}");
     }
 
-    // Unmount every mountpoint of every partition on the target disk. `umount -A`
-    // unmounts all mountpoints that have this source; fall back to lazy unmount if the
-    // kernel says it's busy (we're about to overwrite the partition anyway).
+    // umount -A all mountpoints; lazy-unmount on busy.
     for part in &partitions {
         if Command::new("umount")
             .arg("-A")
@@ -92,7 +75,6 @@ pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
         }
     }
 
-    // Deactivate any LVM VG, then any remaining device-mapper holders.
     if let Err(e) = Command::new("vgchange")
         .arg("-an")
         .invoke(ErrorKind::DiskManagement)
@@ -109,9 +91,7 @@ pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
         tracing::warn!("dmsetup remove_all failed during quiesce: {e}");
     }
 
-    // Drop the kernel's btrfs device-scan cache. Without this, mounting a freshly
-    // mkfs'd btrfs over a partition the kernel previously scanned can race with the
-    // pending re-scan and surface as `mount` exit 32.
+    // Drop btrfs scan cache so a later mount doesn't race with a pending re-scan.
     if let Err(e) = Command::new("btrfs")
         .arg("device")
         .arg("scan")
@@ -125,14 +105,8 @@ pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-/// Tell the kernel about the new partition table on `disk_path` without requiring an
-/// exclusive open of the whole disk.
-///
-/// `partx --update` issues per-entry `BLKPG_*` ioctls (add/delete/resize) and tolerates
-/// other partitions on the same disk being in use, so it works even when a protected
-/// data partition is still claimed by something we couldn't tear down. This replaces
-/// the old `blockdev --rereadpt` (BLKRRPART) path which fails with EBUSY whenever any
-/// partition on the disk is still held.
+/// Per-entry BLKPG update via `partx`. Tolerates a still-busy partition on the
+/// same disk (unlike BLKRRPART, which would fail with EBUSY).
 pub async fn update_partition_table(disk_path: &Path) -> Result<(), Error> {
     Command::new("partx")
         .arg("--update")
@@ -143,9 +117,8 @@ pub async fn update_partition_table(disk_path: &Path) -> Result<(), Error> {
         .arg("settle")
         .invoke(ErrorKind::DiskManagement)
         .await?;
-    // udev re-runs blkid/btrfs scan against the freshly-announced partitions. Forget
-    // any scan refs it may have just installed, so the next mount of the new rootfs
-    // partition isn't racing the kernel's btrfs cache.
+    // Forget any btrfs scan refs udev just re-installed, for the same reason as
+    // in quiesce_disk.
     if let Err(e) = Command::new("btrfs")
         .arg("device")
         .arg("scan")

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -273,7 +273,7 @@ pub enum SetupStatusRes {
     Complete(SetupResult),
 }
 
-#[derive(Default, Debug, Deserialize, Serialize, TS)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize, TS)]
 #[serde(rename_all = "camelCase")]
 pub struct SetupInfo {
     pub guid: Option<InternedString>,

--- a/docs/PHYSICAL_DEVICE_TEST_PLAN.md
+++ b/docs/PHYSICAL_DEVICE_TEST_PLAN.md
@@ -20,14 +20,6 @@ Artifacts:
 - [ ] StartOS ISO for this release (e.g. `startos-0.4.0-beta.4-abcdef0_x86_64.iso`) on the laptop
 - [ ] SHA256 of the ISO from the release manifest
 
-Fixed values used throughout:
-
-| Field          | Value          |
-| -------------- | -------------- |
-| Admin password | `QaTestPass!1` |
-| Server name    | `QA Test`      |
-| Language       | English (US)   |
-
 ---
 
 ## 1. Flash install media & install from USB

--- a/web/projects/setup-wizard/src/app/services/live-api.service.ts
+++ b/web/projects/setup-wizard/src/app/services/live-api.service.ts
@@ -82,6 +82,7 @@ export class LiveApiService extends ApiService {
     return this.rpcRequest<InstallOsRes>({
       method: 'setup.install-os',
       params,
+      timeout: 5 * 60 * 1000,
     })
   }
 


### PR DESCRIPTION
## Summary

- Wraps `install_os` in a `Shared<BoxFuture>` stored on `SetupContext` so retries from the wizard (after a browser HTTP timeout aborts the previous request) attach to the running install instead of starting a parallel one against the same disk.
- Spawns the shared future so it keeps making progress even if every awaiter drops.
- Bumps the `setup.install-os` web client timeout to 5 minutes so the common case completes on a single request.
- Adds `Clone` to `SetupInfo` so the cached result can be returned to all awaiters.
- Drops a stale fixed-values table from the physical device test plan.

## Test plan

- [ ] Boot the setup wizard, start an OS install, simulate a browser HTTP timeout (e.g. throttle/disconnect network briefly mid-install) and retry — verify the second `setup.install-os` returns the same `SetupInfo` rather than racing a fresh install
- [ ] Verify a single happy-path install completes within the 5-minute timeout window
- [ ] Verify dropping all awaiters mid-install (closing the browser tab) doesn't abort the install — wizard reopened later sees the completed result