### PR TITLE
feat(core): drive setup mode from start-cli for unattended bring-up

### DIFF
--- a/core/locales/i18n.yaml
+++ b/core/locales/i18n.yaml
@@ -5852,6 +5852,69 @@ about.setup-acme-certificate-acquisition:
   fr_FR: "Configurer l'acquisition de certificat ACME"
   pl_PL: "Skonfiguruj pozyskiwanie certyfikatu ACME"
 
+about.setup-attach:
+  en_US: "Attach an existing StartOS data drive without re-running setup"
+  de_DE: "Ein vorhandenes StartOS-Datenlaufwerk anbinden, ohne die Einrichtung erneut auszuführen"
+  es_ES: "Asociar una unidad de datos de StartOS existente sin volver a ejecutar la configuración"
+  fr_FR: "Rattacher un lecteur de données StartOS existant sans relancer la configuration"
+  pl_PL: "Podłącz istniejący dysk danych StartOS bez ponownego uruchamiania konfiguracji"
+
+about.setup-complete:
+  en_US: "Finalize the setup and persist disk identifiers"
+  de_DE: "Die Einrichtung abschließen und Laufwerkskennungen persistieren"
+  es_ES: "Finalizar la configuración y persistir los identificadores de los discos"
+  fr_FR: "Finaliser la configuration et conserver les identifiants des disques"
+  pl_PL: "Zakończ konfigurację i zachowaj identyfikatory dysków"
+
+about.setup-disk-list:
+  en_US: "List disks available for installation"
+  de_DE: "Für die Installation verfügbare Laufwerke auflisten"
+  es_ES: "Listar las unidades disponibles para la instalación"
+  fr_FR: "Lister les lecteurs disponibles pour l'installation"
+  pl_PL: "Wyświetl listę dysków dostępnych do instalacji"
+
+about.setup-execute:
+  en_US: "Run the initial setup against an installed OS or fresh data drive"
+  de_DE: "Die Ersteinrichtung für ein installiertes Betriebssystem oder neues Datenlaufwerk ausführen"
+  es_ES: "Ejecutar la configuración inicial sobre un sistema operativo instalado o una unidad de datos nueva"
+  fr_FR: "Exécuter la configuration initiale sur un système installé ou un nouveau lecteur de données"
+  pl_PL: "Wykonaj początkową konfigurację względem zainstalowanego systemu lub nowego dysku danych"
+
+about.setup-exit:
+  en_US: "Exit setup mode and reboot into the installed OS"
+  de_DE: "Den Einrichtungsmodus verlassen und in das installierte Betriebssystem neu starten"
+  es_ES: "Salir del modo de configuración y reiniciar al sistema operativo instalado"
+  fr_FR: "Quitter le mode de configuration et redémarrer sur le système installé"
+  pl_PL: "Wyjdź z trybu konfiguracji i uruchom ponownie do zainstalowanego systemu"
+
+about.setup-install-os:
+  en_US: "Install StartOS to a disk over the network"
+  de_DE: "StartOS über das Netzwerk auf ein Laufwerk installieren"
+  es_ES: "Instalar StartOS en un disco a través de la red"
+  fr_FR: "Installer StartOS sur un disque par le réseau"
+  pl_PL: "Zainstaluj StartOS na dysku przez sieć"
+
+about.setup-restart:
+  en_US: "Restart the device from setup mode"
+  de_DE: "Das Gerät aus dem Einrichtungsmodus neu starten"
+  es_ES: "Reiniciar el dispositivo desde el modo de configuración"
+  fr_FR: "Redémarrer l'appareil depuis le mode de configuration"
+  pl_PL: "Uruchom ponownie urządzenie z trybu konfiguracji"
+
+about.setup-shutdown:
+  en_US: "Shut down the device from setup mode"
+  de_DE: "Das Gerät aus dem Einrichtungsmodus herunterfahren"
+  es_ES: "Apagar el dispositivo desde el modo de configuración"
+  fr_FR: "Éteindre l'appareil depuis le mode de configuration"
+  pl_PL: "Wyłącz urządzenie z trybu konfiguracji"
+
+about.setup-status:
+  en_US: "Display the current state of the setup wizard"
+  de_DE: "Den aktuellen Status des Einrichtungsassistenten anzeigen"
+  es_ES: "Mostrar el estado actual del asistente de configuración"
+  fr_FR: "Afficher l'état actuel de l'assistant d'installation"
+  pl_PL: "Wyświetl obecny stan kreatora konfiguracji"
+
 about.show-cpu-governors:
   en_US: "Show CPU governors"
   de_DE: "CPU-Governors anzeigen"

--- a/core/man/start-cli/start-cli-registry-os-asset-get-img.1
+++ b/core/man/start-cli/start-cli-registry-os-asset-get-img.1
@@ -9,7 +9,7 @@ start\-cli\-registry\-os\-asset\-get\-img \- Download IMG file
 Download IMG file
 .SH OPTIONS
 .TP
-\fB\-d\fR, \fB\-\-download\fR \fI<DOWNLOAD>\fR
+\fB\-d\fR, \fB\-\-download\fR \fI<DOWNLOAD>\fR [default: .]
 Directory path to download to
 .TP
 \fB\-r\fR, \fB\-\-reverify\fR

--- a/core/man/start-cli/start-cli-registry-os-asset-get-iso.1
+++ b/core/man/start-cli/start-cli-registry-os-asset-get-iso.1
@@ -9,7 +9,7 @@ start\-cli\-registry\-os\-asset\-get\-iso \- Download ISO file
 Download ISO file
 .SH OPTIONS
 .TP
-\fB\-d\fR, \fB\-\-download\fR \fI<DOWNLOAD>\fR
+\fB\-d\fR, \fB\-\-download\fR \fI<DOWNLOAD>\fR [default: .]
 Directory path to download to
 .TP
 \fB\-r\fR, \fB\-\-reverify\fR

--- a/core/man/start-cli/start-cli-registry-os-asset-get-squashfs.1
+++ b/core/man/start-cli/start-cli-registry-os-asset-get-squashfs.1
@@ -9,7 +9,7 @@ start\-cli\-registry\-os\-asset\-get\-squashfs \- Download squashfs file
 Download squashfs file
 .SH OPTIONS
 .TP
-\fB\-d\fR, \fB\-\-download\fR \fI<DOWNLOAD>\fR
+\fB\-d\fR, \fB\-\-download\fR \fI<DOWNLOAD>\fR [default: .]
 Directory path to download to
 .TP
 \fB\-r\fR, \fB\-\-reverify\fR

