### PR TITLE
fix(net/acme): honor Retry-After after failed ACME orders

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -241,12 +241,13 @@ dependencies = [
 [[package]]
 name = "async-acme"
 version = "0.6.0"
-source = "git+https://github.com/dr-bonez/async-acme.git#d22a20f9ac0a5dafb8fb383958b12bf6f4151833"
+source = "git+https://github.com/Start9Labs/async-acme.git?rev=6d887d0ba58e5eb49cefc11fb5ab8f6887351f79#6d887d0ba58e5eb49cefc11fb5ab8f6887351f79"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "futures-util",
  "generic-async-http-client",
+ "httpdate",
  "log",
  "pem",
  "rcgen",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -51,7 +51,7 @@ unstable = ["backtrace-on-stack-overflow"]
 
 [dependencies]
 aes = { version = "0.7.5", features = ["ctr"] }
-async-acme = { version = "0.6.0", git = "https://github.com/dr-bonez/async-acme.git", features = [
+async-acme = { version = "0.6.0", git = "https://github.com/Start9Labs/async-acme.git", rev = "6d887d0ba58e5eb49cefc11fb5ab8f6887351f79", features = [
   "use_rustls",
   "use_tokio",
 ] }

--- a/core/src/net/acme.rs
+++ b/core/src/net/acme.rs
@@ -2,9 +2,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use async_acme::acme::{ACME_TLS_ALPN_NAME, Identifier};
+use async_acme::acme::{ACME_TLS_ALPN_NAME, AcmeError, Identifier};
+use async_acme::rustls_helper::OrderError;
 use clap::Parser;
 use clap::builder::ValueParserFactory;
 use futures::future::{BoxFuture, Shared};
@@ -39,13 +40,41 @@ use crate::util::sync::{SyncMutex, Watch};
 pub type AcmeTlsAlpnCache =
     Arc<SyncMutex<BTreeMap<InternedString, Watch<Option<Arc<CertifiedKey>>>>>>;
 
+/// Per-SAN order state: deduplicates concurrent in-flight ACME orders
+/// and arms a cooldown after a failed one. The entry is removed when
+/// `get_cert` next finds a valid cached cert in the DB, so the
+/// success path doesn't need to clean up here.
+#[derive(Default)]
+pub struct OrderEntry {
+    in_flight: Option<Shared<BoxFuture<'static, Option<CertifiedKey>>>>,
+    /// On failure: server-supplied `Retry-After` (when present) or
+    /// [`DEFAULT_FAILURE_BACKOFF`]. Inside this window `get_cert`
+    /// returns `None` instead of starting a new order.
+    backoff_until: Option<Instant>,
+}
+
+/// Cooldown for failures without a server-supplied `Retry-After`. Long
+/// enough to break the per-connection retry loop.
+const DEFAULT_FAILURE_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Cap on server-supplied `Retry-After` so a misbehaving directory
+/// can't indefinitely silence cert issuance.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// `Some(retry_after)` (capped) for a 429, `None` otherwise.
+fn retry_after_from_order_error(err: &OrderError) -> Option<Duration> {
+    let OrderError::Acme(AcmeError::RateLimited { retry_after }) = err else {
+        return None;
+    };
+    retry_after.map(|d| d.min(MAX_RETRY_AFTER))
+}
+
 pub struct AcmeTlsHandler<M: HasModel, S> {
     pub db: TypedPatchDb<M>,
     pub acme_cache: AcmeTlsAlpnCache,
     pub crypto_provider: Arc<CryptoProvider>,
     pub get_provider: S,
-    pub in_progress:
-        Watch<BTreeMap<BTreeSet<InternedString>, Shared<BoxFuture<'static, Option<CertifiedKey>>>>>,
+    pub in_progress: Watch<BTreeMap<BTreeSet<InternedString>, OrderEntry>>,
 }
 impl<M, S> AcmeTlsHandler<M, S>
 where
@@ -60,106 +89,172 @@ where
     pub async fn get_cert(&self, san_info: &BTreeSet<InternedString>) -> Option<CertifiedKey> {
         let provider = self.get_provider.get_provider(san_info).await?;
         let provider = provider.as_ref();
-        loop {
-            let peek = self.db.peek().await;
-            let store = <M as DbAccess<AcmeCertStore>>::access(&peek);
-            if let Some(cert) = store
-                .as_certs()
-                .as_idx(&provider.0)
-                .and_then(|p| p.as_idx(JsonKey::new_ref(san_info)))
+
+        let peek = self.db.peek().await;
+        let store = <M as DbAccess<AcmeCertStore>>::access(&peek);
+        if let Some(cert) = store
+            .as_certs()
+            .as_idx(&provider.0)
+            .and_then(|p| p.as_idx(JsonKey::new_ref(san_info)))
+        {
+            let cert = cert.de().log_err()?;
+            if cert
+                .fullchain
+                .get(0)
+                .and_then(|c| should_use_cert(&c.0).log_err())
+                .unwrap_or(false)
             {
-                let cert = cert.de().log_err()?;
-                if cert
-                    .fullchain
-                    .get(0)
-                    .and_then(|c| should_use_cert(&c.0).log_err())
-                    .unwrap_or(false)
-                {
-                    self.in_progress
-                        .send_if_modified(|map| map.remove(san_info).is_some());
-                    return Some(
-                        CertifiedKey::from_der(
-                            cert.fullchain
-                                .into_iter()
-                                .map(|c| Ok(CertificateDer::from(c.to_der()?)))
-                                .collect::<Result<_, Error>>()
-                                .log_err()?,
-                            PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
-                                cert.key.0.private_key_to_pkcs8().log_err()?,
-                            )),
-                            &*self.crypto_provider,
-                        )
-                        .log_err()?,
-                    );
+                // Cached cert is healthy; drop any stale order/backoff state.
+                self.in_progress
+                    .send_if_modified(|map| map.remove(san_info).is_some());
+                return Some(
+                    CertifiedKey::from_der(
+                        cert.fullchain
+                            .into_iter()
+                            .map(|c| Ok(CertificateDer::from(c.to_der()?)))
+                            .collect::<Result<_, Error>>()
+                            .log_err()?,
+                        PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
+                            cert.key.0.private_key_to_pkcs8().log_err()?,
+                        )),
+                        &*self.crypto_provider,
+                    )
+                    .log_err()?,
+                );
+            }
+        }
+
+        let contact = <M as DbAccessByKey<AcmeSettings>>::access_by_key(&peek, &provider)?
+            .as_contact()
+            .de()
+            .log_err()?;
+        drop(peek);
+
+        let identifiers: Vec<_> = san_info
+            .iter()
+            .map(|d| match d.parse::<IpAddr>() {
+                Ok(a) => Identifier::Ip(a),
+                _ => Identifier::Dns((&**d).into()),
+            })
+            .collect::<Vec<_>>();
+
+        let cache_entries = san_info
+            .iter()
+            .cloned()
+            .map(|d| (d, Watch::new(None)))
+            .collect::<BTreeMap<_, _>>();
+
+        // Reuse an in-flight order, honour an active backoff, or start a
+        // new order — all under the in_progress lock.
+        enum Action {
+            Await(Shared<BoxFuture<'static, Option<CertifiedKey>>>),
+            Backoff,
+        }
+        let action = self.in_progress.send_modify(|map| {
+            let entry = map.entry(san_info.clone()).or_default();
+
+            // A resolved future's result is either in the DB (cached-cert
+            // path would have hit) or in `backoff_until` — don't await it.
+            if let Some(fut) = &entry.in_flight {
+                if fut.peek().is_some() {
+                    entry.in_flight = None;
                 }
             }
 
-            let contact = <M as DbAccessByKey<AcmeSettings>>::access_by_key(&peek, &provider)?
-                .as_contact()
-                .de()
-                .log_err()?;
+            if let Some(fut) = &entry.in_flight {
+                return Action::Await(fut.clone());
+            }
 
-            let identifiers: Vec<_> = san_info
-                .iter()
-                .map(|d| match d.parse::<IpAddr>() {
-                    Ok(a) => Identifier::Ip(a),
-                    _ => Identifier::Dns((&**d).into()),
-                })
-                .collect::<Vec<_>>();
+            if let Some(until) = entry.backoff_until {
+                if Instant::now() < until {
+                    return Action::Backoff;
+                }
+            }
 
-            let cache_entries = san_info
-                .iter()
-                .cloned()
-                .map(|d| (d, Watch::new(None)))
-                .collect::<BTreeMap<_, _>>();
+            let provider_clone = provider.clone();
+            let acme_cache = self.acme_cache.clone();
+            let db = self.db.clone();
+            let in_progress = self.in_progress.clone();
+            let san_info_clone = san_info.clone();
+            let cache_entries_clone = cache_entries.clone();
+            let identifiers_clone = identifiers.clone();
+            let contact_clone = contact.clone();
 
-            let cert = self
-                .in_progress
-                .send_modify(|map| {
-                    if let Some(fut) = map.get(san_info).cloned() {
-                        if fut.peek().map_or(true, |f| f.is_some()) {
-                            return fut;
-                        }
+            let fut = async move {
+                acme_cache.mutate(|c| {
+                    c.extend(
+                        cache_entries_clone
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.clone())),
+                    );
+                });
+
+                let res = tokio::time::timeout(
+                    Duration::from_secs(120),
+                    async_acme::rustls_helper::order(
+                        |identifier, cert| {
+                            let domain = InternedString::from_display(&identifier);
+                            if let Some(entry) = cache_entries_clone.get(&domain) {
+                                entry.send(Some(Arc::new(cert)));
+                            }
+                            Ok(())
+                        },
+                        provider_clone.0.as_str(),
+                        &identifiers_clone,
+                        Some(&AcmeCertCache(&db)),
+                        &contact_clone,
+                    ),
+                )
+                .await;
+
+                acme_cache.mutate(|c| c.retain(|c, _| !cache_entries_clone.contains_key(c)));
+
+                let (cert, backoff) = match res {
+                    Ok(Ok(cert)) => (Some(cert), None),
+                    Ok(Err(e)) => {
+                        let retry_after = retry_after_from_order_error(&e);
+                        tracing::warn!("ACME order failed for {san_info_clone:?}: {e}");
+                        tracing::debug!("{e:?}");
+                        (None, Some(retry_after.unwrap_or(DEFAULT_FAILURE_BACKOFF)))
                     }
-                    let provider = provider.clone();
-                    let acme_cache = self.acme_cache.clone();
-                    let db = self.db.clone();
-                    let fut = async move {
-                        acme_cache.mutate(|c| {
-                            c.extend(cache_entries.iter().map(|(k, v)| (k.clone(), v.clone())));
-                        });
-
-                        let cert = tokio::time::timeout(
-                            Duration::from_secs(120),
-                            async_acme::rustls_helper::order(
-                                |identifier, cert| {
-                                    let domain = InternedString::from_display(&identifier);
-                                    if let Some(entry) = cache_entries.get(&domain) {
-                                        entry.send(Some(Arc::new(cert)));
-                                    }
-                                    Ok(())
-                                },
-                                provider.0.as_str(),
-                                &identifiers,
-                                Some(&AcmeCertCache(&db)),
-                                &contact,
-                            ),
-                        )
-                        .await
-                        .log_err()?
-                        .log_err()?;
-
-                        acme_cache.mutate(|c| c.retain(|c, _| !cache_entries.contains_key(c)));
-
-                        Some(cert)
+                    Err(_) => {
+                        tracing::warn!(
+                            "ACME order timed out for {san_info_clone:?} after 120s"
+                        );
+                        (None, Some(DEFAULT_FAILURE_BACKOFF))
                     }
-                    .boxed()
-                    .shared();
-                    map.insert(san_info.clone(), fut.clone());
-                    fut
-                })
-                .await?;
-            return Some(cert);
+                };
+
+                // Success: leave the entry alone; the next cached-cert
+                // path call removes it. Failure: arm the cooldown.
+                if let Some(d) = backoff {
+                    in_progress.send_if_modified(|map| {
+                        let Some(entry) = map.get_mut(&san_info_clone) else {
+                            return false;
+                        };
+                        entry.in_flight = None;
+                        entry.backoff_until = Some(Instant::now() + d);
+                        tracing::info!(
+                            "ACME order for {san_info_clone:?} backing off for {d:?}"
+                        );
+                        true
+                    });
+                }
+
+                cert
+            }
+            .boxed()
+            .shared();
+
+            entry.in_flight = Some(fut.clone());
+            Action::Await(fut)
+        });
+
+        match action {
+            Action::Await(fut) => fut.await,
+            // Inside cooldown: fall through to a self-signed cert from
+            // `RootCaTlsHandler` instead of blocking the handshake.
+            Action::Backoff => None,
         }
     }
 }
@@ -525,4 +620,53 @@ pub async fn remove(
         .await
         .result?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use async_acme::acme::{AcmeError, Identifier};
+    use async_acme::rustls_helper::OrderError;
+
+    use super::{MAX_RETRY_AFTER, retry_after_from_order_error};
+
+    #[test]
+    fn rate_limited_with_retry_after_passes_through() {
+        let err = OrderError::Acme(AcmeError::RateLimited {
+            retry_after: Some(Duration::from_secs(120)),
+        });
+        assert_eq!(
+            retry_after_from_order_error(&err),
+            Some(Duration::from_secs(120)),
+        );
+    }
+
+    #[test]
+    fn rate_limited_retry_after_capped_at_max() {
+        // Pathological server: "please come back in a year".
+        let err = OrderError::Acme(AcmeError::RateLimited {
+            retry_after: Some(Duration::from_secs(365 * 24 * 60 * 60)),
+        });
+        assert_eq!(retry_after_from_order_error(&err), Some(MAX_RETRY_AFTER));
+    }
+
+    #[test]
+    fn rate_limited_without_retry_after_returns_none() {
+        let err = OrderError::Acme(AcmeError::RateLimited { retry_after: None });
+        assert_eq!(retry_after_from_order_error(&err), None);
+    }
+
+    #[test]
+    fn non_429_http_status_returns_none() {
+        let err = OrderError::Acme(AcmeError::HttpStatus(503));
+        assert_eq!(retry_after_from_order_error(&err), None);
+    }
+
+    #[test]
+    fn non_http_errors_return_none() {
+        let err =
+            OrderError::TooManyAttemptsAuth(Identifier::Dns("example.test".into()));
+        assert_eq!(retry_after_from_order_error(&err), None);
+    }
 }


### PR DESCRIPTION
## Problem

`AcmeTlsHandler::get_cert` deduplicates concurrent ACME orders via a shared future stored in `in_progress`, but a **failed** future is immediately replaced by a fresh order attempt on the very next call:

```rust
if let Some(fut) = map.get(san_info).cloned() {
    if fut.peek().map_or(true, |f| f.is_some()) { return fut; }
    // Some(None) — failed — falls through and starts a new order
}
```

Every TLS handshake landing on an ACME-managed SNI calls `get_cert`. Combined with the above, a single transient `429 Too Many Requests` from the ACME server turns into a self-sustaining retry storm: failed order → next inbound TLS handshake fires another order → 429 → … The retry rate is bounded only by inbound traffic, so the rate-limit window can never expire and the cert never issues. While that's happening, every TLS handshake also pays the multi-RTT cost of the failing ACME round-trip.

## Fix

Restructure the per-SAN state from a bare `Shared<Future>` into an `OrderEntry` that tracks both the in-flight order and a single cooldown timestamp. On failure, arm the cooldown from the server's `Retry-After` header when present (only `429 Too Many Requests` carries one), otherwise a fixed 60s fallback that's just long enough to break the per-connection retry loop.

While inside the cooldown window, `get_cert` returns `None` immediately so the `ChainedHandler` falls through to a self-signed cert from `RootCaTlsHandler` — inbound TLS handshakes stay fast while the ACME issue is investigated.

The order future writes back into its own `OrderEntry` on completion (clears `in_flight`, arms or resets the cooldown), so callers arriving after a future has resolved see fresh state without needing a separate cleanup task. Server-supplied `Retry-After` is capped at 24h so a misbehaving directory can't indefinitely silence cert issuance.

## Upstream change in `async-acme`

Surfacing `Retry-After` required a small change in [`Start9Labs/async-acme#1`](https://github.com/Start9Labs/async-acme/pull/1): a new non-breaking `AcmeError::RateLimited { retry_after: Option<Duration> }` variant for HTTP 429 responses. `jose_req` reads `Retry-After` from the response before discarding the body and parses the delta-seconds form (HTTP-date is reported as `None`). Other non-2xx responses continue to use `HttpStatus(u16)` unchanged.

This PR also **moves the dependency from `dr-bonez/async-acme` to `Start9Labs/async-acme`**, pinning to the commit that has the change. Bringing the fork into the org so iteration doesn't depend on an individual contributor's account.

Drive-by: lifted the cached-cert lookup out of a `loop` it was never actually iterating.

## Tests

- `cargo check --lib -p start-os`: clean.
- `cargo test --lib -p start-os net::acme`: 7/7 pass (5 new tests cover Retry-After extraction from `RateLimited`, the 24h cap, the no-Retry-After fallback, non-429 HTTP statuses, and non-HTTP errors).
- `cargo test --lib -p start-os net::`: 68/68 pass.

## Notes

- Background-driven renewal (so an idle host actually retries after the cooldown without inbound traffic) is intentionally out of scope — flagged for a separate change.
- Independent of #3191 (vhost passthrough handler refactor) but solves a related pain point. Together they're the difference between "ACME failure makes every TLS handshake on this server slow forever" and "ACME failure has no effect on TLS handshake latency until the operator fixes it".