### PR TITLE
docs(contributing): drop --branch next/major from clone snippet; clarify PR target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,7 @@ git clone --recursive https://github.com/Start9Labs/start-os.git
 cd start-os
 ```
 
-The default branch is `master`, which is also the PR target for
-bug fixes and most features. `next/major` is a long-lived branch
-holding work for the next major release; only target it for changes
-that must wait for that bump.
+StartOS has 4 major branches for integration. `master` is for the current release. If the current latest release is a pre-release (i.e. "beta.X"), PRs for new features and bugfixes should go here. Otherwise we have `next/` branches depending on which release of StartOS the changes should be included in; `next/patch` for the next patch release, `next/minor` for the next minor release, and `next/major` for the next major release. If you are unsure which branch to target, ask a maintainer.
 
 ### Development Mode
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,14 @@ nvm alias default 24 # this prevents your machine from reverting back to another
 ### Cloning the Repository
 
 ```sh
-git clone --recursive https://github.com/Start9Labs/start-os.git --branch next/major
+git clone --recursive https://github.com/Start9Labs/start-os.git
 cd start-os
 ```
+
+The default branch is `master`, which is also the PR target for
+bug fixes and most features. `next/major` is a long-lived branch
+holding work for the next major release; only target it for changes
+that must wait for that bump.
 
 ### Development Mode
 


### PR DESCRIPTION
## Why

The "Cloning the Repository" snippet in CONTRIBUTING.md tells you to clone with `--branch next/major`:

```sh
git clone --recursive https://github.com/Start9Labs/start-os.git --branch next/major
```

…but `master` is the actual default branch and the PR target. I tripped on this myself and opened #3196 against `next/major` before noticing every other recent PR (#3190…#3197) targets `master`. Easy mistake to make from the doc as written.

## What

- Drop the `--branch next/major` flag from the clone command so a fresh checkout lands on the default branch.
- Add a short paragraph clarifying that `master` is the PR target and `next/major` is the long-lived branch for the next major release (only target it for changes that must wait for that bump).

No build / behaviour changes — docs only.