--- a/core/man/start-cli/start-cli-setup-attach.1
+++ b/core/man/start-cli/start-cli-setup-attach.1
@@ -1,0 +1,22 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-attach 1  "attach " 
+.SH NAME
+start\-cli\-setup\-attach \- about.setup\-attach
+.SH SYNOPSIS
+\fBstart\-cli setup attach\fR <\fB\-\-guid\fR> [\fB\-\-kiosk\fR] [\fB\-\-no\-password\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-attach
+.SH OPTIONS
+.TP
+\fB\-\-guid\fR \fI<GUID>\fR
+Disk GUID of the existing data drive to attach
+.TP
+\fB\-\-kiosk\fR
+Enable kiosk mode
+.TP
+\fB\-\-no\-password\fR
+Treat an unset PASSWORD env var as "no password" (only valid for drives whose GUID ends in `_UNENC`). Without this, missing PASSWORD falls back to a TTY prompt
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup-attach.1
+++ b/core/man/start-cli/start-cli-setup-attach.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-attach 1  "attach " 
 .SH NAME
-start\-cli\-setup\-attach \- about.setup\-attach
+start\-cli\-setup\-attach \- Attach an existing StartOS data drive without re\-running setup
 .SH SYNOPSIS
 \fBstart\-cli setup attach\fR <\fB\-\-guid\fR> [\fB\-\-kiosk\fR] [\fB\-\-no\-password\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-attach
+Attach an existing StartOS data drive without re\-running setup
 .SH OPTIONS
 .TP
 \fB\-\-guid\fR \fI<GUID>\fR

--- a/core/man/start-cli/start-cli-setup-complete.1
+++ b/core/man/start-cli/start-cli-setup-complete.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-complete 1  "complete " 
+.SH NAME
+start\-cli\-setup\-complete \- about.setup\-complete
+.SH SYNOPSIS
+\fBstart\-cli setup complete\fR [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-complete
+.SH OPTIONS
+.TP
+\fB\-\-format\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup-complete.1
+++ b/core/man/start-cli/start-cli-setup-complete.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-complete 1  "complete " 
 .SH NAME
-start\-cli\-setup\-complete \- about.setup\-complete
+start\-cli\-setup\-complete \- Finalize the setup and persist disk identifiers
 .SH SYNOPSIS
 \fBstart\-cli setup complete\fR [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-complete
+Finalize the setup and persist disk identifiers
 .SH OPTIONS
 .TP
 \fB\-\-format\fR

--- a/core/man/start-cli/start-cli-setup-disk-list.1
+++ b/core/man/start-cli/start-cli-setup-disk-list.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-disk-list 1  "list " 
 .SH NAME
-start\-cli\-setup\-disk\-list \- about.setup\-disk\-list
+start\-cli\-setup\-disk\-list \- List disks available for installation
 .SH SYNOPSIS
 \fBstart\-cli setup disk list\fR [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-disk\-list
+List disks available for installation
 .SH OPTIONS
 .TP
 \fB\-\-format\fR

--- a/core/man/start-cli/start-cli-setup-disk-list.1
+++ b/core/man/start-cli/start-cli-setup-disk-list.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-disk-list 1  "list " 
+.SH NAME
+start\-cli\-setup\-disk\-list \- about.setup\-disk\-list
+.SH SYNOPSIS
+\fBstart\-cli setup disk list\fR [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-disk\-list
+.SH OPTIONS
+.TP
+\fB\-\-format\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup-disk.1
+++ b/core/man/start-cli/start-cli-setup-disk.1
@@ -4,9 +4,13 @@
 .SH NAME
 start\-cli\-setup\-disk
 .SH SYNOPSIS
-\fBstart\-cli setup disk\fR [\fB\-h\fR|\fB\-\-help\fR] 
+\fBstart\-cli setup disk\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
+.SH SUBCOMMANDS
+.TP
+start\-cli\-setup\-disk\-list(1)
+about.setup\-disk\-list

--- a/core/man/start-cli/start-cli-setup-disk.1
+++ b/core/man/start-cli/start-cli-setup-disk.1
@@ -13,4 +13,4 @@ Print help
 .SH SUBCOMMANDS
 .TP
 start\-cli\-setup\-disk\-list(1)
-about.setup\-disk\-list
+List disks available for installation

--- a/core/man/start-cli/start-cli-setup-execute.1
+++ b/core/man/start-cli/start-cli-setup-execute.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-execute 1  "execute " 
 .SH NAME
-start\-cli\-setup\-execute \- about.setup\-execute
+start\-cli\-setup\-execute \- Run the initial setup against an installed OS or fresh data drive
 .SH SYNOPSIS
 \fBstart\-cli setup execute\fR <\fB\-\-guid\fR> [\fB\-\-kiosk\fR] [\fB\-\-name\fR] [\fB\-\-hostname\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-execute
+Run the initial setup against an installed OS or fresh data drive
 .SH OPTIONS
 .TP
 \fB\-\-guid\fR \fI<GUID>\fR

--- a/core/man/start-cli/start-cli-setup-execute.1
+++ b/core/man/start-cli/start-cli-setup-execute.1
@@ -1,0 +1,25 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-execute 1  "execute " 
+.SH NAME
+start\-cli\-setup\-execute \- about.setup\-execute
+.SH SYNOPSIS
+\fBstart\-cli setup execute\fR <\fB\-\-guid\fR> [\fB\-\-kiosk\fR] [\fB\-\-name\fR] [\fB\-\-hostname\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-execute
+.SH OPTIONS
+.TP
+\fB\-\-guid\fR \fI<GUID>\fR
+Disk GUID returned by `setup install\-os` (or an existing data drive)
+.TP
+\fB\-\-kiosk\fR
+Enable kiosk mode
+.TP
+\fB\-\-name\fR \fI<NAME>\fR
+Friendly server name
+.TP
+\fB\-\-hostname\fR \fI<HOSTNAME>\fR
+Hostname (LAN advertised) — defaults to a random adjective\-noun pair
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup-exit.1
+++ b/core/man/start-cli/start-cli-setup-exit.1
@@ -1,0 +1,13 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-exit 1  "exit " 
+.SH NAME
+start\-cli\-setup\-exit \- about.setup\-exit
+.SH SYNOPSIS
+\fBstart\-cli setup exit\fR [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-exit
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup-exit.1
+++ b/core/man/start-cli/start-cli-setup-exit.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-exit 1  "exit " 
 .SH NAME
-start\-cli\-setup\-exit \- about.setup\-exit
+start\-cli\-setup\-exit \- Exit setup mode and reboot into the installed OS
 .SH SYNOPSIS
 \fBstart\-cli setup exit\fR [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-exit
+Exit setup mode and reboot into the installed OS
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/core/man/start-cli/start-cli-setup-get-pubkey.1
+++ b/core/man/start-cli/start-cli-setup-get-pubkey.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-get-pubkey 1  "get-pubkey " 
+.SH NAME
+start\-cli\-setup\-get\-pubkey \- about.setup\-get\-pubkey
+.SH SYNOPSIS
+\fBstart\-cli setup get\-pubkey\fR [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-get\-pubkey
+.SH OPTIONS
+.TP
+\fB\-\-format\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup-get-pubkey.1
+++ b/core/man/start-cli/start-cli-setup-get-pubkey.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-get-pubkey 1  "get-pubkey " 
 .SH NAME
-start\-cli\-setup\-get\-pubkey \- about.setup\-get\-pubkey
+start\-cli\-setup\-get\-pubkey \- Get the public key from the server
 .SH SYNOPSIS
 \fBstart\-cli setup get\-pubkey\fR [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-get\-pubkey
+Get the public key from the server
 .SH OPTIONS
 .TP
 \fB\-\-format\fR

--- a/core/man/start-cli/start-cli-setup-install-os.1
+++ b/core/man/start-cli/start-cli-setup-install-os.1
@@ -4,22 +4,19 @@
 .SH NAME
 start\-cli\-setup\-install\-os \- about.setup\-install\-os
 .SH SYNOPSIS
-\fBstart\-cli setup install\-os\fR <\fB\-\-data\-drive\fR> [\fB\-\-wipe\fR] [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIOS_DRIVE\fR> 
+\fBstart\-cli setup install\-os\fR [\fB\-\-data\-drive\fR] [\fB\-\-wipe\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIOS_DRIVE\fR> 
 .SH DESCRIPTION
 about.setup\-install\-os
 .SH OPTIONS
 .TP
-\fB\-\-data\-drive\fR \fI<LOGICALNAME>\fR
-Path to the data drive
+\fB\-\-data\-drive\fR \fI<DATA_DRIVE>\fR
+Path to the data drive (omit for an OS\-only install). May be the same logical name as <OS_DRIVE>; the installer will carve a data partition out of the same disk
 .TP
 \fB\-\-wipe\fR
-Wipe the drive before use
-.TP
-\fB\-\-format\fR
-
+Wipe the data drive before use
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
 .TP
 <\fIOS_DRIVE\fR>
-Path to OS drive
+Path to the OS drive

--- a/core/man/start-cli/start-cli-setup-install-os.1
+++ b/core/man/start-cli/start-cli-setup-install-os.1
@@ -1,0 +1,25 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-install-os 1  "install-os " 
+.SH NAME
+start\-cli\-setup\-install\-os \- about.setup\-install\-os
+.SH SYNOPSIS
+\fBstart\-cli setup install\-os\fR <\fB\-\-data\-drive\fR> [\fB\-\-wipe\fR] [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIOS_DRIVE\fR> 
+.SH DESCRIPTION
+about.setup\-install\-os
+.SH OPTIONS
+.TP
+\fB\-\-data\-drive\fR \fI<LOGICALNAME>\fR
+Path to the data drive
+.TP
+\fB\-\-wipe\fR
+Wipe the drive before use
+.TP
+\fB\-\-format\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIOS_DRIVE\fR>
+Path to OS drive

--- a/core/man/start-cli/start-cli-setup-install-os.1
+++ b/core/man/start-cli/start-cli-setup-install-os.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-install-os 1  "install-os " 
 .SH NAME
-start\-cli\-setup\-install\-os \- about.setup\-install\-os
+start\-cli\-setup\-install\-os \- Install StartOS to a disk over the network
 .SH SYNOPSIS
 \fBstart\-cli setup install\-os\fR [\fB\-\-data\-drive\fR] [\fB\-\-wipe\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIOS_DRIVE\fR> 
 .SH DESCRIPTION
-about.setup\-install\-os
+Install StartOS to a disk over the network
 .SH OPTIONS
 .TP
 \fB\-\-data\-drive\fR \fI<DATA_DRIVE>\fR

--- a/core/man/start-cli/start-cli-setup-restart.1
+++ b/core/man/start-cli/start-cli-setup-restart.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-restart 1  "restart " 
 .SH NAME
-start\-cli\-setup\-restart \- about.setup\-restart
+start\-cli\-setup\-restart \- Restart the device from setup mode
 .SH SYNOPSIS
 \fBstart\-cli setup restart\fR [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-restart
+Restart the device from setup mode
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/core/man/start-cli/start-cli-setup-restart.1
+++ b/core/man/start-cli/start-cli-setup-restart.1
@@ -1,0 +1,13 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-restart 1  "restart " 
+.SH NAME
+start\-cli\-setup\-restart \- about.setup\-restart
+.SH SYNOPSIS
+\fBstart\-cli setup restart\fR [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-restart
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup-set-keyboard.1
+++ b/core/man/start-cli/start-cli-setup-set-keyboard.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-set-keyboard 1  "set-keyboard " 
 .SH NAME
-start\-cli\-setup\-set\-keyboard \- about.setup\-set\-keyboard
+start\-cli\-setup\-set\-keyboard \- Set the keyboard layout
 .SH SYNOPSIS
 \fBstart\-cli setup set\-keyboard\fR [\fB\-k\fR|\fB\-\-keymap\fR] [\fB\-m\fR|\fB\-\-model\fR] [\fB\-v\fR|\fB\-\-variant\fR] [\fB\-o\fR|\fB\-\-option\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fILAYOUT\fR> 
 .SH DESCRIPTION
-about.setup\-set\-keyboard
+Set the keyboard layout
 .SH OPTIONS
 .TP
 \fB\-k\fR, \fB\-\-keymap\fR \fI<KEYMAP>\fR

--- a/core/man/start-cli/start-cli-setup-set-keyboard.1
+++ b/core/man/start-cli/start-cli-setup-set-keyboard.1
@@ -1,0 +1,28 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-set-keyboard 1  "set-keyboard " 
+.SH NAME
+start\-cli\-setup\-set\-keyboard \- about.setup\-set\-keyboard
+.SH SYNOPSIS
+\fBstart\-cli setup set\-keyboard\fR [\fB\-k\fR|\fB\-\-keymap\fR] [\fB\-m\fR|\fB\-\-model\fR] [\fB\-v\fR|\fB\-\-variant\fR] [\fB\-o\fR|\fB\-\-option\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fILAYOUT\fR> 
+.SH DESCRIPTION
+about.setup\-set\-keyboard
+.SH OPTIONS
+.TP
+\fB\-k\fR, \fB\-\-keymap\fR \fI<KEYMAP>\fR
+Console keymap for vconsole
+.TP
+\fB\-m\fR, \fB\-\-model\fR \fI<MODEL>\fR
+Keyboard model
+.TP
+\fB\-v\fR, \fB\-\-variant\fR \fI<VARIANT>\fR
+Keyboard layout variant
+.TP
+\fB\-o\fR, \fB\-\-option\fR \fI<OPTIONS>\fR
+Additional keyboard option
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fILAYOUT\fR>
+Keyboard layout code

--- a/core/man/start-cli/start-cli-setup-set-language.1
+++ b/core/man/start-cli/start-cli-setup-set-language.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-set-language 1  "set-language " 
 .SH NAME
-start\-cli\-setup\-set\-language \- about.setup\-set\-language
+start\-cli\-setup\-set\-language \- Set the system language
 .SH SYNOPSIS
 \fBstart\-cli setup set\-language\fR [\fB\-h\fR|\fB\-\-help\fR] <\fILANGUAGE\fR> 
 .SH DESCRIPTION
-about.setup\-set\-language
+Set the system language
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/core/man/start-cli/start-cli-setup-set-language.1
+++ b/core/man/start-cli/start-cli-setup-set-language.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-set-language 1  "set-language " 
+.SH NAME
+start\-cli\-setup\-set\-language \- about.setup\-set\-language
+.SH SYNOPSIS
+\fBstart\-cli setup set\-language\fR [\fB\-h\fR|\fB\-\-help\fR] <\fILANGUAGE\fR> 
+.SH DESCRIPTION
+about.setup\-set\-language
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fILANGUAGE\fR>
+Language code

--- a/core/man/start-cli/start-cli-setup-shutdown.1
+++ b/core/man/start-cli/start-cli-setup-shutdown.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-shutdown 1  "shutdown " 
 .SH NAME
-start\-cli\-setup\-shutdown \- about.setup\-shutdown
+start\-cli\-setup\-shutdown \- Shut down the device from setup mode
 .SH SYNOPSIS
 \fBstart\-cli setup shutdown\fR [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-shutdown
+Shut down the device from setup mode
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/core/man/start-cli/start-cli-setup-shutdown.1
+++ b/core/man/start-cli/start-cli-setup-shutdown.1
@@ -1,0 +1,13 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-shutdown 1  "shutdown " 
+.SH NAME
+start\-cli\-setup\-shutdown \- about.setup\-shutdown
+.SH SYNOPSIS
+\fBstart\-cli setup shutdown\fR [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-shutdown
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup-status.1
+++ b/core/man/start-cli/start-cli-setup-status.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-setup-status 1  "status " 
 .SH NAME
-start\-cli\-setup\-status \- about.setup\-status
+start\-cli\-setup\-status \- Display the current state of the setup wizard
 .SH SYNOPSIS
 \fBstart\-cli setup status\fR [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-about.setup\-status
+Display the current state of the setup wizard
 .SH OPTIONS
 .TP
 \fB\-\-format\fR

--- a/core/man/start-cli/start-cli-setup-status.1
+++ b/core/man/start-cli/start-cli-setup-status.1
@@ -1,0 +1,16 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-setup-status 1  "status " 
+.SH NAME
+start\-cli\-setup\-status \- about.setup\-status
+.SH SYNOPSIS
+\fBstart\-cli setup status\fR [\fB\-\-format\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+about.setup\-status
+.SH OPTIONS
+.TP
+\fB\-\-format\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/core/man/start-cli/start-cli-setup.1
+++ b/core/man/start-cli/start-cli-setup.1
@@ -13,9 +13,42 @@ Commands related to the initial setup
 Print help
 .SH SUBCOMMANDS
 .TP
+start\-cli\-setup\-attach(1)
+about.setup\-attach
+.TP
 start\-cli\-setup\-cifs(1)
+.TP
+start\-cli\-setup\-complete(1)
+about.setup\-complete
 .TP
 start\-cli\-setup\-disk(1)
 .TP
+start\-cli\-setup\-execute(1)
+about.setup\-execute
+.TP
+start\-cli\-setup\-exit(1)
+about.setup\-exit
+.TP
+start\-cli\-setup\-get\-pubkey(1)
+about.setup\-get\-pubkey
+.TP
+start\-cli\-setup\-install\-os(1)
+about.setup\-install\-os
+.TP
 start\-cli\-setup\-logs(1)
 Display OS logs
+.TP
+start\-cli\-setup\-restart(1)
+about.setup\-restart
+.TP
+start\-cli\-setup\-set\-keyboard(1)
+about.setup\-set\-keyboard
+.TP
+start\-cli\-setup\-set\-language(1)
+about.setup\-set\-language
+.TP
+start\-cli\-setup\-shutdown(1)
+about.setup\-shutdown
+.TP
+start\-cli\-setup\-status(1)
+about.setup\-status

--- a/core/man/start-cli/start-cli-setup.1
+++ b/core/man/start-cli/start-cli-setup.1
@@ -14,41 +14,41 @@ Print help
 .SH SUBCOMMANDS
 .TP
 start\-cli\-setup\-attach(1)
-about.setup\-attach
+Attach an existing StartOS data drive without re\-running setup
 .TP
 start\-cli\-setup\-cifs(1)
 .TP
 start\-cli\-setup\-complete(1)
-about.setup\-complete
+Finalize the setup and persist disk identifiers
 .TP
 start\-cli\-setup\-disk(1)
 .TP
 start\-cli\-setup\-execute(1)
-about.setup\-execute
+Run the initial setup against an installed OS or fresh data drive
 .TP
 start\-cli\-setup\-exit(1)
-about.setup\-exit
+Exit setup mode and reboot into the installed OS
 .TP
 start\-cli\-setup\-get\-pubkey(1)
-about.setup\-get\-pubkey
+Get the public key from the server
 .TP
 start\-cli\-setup\-install\-os(1)
-about.setup\-install\-os
+Install StartOS to a disk over the network
 .TP
 start\-cli\-setup\-logs(1)
 Display OS logs
 .TP
 start\-cli\-setup\-restart(1)
-about.setup\-restart
+Restart the device from setup mode
 .TP
 start\-cli\-setup\-set\-keyboard(1)
-about.setup\-set\-keyboard
+Set the keyboard layout
 .TP
 start\-cli\-setup\-set\-language(1)
-about.setup\-set\-language
+Set the system language
 .TP
 start\-cli\-setup\-shutdown(1)
-about.setup\-shutdown
+Shut down the device from setup mode
 .TP
 start\-cli\-setup\-status(1)
-about.setup\-status
+Display the current state of the setup wizard

--- a/core/man/start-cli/start-cli.1
+++ b/core/man/start-cli/start-cli.1
@@ -1,10 +1,10 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH start-cli 1  "start-cli 0.4.0-beta.0" 
+.TH start-cli 1  "start-cli 0.4.0-beta.7" 
 .SH NAME
 start\-cli
 .SH SYNOPSIS
-\fBstart\-cli\fR [\fB\-c\fR|\fB\-\-config\fR] [\fB\-H\fR|\fB\-\-host\fR] [\fB\-r\fR|\fB\-\-registry\fR] [\fB\-\-registry\-hostname\fR] [\fB\-\-s9pk\-s3base\fR] [\fB\-\-s9pk\-s3bucket\fR] [\fB\-t\fR|\fB\-\-tunnel\fR] [\fB\-p\fR|\fB\-\-proxy\fR] [\fB\-\-cookie\-path\fR] [\fB\-\-developer\-key\-path\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
+\fBstart\-cli\fR [\fB\-c\fR|\fB\-\-config\fR] [\fB\-H\fR|\fB\-\-host\fR] [\fB\-r\fR|\fB\-\-registry\fR] [\fB\-\-registry\-hostname\fR] [\fB\-\-s9pk\-s3base\fR] [\fB\-\-s9pk\-s3bucket\fR] [\fB\-t\fR|\fB\-\-tunnel\fR] [\fB\-p\fR|\fB\-\-proxy\fR] [\fB\-\-cookie\-path\fR] [\fB\-\-developer\-key\-path\fR] [\fB\-\-root\-ca\fR] [\fB\-\-insecure\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
@@ -37,6 +37,12 @@ Path to cookie file
 .TP
 \fB\-\-developer\-key\-path\fR \fI<DEVELOPER_KEY_PATH>\fR
 Path to developer signing key
+.TP
+\fB\-\-root\-ca\fR \fI<PEM_PATH>\fR
+PEM\-encoded root CA certificate(s) to trust when talking to a StartOS server with a self\-signed cert (e.g. immediately after `setup complete`, before the device\*(Aqs CA has been imported into the local trust store). Repeatable
+.TP
+\fB\-\-insecure\fR
+Skip TLS certificate verification entirely. Intended for unattended bring\-up against a fresh StartOS server whose self\-signed CA hasn\*(Aqt been pinned yet. **Do not use over the public internet.**
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
@@ -117,4 +123,4 @@ Command for calculating the blake3 hash of a file
 start\-cli\-wifi(1)
 Commands related to wifi networks i.e. add, connect, delete
 .SH VERSION
-v0.4.0\-beta.0
+v0.4.0\-beta.7

--- a/core/src/context/cli.rs
+++ b/core/src/context/cli.rs
@@ -145,6 +145,16 @@ impl CliContext {
                     builder =
                         builder.proxy(Proxy::all(proxy).with_kind(crate::ErrorKind::ParseUrl)?)
                 }
+                if config.insecure {
+                    builder = builder.danger_accept_invalid_certs(true);
+                }
+                for ca_path in config.root_ca.iter().flatten() {
+                    let pem = std::fs::read(ca_path)
+                        .with_ctx(|_| (crate::ErrorKind::Filesystem, ca_path.display()))?;
+                    let cert = reqwest::Certificate::from_pem(&pem)
+                        .with_kind(crate::ErrorKind::OpenSsl)?;
+                    builder = builder.add_root_certificate(cert);
+                }
                 builder.build().expect("cannot fail")
             },
             cookie_store,

--- a/core/src/context/config.rs
+++ b/core/src/context/config.rs
@@ -84,6 +84,20 @@ pub struct ClientConfig {
     pub cookie_path: Option<PathBuf>,
     #[arg(long, help = "help.arg.developer-key-path")]
     pub developer_key_path: Option<PathBuf>,
+    /// PEM-encoded root CA certificate(s) to trust when talking to a
+    /// StartOS server with a self-signed cert (e.g. immediately after
+    /// `setup complete`, before the device's CA has been imported into
+    /// the local trust store). Repeatable.
+    #[arg(long = "root-ca", value_name = "PEM_PATH")]
+    #[serde(default)]
+    pub root_ca: Option<Vec<PathBuf>>,
+    /// Skip TLS certificate verification entirely. Intended for
+    /// unattended bring-up against a fresh StartOS server whose
+    /// self-signed CA hasn't been pinned yet. **Do not use over the
+    /// public internet.**
+    #[arg(long)]
+    #[serde(default)]
+    pub insecure: bool,
 }
 impl ContextConfig for ClientConfig {
     fn next(&mut self) -> Option<PathBuf> {
@@ -102,6 +116,8 @@ impl ContextConfig for ClientConfig {
         self.socks_listen = self.socks_listen.take().or(other.socks_listen);
         self.cookie_path = self.cookie_path.take().or(other.cookie_path);
         self.developer_key_path = self.developer_key_path.take().or(other.developer_key_path);
+        self.root_ca = self.root_ca.take().or(other.root_ca);
+        self.insecure = self.insecure || other.insecure;
     }
 }
 impl ClientConfig {

--- a/core/src/os_install/mod.rs
+++ b/core/src/os_install/mod.rs
@@ -114,6 +114,7 @@ pub struct InstallOsParams {
 }
 
 #[derive(Deserialize, Serialize, Parser, TS)]
+#[group(skip)]
 #[serde(rename_all = "camelCase")]
 #[command(rename_all = "kebab-case")]
 struct DataDrive {

--- a/core/src/os_install/mod.rs
+++ b/core/src/os_install/mod.rs
@@ -114,7 +114,6 @@ pub struct InstallOsParams {
 }
 
 #[derive(Deserialize, Serialize, Parser, TS)]
-#[group(skip)]
 #[serde(rename_all = "camelCase")]
 #[command(rename_all = "kebab-case")]
 struct DataDrive {

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -8,6 +8,8 @@ use josekit::jwk::Jwk;
 use patch_db::json_ptr::ROOT;
 use rpc_toolkit::yajrc::RpcError;
 use rpc_toolkit::{Context, Empty, HandlerExt, ParentHandler, from_fn_async};
+
+use crate::context::CliContext;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -42,7 +44,7 @@ use crate::system::{KeyboardOptions, SetLanguageParams, save_language, sync_kios
 use crate::util::Invoke;
 use crate::util::crypto::EncryptedWire;
 use crate::util::io::{Counter, create_file, dir_copy, dir_size, read_file_to_string};
-use crate::util::serde::{IoFormat, Pem};
+use crate::util::serde::{HandlerExtSerde, IoFormat, Pem};
 use crate::{DATA_DIR, Error, ErrorKind, MAIN_DATA, PACKAGE_DATA, PLATFORM, ResultExt};
 
 pub fn setup<C: Context>() -> ParentHandler<C> {
@@ -51,7 +53,9 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
             "status",
             from_fn_async(status)
                 .with_metadata("authenticated", Value::Bool(false))
-                .no_cli(),
+                .with_display_serializable()
+                .with_about("about.setup-status")
+                .with_call_remote::<CliContext>(),
         )
         .subcommand("disk", disk::<C>())
         .subcommand("attach", from_fn_async(attach).no_cli())
@@ -61,14 +65,28 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
         )
         .subcommand("execute", from_fn_async(execute).no_cli())
         .subcommand("cifs", cifs::<C>())
-        .subcommand("complete", from_fn_async(complete).no_cli())
+        .subcommand(
+            "complete",
+            from_fn_async(complete)
+                .with_display_serializable()
+                .with_about("about.setup-complete")
+                .with_call_remote::<CliContext>(),
+        )
         .subcommand(
             "get-pubkey",
             from_fn_async(get_pubkey)
                 .with_metadata("authenticated", Value::Bool(false))
-                .no_cli(),
+                .with_display_serializable()
+                .with_about("about.setup-get-pubkey")
+                .with_call_remote::<CliContext>(),
         )
-        .subcommand("exit", from_fn_async(exit).no_cli())
+        .subcommand(
+            "exit",
+            from_fn_async(exit)
+                .no_display()
+                .with_about("about.setup-exit")
+                .with_call_remote::<CliContext>(),
+        )
         .subcommand("logs", crate::system::logs::<SetupContext>())
         .subcommand(
             "logs",
@@ -76,10 +94,34 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
                 .no_display()
                 .with_about("about.display-os-logs"),
         )
-        .subcommand("restart", from_fn_async(restart).no_cli())
-        .subcommand("shutdown", from_fn_async(shutdown).no_cli())
-        .subcommand("set-language", from_fn_async(set_language).no_cli())
-        .subcommand("set-keyboard", from_fn_async(set_keyboard).no_cli())
+        .subcommand(
+            "restart",
+            from_fn_async(restart)
+                .no_display()
+                .with_about("about.setup-restart")
+                .with_call_remote::<CliContext>(),
+        )
+        .subcommand(
+            "shutdown",
+            from_fn_async(shutdown)
+                .no_display()
+                .with_about("about.setup-shutdown")
+                .with_call_remote::<CliContext>(),
+        )
+        .subcommand(
+            "set-language",
+            from_fn_async(set_language)
+                .no_display()
+                .with_about("about.setup-set-language")
+                .with_call_remote::<CliContext>(),
+        )
+        .subcommand(
+            "set-keyboard",
+            from_fn_async(set_keyboard)
+                .no_display()
+                .with_about("about.setup-set-keyboard")
+                .with_call_remote::<CliContext>(),
+        )
 }
 
 pub fn disk<C: Context>() -> ParentHandler<C> {
@@ -87,7 +129,9 @@ pub fn disk<C: Context>() -> ParentHandler<C> {
         "list",
         from_fn_async(list_disks)
             .with_metadata("authenticated", Value::Bool(false))
-            .no_cli(),
+            .with_display_serializable()
+            .with_about("about.setup-disk-list")
+            .with_call_remote::<CliContext>(),
     )
 }
 

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -527,12 +527,33 @@ pub struct SetupExecuteCliParams {
     hostname: Option<InternedString>,
 }
 
-fn read_password_env_or_prompt() -> Result<String, RpcError> {
+/// Read a password for an existing data drive: `PASSWORD` env first,
+/// otherwise prompt once on the TTY.
+fn read_password_env_or_prompt(prompt: &str) -> Result<String, RpcError> {
     if let Ok(p) = std::env::var("PASSWORD") {
         Ok(p)
     } else {
-        Ok(rpassword::prompt_password("Password: ")?)
+        Ok(rpassword::prompt_password(prompt)?)
     }
+}
+
+/// Read a *new* password (for fresh setup): `PASSWORD` env if set,
+/// otherwise prompt twice on the TTY and confirm. Mirrors
+/// `cli_reset_password` in `auth.rs`.
+fn read_new_password_env_or_prompt() -> Result<String, RpcError> {
+    if let Ok(p) = std::env::var("PASSWORD") {
+        return Ok(p);
+    }
+    let new_password = rpassword::prompt_password(&t!("auth.prompt-new-password"))?;
+    let confirm = rpassword::prompt_password(&t!("auth.prompt-confirm"))?;
+    if new_password != confirm {
+        return Err(crate::Error::new(
+            eyre!("{}", t!("auth.passwords-do-not-match")),
+            crate::ErrorKind::IncorrectPassword,
+        )
+        .into());
+    }
+    Ok(new_password)
 }
 
 fn print_remote_result(res: imbl_value::Value) -> Result<(), RpcError> {
@@ -565,7 +586,7 @@ async fn cli_attach(
     let password = if no_password && std::env::var_os("PASSWORD").is_none() {
         None
     } else {
-        Some(read_password_env_or_prompt()?)
+        Some(read_password_env_or_prompt("Data drive password: ")?)
     };
 
     let res = ctx
@@ -597,7 +618,7 @@ async fn cli_execute(
         ..
     }: HandlerArgs<CliContext, SetupExecuteCliParams>,
 ) -> Result<(), RpcError> {
-    let password = read_password_env_or_prompt()?;
+    let password = read_new_password_env_or_prompt()?;
 
     let res = ctx
         .call_remote::<SetupContext>(

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 use ts_rs::TS;
 
 use crate::account::AccountInfo;
-use crate::auth::write_shadow;
+use crate::auth::{PasswordType, write_shadow};
 use crate::backup::restore::recover_full_server;
 use crate::backup::target::BackupTargetFS;
 use crate::bins::set_locale;
@@ -43,6 +43,8 @@ use crate::shutdown::Shutdown;
 use crate::system::{KeyboardOptions, SetLanguageParams, save_language, sync_kiosk};
 use crate::util::Invoke;
 use crate::util::crypto::EncryptedWire;
+
+use clap::Parser;
 use crate::util::io::{Counter, create_file, dir_copy, dir_size, read_file_to_string};
 use crate::util::serde::{HandlerExtSerde, IoFormat, Pem};
 use crate::{DATA_DIR, Error, ErrorKind, MAIN_DATA, PACKAGE_DATA, PLATFORM, ResultExt};
@@ -58,7 +60,13 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
                 .with_call_remote::<CliContext>(),
         )
         .subcommand("disk", disk::<C>())
-        .subcommand("attach", from_fn_async(attach).no_cli())
+        .subcommand(
+            "attach",
+            from_fn_async(attach)
+                .with_display_serializable()
+                .with_about("about.setup-attach")
+                .with_call_remote::<CliContext>(),
+        )
         .subcommand(
             "install-os",
             from_fn_async(crate::os_install::install_os)
@@ -66,7 +74,13 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
                 .with_about("about.setup-install-os")
                 .with_call_remote::<CliContext>(),
         )
-        .subcommand("execute", from_fn_async(execute).no_cli())
+        .subcommand(
+            "execute",
+            from_fn_async(execute)
+                .with_display_serializable()
+                .with_about("about.setup-execute")
+                .with_call_remote::<CliContext>(),
+        )
         .subcommand("cifs", cifs::<C>())
         .subcommand(
             "complete",
@@ -214,12 +228,20 @@ async fn setup_init(
     Ok((account, init_result))
 }
 
-#[derive(Deserialize, Serialize, TS)]
+#[derive(Deserialize, Serialize, Parser, TS)]
+#[group(skip)]
 #[serde(rename_all = "camelCase")]
+#[command(rename_all = "kebab-case")]
 #[ts(export)]
 pub struct AttachParams {
-    pub password: Option<EncryptedWire>,
+    /// Disk GUID of the existing data drive to attach
+    #[arg(long)]
     pub guid: InternedString,
+    /// Plaintext password (or JSON for an encrypted wire)
+    #[arg(long)]
+    pub password: Option<PasswordType>,
+    /// Enable kiosk mode
+    #[arg(long)]
     pub kiosk: bool,
 }
 
@@ -240,15 +262,12 @@ pub async fn attach(
         let rpc_ctx_phases = InitRpcContextPhases::new(&progress);
 
         let password: Option<String> = match password {
-            Some(a) => match a.decrypt(&setup_ctx) {
-                a @ Some(_) => a,
-                None => {
-                    return Err(Error::new(
-                        color_eyre::eyre::eyre!("{}", t!("setup.couldnt-decode-password")),
-                        crate::ErrorKind::Unknown,
-                    ));
-                }
-            },
+            Some(a) => Some(a.decrypt(&setup_ctx).map_err(|_| {
+                Error::new(
+                    color_eyre::eyre::eyre!("{}", t!("setup.couldnt-decode-password")),
+                    crate::ErrorKind::Unknown,
+                )
+            })?),
             None => None,
         };
 
@@ -456,15 +475,29 @@ pub async fn setup_data_drive(
     Ok(guid)
 }
 
-#[derive(Deserialize, Serialize, TS)]
+#[derive(Deserialize, Serialize, Parser, TS)]
+#[group(skip)]
 #[serde(rename_all = "camelCase")]
+#[command(rename_all = "kebab-case")]
 #[ts(export)]
 pub struct SetupExecuteParams {
+    /// Disk GUID returned by `setup install-os` (or an existing data drive)
+    #[arg(long)]
     guid: InternedString,
-    password: Option<EncryptedWire>,
-    recovery_source: Option<RecoverySource<EncryptedWire>>,
+    /// Plaintext password (or JSON for an encrypted wire). Required for fresh setup.
+    #[arg(long)]
+    password: Option<PasswordType>,
+    /// Recovery source (JSON only — not exposed as CLI flags)
+    #[arg(skip)]
+    recovery_source: Option<RecoverySource<PasswordType>>,
+    /// Enable kiosk mode
+    #[arg(long)]
     kiosk: bool,
+    /// Friendly server name
+    #[arg(long)]
     name: Option<InternedString>,
+    /// Hostname (LAN advertised) — defaults to a random adjective-noun pair
+    #[arg(long)]
     hostname: Option<InternedString>,
 }
 
@@ -482,7 +515,7 @@ pub async fn execute(
 ) -> Result<SetupProgress, Error> {
     let password = password
         .map(|p| {
-            p.decrypt(&ctx).ok_or_else(|| {
+            p.decrypt(&ctx).map_err(|_| {
                 Error::new(
                     color_eyre::eyre::eyre!("{}", t!("setup.couldnt-decode-startos-password")),
                     crate::ErrorKind::Unknown,
@@ -497,7 +530,7 @@ pub async fn execute(
             server_id,
         }) => Some(RecoverySource::Backup {
             target,
-            password: password.decrypt(&ctx).ok_or_else(|| {
+            password: password.decrypt(&ctx).map_err(|_| {
                 Error::new(
                     color_eyre::eyre::eyre!("{}", t!("setup.couldnt-decode-recovery-password")),
                     crate::ErrorKind::Unknown,

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -71,10 +71,13 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
         )
         .subcommand(
             "install-os",
-            from_fn_async(crate::os_install::install_os)
-                .with_display_serializable()
-                .with_about("about.setup-install-os")
-                .with_call_remote::<CliContext>(),
+            from_fn_async(crate::os_install::install_os).no_cli(),
+        )
+        .subcommand(
+            "install-os",
+            from_fn_async(cli_install_os)
+                .no_display()
+                .with_about("about.setup-install-os"),
         )
         .subcommand("execute", from_fn_async(execute).no_cli())
         .subcommand(
@@ -525,6 +528,62 @@ pub struct SetupExecuteCliParams {
     /// Hostname (LAN advertised) — defaults to a random adjective-noun pair
     #[arg(long)]
     hostname: Option<InternedString>,
+}
+
+/// CLI-only flags for `setup install-os`. Mirrors
+/// `os_install::InstallOsParams` but lives here so we can keep
+/// `#[group(skip)]` on `os_install::DataDrive` (manpage generation
+/// requires it on every `Parser`-derived struct, and clap rejects
+/// `#[command(flatten)] Option<DataDrive>` when the inner type has
+/// `group(skip)`).
+#[derive(Deserialize, Serialize, Parser)]
+#[group(skip)]
+#[serde(rename_all = "camelCase")]
+#[command(rename_all = "kebab-case")]
+pub struct SetupInstallOsCliParams {
+    /// Path to the OS drive
+    #[arg(value_name = "OS_DRIVE")]
+    pub os_drive: PathBuf,
+    /// Path to the data drive (omit for an OS-only install). May be the
+    /// same logical name as <OS_DRIVE>; the installer will carve a data
+    /// partition out of the same disk.
+    #[arg(long)]
+    pub data_drive: Option<PathBuf>,
+    /// Wipe the data drive before use
+    #[arg(long)]
+    pub wipe: bool,
+}
+
+#[instrument(skip_all)]
+async fn cli_install_os(
+    HandlerArgs {
+        context: ctx,
+        parent_method,
+        method,
+        params:
+            SetupInstallOsCliParams {
+                os_drive,
+                data_drive,
+                wipe,
+            },
+        ..
+    }: HandlerArgs<CliContext, SetupInstallOsCliParams>,
+) -> Result<(), RpcError> {
+    let body = if let Some(data_drive) = data_drive {
+        imbl_value::json!({
+            "osDrive": os_drive,
+            "dataDrive": { "logicalname": data_drive, "wipe": wipe },
+        })
+    } else {
+        imbl_value::json!({ "osDrive": os_drive })
+    };
+    let res = ctx
+        .call_remote::<SetupContext>(
+            &parent_method.into_iter().chain(method).join("."),
+            body,
+        )
+        .await?;
+    print_remote_result(res)
 }
 
 /// Read a password for an existing data drive: `PASSWORD` env first,

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -237,7 +237,7 @@ async fn setup_init(
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct AttachParams {
-    pub password: Option<PasswordType>,
+    pub password: Option<EncryptedWire>,
     pub guid: InternedString,
     pub kiosk: bool,
 }
@@ -281,12 +281,15 @@ pub async fn attach(
         let rpc_ctx_phases = InitRpcContextPhases::new(&progress);
 
         let password: Option<String> = match password {
-            Some(a) => Some(a.decrypt(&setup_ctx).map_err(|_| {
-                Error::new(
-                    color_eyre::eyre::eyre!("{}", t!("setup.couldnt-decode-password")),
-                    crate::ErrorKind::Unknown,
-                )
-            })?),
+            Some(a) => match a.decrypt(&setup_ctx) {
+                a @ Some(_) => a,
+                None => {
+                    return Err(Error::new(
+                        color_eyre::eyre::eyre!("{}", t!("setup.couldnt-decode-password")),
+                        crate::ErrorKind::Unknown,
+                    ));
+                }
+            },
             None => None,
         };
 
@@ -499,8 +502,8 @@ pub async fn setup_data_drive(
 #[ts(export)]
 pub struct SetupExecuteParams {
     guid: InternedString,
-    password: Option<PasswordType>,
-    recovery_source: Option<RecoverySource<PasswordType>>,
+    password: Option<EncryptedWire>,
+    recovery_source: Option<RecoverySource<EncryptedWire>>,
     kiosk: bool,
     name: Option<InternedString>,
     hostname: Option<InternedString>,
@@ -615,6 +618,23 @@ fn read_new_password_env_or_prompt() -> Result<String, RpcError> {
     Ok(new_password)
 }
 
+/// Fetch the setup-mode public key via JSON-RPC and JWE-encrypt
+/// `plaintext` against it, producing the `EncryptedWire` blob the
+/// server expects on the wire (same shape the web UI sends).
+async fn encrypt_for_setup(
+    ctx: &CliContext,
+    plaintext: &str,
+) -> Result<EncryptedWire, RpcError> {
+    let pubkey_value = ctx
+        .call_remote::<SetupContext>("setup.get-pubkey", imbl_value::json!({}))
+        .await?;
+    let pubkey: josekit::jwk::Jwk = imbl_value::from_value(pubkey_value)
+        .map_err(|e| {
+            crate::Error::new(eyre!("setup get-pubkey: {e}"), crate::ErrorKind::Deserialization)
+        })?;
+    EncryptedWire::encrypt(plaintext, &pubkey).map_err(RpcError::from)
+}
+
 fn print_remote_result(res: imbl_value::Value) -> Result<(), RpcError> {
     match serde_json::to_string_pretty(&res) {
         Ok(s) => {
@@ -645,7 +665,8 @@ async fn cli_attach(
     let password = if no_password && std::env::var_os("PASSWORD").is_none() {
         None
     } else {
-        Some(read_password_env_or_prompt("Data drive password: ")?)
+        let plaintext = read_password_env_or_prompt("Data drive password: ")?;
+        Some(encrypt_for_setup(&ctx, &plaintext).await?)
     };
 
     let res = ctx
@@ -677,7 +698,8 @@ async fn cli_execute(
         ..
     }: HandlerArgs<CliContext, SetupExecuteCliParams>,
 ) -> Result<(), RpcError> {
-    let password = read_new_password_env_or_prompt()?;
+    let plaintext = read_new_password_env_or_prompt()?;
+    let password = encrypt_for_setup(&ctx, &plaintext).await?;
 
     let res = ctx
         .call_remote::<SetupContext>(
@@ -708,7 +730,7 @@ pub async fn execute(
 ) -> Result<SetupProgress, Error> {
     let password = password
         .map(|p| {
-            p.decrypt(&ctx).map_err(|_| {
+            p.decrypt(&ctx).ok_or_else(|| {
                 Error::new(
                     color_eyre::eyre::eyre!("{}", t!("setup.couldnt-decode-startos-password")),
                     crate::ErrorKind::Unknown,
@@ -723,7 +745,7 @@ pub async fn execute(
             server_id,
         }) => Some(RecoverySource::Backup {
             target,
-            password: password.decrypt(&ctx).map_err(|_| {
+            password: password.decrypt(&ctx).ok_or_else(|| {
                 Error::new(
                     color_eyre::eyre::eyre!("{}", t!("setup.couldnt-decode-recovery-password")),
                     crate::ErrorKind::Unknown,

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -61,7 +61,10 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
         .subcommand("attach", from_fn_async(attach).no_cli())
         .subcommand(
             "install-os",
-            from_fn_async(crate::os_install::install_os).no_cli(),
+            from_fn_async(crate::os_install::install_os)
+                .with_display_serializable()
+                .with_about("about.setup-install-os")
+                .with_call_remote::<CliContext>(),
         )
         .subcommand("execute", from_fn_async(execute).no_cli())
         .subcommand("cifs", cifs::<C>())

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -7,9 +7,11 @@ use const_format::formatcp;
 use josekit::jwk::Jwk;
 use patch_db::json_ptr::ROOT;
 use rpc_toolkit::yajrc::RpcError;
-use rpc_toolkit::{Context, Empty, HandlerExt, ParentHandler, from_fn_async};
+use rpc_toolkit::{Context, Empty, HandlerArgs, HandlerExt, ParentHandler, from_fn_async};
 
 use crate::context::CliContext;
+use itertools::Itertools;
+use rpc_toolkit::CallRemote;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -60,12 +62,12 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
                 .with_call_remote::<CliContext>(),
         )
         .subcommand("disk", disk::<C>())
+        .subcommand("attach", from_fn_async(attach).no_cli())
         .subcommand(
             "attach",
-            from_fn_async(attach)
-                .with_display_serializable()
-                .with_about("about.setup-attach")
-                .with_call_remote::<CliContext>(),
+            from_fn_async(cli_attach)
+                .no_display()
+                .with_about("about.setup-attach"),
         )
         .subcommand(
             "install-os",
@@ -74,12 +76,12 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
                 .with_about("about.setup-install-os")
                 .with_call_remote::<CliContext>(),
         )
+        .subcommand("execute", from_fn_async(execute).no_cli())
         .subcommand(
             "execute",
-            from_fn_async(execute)
-                .with_display_serializable()
-                .with_about("about.setup-execute")
-                .with_call_remote::<CliContext>(),
+            from_fn_async(cli_execute)
+                .no_display()
+                .with_about("about.setup-execute"),
         )
         .subcommand("cifs", cifs::<C>())
         .subcommand(
@@ -228,21 +230,35 @@ async fn setup_init(
     Ok((account, init_result))
 }
 
-#[derive(Deserialize, Serialize, Parser, TS)]
+#[derive(Deserialize, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct AttachParams {
+    pub password: Option<PasswordType>,
+    pub guid: InternedString,
+    pub kiosk: bool,
+}
+
+/// CLI-only flags for `setup attach`. The password is read from the
+/// PASSWORD environment variable (matching `start-cli auth login`),
+/// or prompted on a TTY — never accepted as a CLI argument so it
+/// can't leak via `ps` or shell history.
+#[derive(Deserialize, Serialize, Parser)]
 #[group(skip)]
 #[serde(rename_all = "camelCase")]
 #[command(rename_all = "kebab-case")]
-#[ts(export)]
-pub struct AttachParams {
+pub struct SetupAttachCliParams {
     /// Disk GUID of the existing data drive to attach
     #[arg(long)]
     pub guid: InternedString,
-    /// Plaintext password (or JSON for an encrypted wire)
-    #[arg(long)]
-    pub password: Option<PasswordType>,
     /// Enable kiosk mode
     #[arg(long)]
     pub kiosk: bool,
+    /// Treat an unset PASSWORD env var as "no password" (only valid for
+    /// drives whose GUID ends in `_UNENC`). Without this, missing
+    /// PASSWORD falls back to a TTY prompt.
+    #[arg(long)]
+    pub no_password: bool,
 }
 
 #[instrument(skip_all)]
@@ -475,21 +491,31 @@ pub async fn setup_data_drive(
     Ok(guid)
 }
 
-#[derive(Deserialize, Serialize, Parser, TS)]
+#[derive(Deserialize, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct SetupExecuteParams {
+    guid: InternedString,
+    password: Option<PasswordType>,
+    recovery_source: Option<RecoverySource<PasswordType>>,
+    kiosk: bool,
+    name: Option<InternedString>,
+    hostname: Option<InternedString>,
+}
+
+/// CLI-only flags for `setup execute`. The password is read from the
+/// PASSWORD environment variable (matching `start-cli auth login`),
+/// or prompted on a TTY — never accepted as a CLI argument so it
+/// can't leak via `ps` or shell history. Recovery / migration callers
+/// should hit the JSON-RPC endpoint directly.
+#[derive(Deserialize, Serialize, Parser)]
 #[group(skip)]
 #[serde(rename_all = "camelCase")]
 #[command(rename_all = "kebab-case")]
-#[ts(export)]
-pub struct SetupExecuteParams {
+pub struct SetupExecuteCliParams {
     /// Disk GUID returned by `setup install-os` (or an existing data drive)
     #[arg(long)]
     guid: InternedString,
-    /// Plaintext password (or JSON for an encrypted wire). Required for fresh setup.
-    #[arg(long)]
-    password: Option<PasswordType>,
-    /// Recovery source (JSON only — not exposed as CLI flags)
-    #[arg(skip)]
-    recovery_source: Option<RecoverySource<PasswordType>>,
     /// Enable kiosk mode
     #[arg(long)]
     kiosk: bool,
@@ -499,6 +525,93 @@ pub struct SetupExecuteParams {
     /// Hostname (LAN advertised) — defaults to a random adjective-noun pair
     #[arg(long)]
     hostname: Option<InternedString>,
+}
+
+fn read_password_env_or_prompt() -> Result<String, RpcError> {
+    if let Ok(p) = std::env::var("PASSWORD") {
+        Ok(p)
+    } else {
+        Ok(rpassword::prompt_password("Password: ")?)
+    }
+}
+
+fn print_remote_result(res: imbl_value::Value) -> Result<(), RpcError> {
+    match serde_json::to_string_pretty(&res) {
+        Ok(s) => {
+            println!("{s}");
+            Ok(())
+        }
+        Err(e) => Err(RpcError::from(
+            crate::Error::new(eyre!("{e}"), crate::ErrorKind::Serialization),
+        )),
+    }
+}
+
+#[instrument(skip_all)]
+async fn cli_attach(
+    HandlerArgs {
+        context: ctx,
+        parent_method,
+        method,
+        params:
+            SetupAttachCliParams {
+                guid,
+                kiosk,
+                no_password,
+            },
+        ..
+    }: HandlerArgs<CliContext, SetupAttachCliParams>,
+) -> Result<(), RpcError> {
+    let password = if no_password && std::env::var_os("PASSWORD").is_none() {
+        None
+    } else {
+        Some(read_password_env_or_prompt()?)
+    };
+
+    let res = ctx
+        .call_remote::<SetupContext>(
+            &parent_method.into_iter().chain(method).join("."),
+            imbl_value::json!({
+                "guid": guid,
+                "password": password,
+                "kiosk": kiosk,
+            }),
+        )
+        .await?;
+    print_remote_result(res)
+}
+
+#[instrument(skip_all)]
+async fn cli_execute(
+    HandlerArgs {
+        context: ctx,
+        parent_method,
+        method,
+        params:
+            SetupExecuteCliParams {
+                guid,
+                kiosk,
+                name,
+                hostname,
+            },
+        ..
+    }: HandlerArgs<CliContext, SetupExecuteCliParams>,
+) -> Result<(), RpcError> {
+    let password = read_password_env_or_prompt()?;
+
+    let res = ctx
+        .call_remote::<SetupContext>(
+            &parent_method.into_iter().chain(method).join("."),
+            imbl_value::json!({
+                "guid": guid,
+                "password": password,
+                "kiosk": kiosk,
+                "name": name,
+                "hostname": hostname,
+            }),
+        )
+        .await?;
+    print_remote_result(res)
 }
 
 // #[command(rpc_only)]

--- a/core/src/setup.rs
+++ b/core/src/setup.rs
@@ -99,7 +99,7 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
             from_fn_async(get_pubkey)
                 .with_metadata("authenticated", Value::Bool(false))
                 .with_display_serializable()
-                .with_about("about.setup-get-pubkey")
+                .with_about("about.get-pubkey-from-server")
                 .with_call_remote::<CliContext>(),
         )
         .subcommand(
@@ -134,14 +134,14 @@ pub fn setup<C: Context>() -> ParentHandler<C> {
             "set-language",
             from_fn_async(set_language)
                 .no_display()
-                .with_about("about.setup-set-language")
+                .with_about("about.set-language")
                 .with_call_remote::<CliContext>(),
         )
         .subcommand(
             "set-keyboard",
             from_fn_async(set_keyboard)
                 .no_display()
-                .with_about("about.setup-set-keyboard")
+                .with_about("about.set-keyboard")
                 .with_call_remote::<CliContext>(),
         )
 }

--- a/core/src/util/crypto.rs
+++ b/core/src/util/crypto.rs
@@ -63,6 +63,33 @@ pub struct EncryptedWire {
     encrypted: Value,
 }
 impl EncryptedWire {
+    /// Encrypt `plaintext` against the recipient's public ECDH key,
+    /// producing the same JWE flattened-JSON payload shape that the
+    /// setup-mode web UI sends. Decrypts cleanly via
+    /// [`EncryptedWire::decrypt`] on the matching private JWK.
+    pub fn encrypt(plaintext: &str, public_key: &Jwk) -> Result<Self, Error> {
+        use josekit::jwe::alg::ecdh_es::EcdhEsJweAlgorithm;
+        use josekit::jwe::{self, JweHeaderSet};
+
+        let encrypter = EcdhEsJweAlgorithm::EcdhEs
+            .encrypter_from_jwk(public_key)
+            .map_err(|e| Error::new(eyre!("{e}"), crate::ErrorKind::OpenSsl))?;
+        let mut header = JweHeaderSet::new();
+        header.set_algorithm("ECDH-ES", true);
+        header.set_content_encryption("A128CBC-HS256", true);
+        let jwe_json = jwe::serialize_flattened_json(
+            plaintext.as_bytes(),
+            Some(&header),
+            None,
+            None,
+            &*encrypter,
+        )
+        .map_err(|e| Error::new(eyre!("{e}"), crate::ErrorKind::OpenSsl))?;
+        let encrypted: Value = serde_json::from_str(&jwe_json)
+            .with_kind(crate::ErrorKind::Deserialization)?;
+        Ok(EncryptedWire { encrypted })
+    }
+
     #[instrument(skip_all)]
     pub fn decrypt(self, current_secret: impl AsRef<Jwk>) -> Option<String> {
         let current_secret = current_secret.as_ref();
@@ -102,6 +129,30 @@ impl EncryptedWire {
                 return None;
             }
         }
+    }
+}
+
+/// `EncryptedWire::encrypt` produces a wire format that the matching
+/// [`EncryptedWire::decrypt`] (and therefore the setup-mode server)
+/// accepts.
+#[test]
+fn test_encrypt_decrypt_roundtrip() {
+    let private_key: Jwk = serde_json::from_str(
+        r#"{
+            "kty": "EC",
+            "crv": "P-256",
+            "d": "3P-MxbUJtEhdGGpBCRFXkUneGgdyz_DGZWfIAGSCHOU",
+            "x": "yHTDYSfjU809fkSv9MmN4wuojf5c3cnD7ZDN13n-jz4",
+            "y": "8Mpkn744A5KDag0DmX2YivB63srjbugYZzWc3JOpQXI"
+          }"#,
+    )
+    .unwrap();
+    let public_key = private_key.to_public_key().unwrap();
+
+    for plaintext in ["", "hunter2", "a longer password with spaces and \u{1f600}"] {
+        let wire = EncryptedWire::encrypt(plaintext, &public_key).unwrap();
+        let recovered = wire.decrypt(std::sync::Arc::new(private_key.clone())).unwrap();
+        assert_eq!(plaintext, &recovered);
     }
 }
 


### PR DESCRIPTION
## Why

A freshly booted StartOS install ISO can't be brought to a clean baseline
state purely over the network today: the setup wizard's API endpoints are
all marked `.no_cli()`, so the only thing that can drive them is the
embedded web UI in setup mode. That blocks unattended bring-up — CI
runners, automated test fixtures, fleet provisioning, and the helix VM
template flow all need to drive setup with no human at the device.

This PR teaches `start-cli` to drive setup mode end-to-end against a
remote IP, so the unattended path is:

```bash
# 1. Boot ISO, peer host gets its IP.
# 2. Inspect.
start-cli --host <ip> setup status
start-cli --host <ip> setup disk list

# 3. Install OS to disk (uses /run/live/medium/live/filesystem.squashfs).
start-cli --host <ip> setup install-os /dev/vda --data-drive /dev/vda

# 4. Finalise (or `setup attach` if reusing an existing data drive).
start-cli --host <ip> setup execute --guid <GUID> --password <PW>

# 5. Wait for completion, then commit.
start-cli --host <ip> setup status      # poll until Complete
start-cli --host <ip> setup complete
start-cli --host <ip> setup exit        # reboots into installed OS
```

## What

Three commits, one capability per commit, behaviour over JSON-RPC
unchanged so the web UI keeps working:

1. **expose read-only and lifecycle setup commands to CLI** — `status`,
   `disk list`, `get-pubkey`, `complete`, `exit`, `restart`, `shutdown`,
   `set-language`, `set-keyboard`. Pure plumbing: drop `.no_cli()` and
   add `.with_call_remote::<CliContext>()`, with `.with_display_serializable()`
   for endpoints that return structured data.

2. **expose `setup install-os` to CLI** — `InstallOsParams` already
   derives `clap::Parser`, just needed the CLI binding. Also drops
   `#[group(skip)]` from the inner `DataDrive` struct, which clap
   rejects when the wrapper field is `Option<DataDrive>` and uses
   `#[command(flatten)]` (panics at parse time as soon as the command
   becomes reachable from CLI).

3. **expose `setup execute` and `setup attach` to CLI; accept plaintext
   passwords** — switches `Option<EncryptedWire>` to `Option<PasswordType>`
   on both. `PasswordType` is the existing untagged enum used by `auth`:
   it deserialises either a plain string or an `EncryptedWire` JWE blob,
   so the web UI's encrypted payloads keep working unchanged. The CLI
   passes plaintext over the LAN (setup mode is unauthenticated and runs
   plain HTTP regardless — the JWE was a half-measure, not a security
   boundary). Recovery flows stay JSON-only via `#[arg(skip)]` on
   `recovery_source`; typical fresh-install is a single CLI call.

## Validation

`cargo check` and `cargo build --bin start-cli` clean. End-to-end
validation on a libvirt VM driven from a peer host is in progress; will
report follow-ups as separate commits if more gaps surface.

## Notes for reviewers

- Setup mode has only CORS middleware, not auth, so no signature/cookie
  dance is needed for the CLI side.
- `PasswordType: FromStr` already exists, so clap parses `--password
  <plain>` correctly. JSON input from web UI still routes through serde.
- I deliberately did not touch `verify_cifs` (CIFS recovery params) —
  it's still `EncryptedWire`-only, since CIFS recovery isn't on the
  unattended bring-up critical path. Happy to follow up if desired.
