### PR TITLE
fix(ui): preserve marketplace search query when opening service drawer

### DIFF
--- a/web/projects/ui/src/app/routes/portal/routes/marketplace/marketplace.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/marketplace/marketplace.component.ts
@@ -169,7 +169,13 @@ export default class MarketplaceComponent {
       tap(params => {
         const registry = params.get('registry')
 
-        this.categoryService.setQuery(params.get('search') || '')
+        // Only override the query from the URL when `search` is explicitly
+        // present (e.g. a deep link from a dependency tile). Otherwise we'd
+        // wipe out the user's typed search every time another query param
+        // changes (such as `id`/`flavor` when opening a service drawer).
+        if (params.has('search')) {
+          this.categoryService.setQuery(params.get('search') || '')
+        }
 
         if (!registry) {
           this.router.navigate([], {


### PR DESCRIPTION
## Problem

In the marketplace, typing in the search bar filters the package list, but clicking one of the resulting service tiles resets the list back to unfiltered — even though the search bar text itself remains visible.

## Cause

The search bar doesn't write its value to the URL. Only the deep-link from a dependency tile (`?search=<id>`) does. But `MarketplaceComponent` was unconditionally syncing query state from the URL on every `queryParamMap` emission:

```ts
this.categoryService.setQuery(params.get('search') || '')
```

Clicking a tile merges `id` / `flavor` into the URL via `queryParamsHandling: 'merge'`, which re-fires this subscription. Since `search` was never in the URL, `setQuery('')` ran and wiped the active filter.

## Fix

Only override the in-memory query from the URL when `search` is **explicitly present**:

```ts
if (params.has('search')) {
  this.categoryService.setQuery(params.get('search') || '')
}
```

The dependency-deep-link case still works; ordinary tile-click navigation now preserves the user's typed filter.

## Test

1. Open Marketplace
2. Type something in the search bar so the list filters
3. Click one of the filtered tiles — the drawer opens, and the list behind it stays filtered ✅