### PR TITLE
fix(tunnel/web): allow non-ECDSA leaves in import-certificate

### DIFF
--- a/core/src/tunnel/web.rs
+++ b/core/src/tunnel/web.rs
@@ -252,7 +252,14 @@ pub async fn import_certificate_cli(
                     }
                 }
 
-                let is_root = cert.0.verify(&pubkey)?;
+                // Self-signed check used purely as an end-of-chain sentinel.
+                // `X509::verify` returns Err (rather than Ok(false)) when the cert's
+                // signature algorithm is incompatible with the candidate pubkey type
+                // (e.g. an Ed25519 leaf whose signature is ECDSA from a p256 issuer
+                // is verified here against its own Ed25519 pubkey). Treat any such
+                // mismatch as "not self-signed" so non-ECDSA leaves don't blow up
+                // import with a raw OpenSSL error.
+                let is_root = cert.0.verify(&pubkey).unwrap_or(false);
 
                 chain.push(cert.0);
 


### PR DESCRIPTION
## Problem

`start-tunnel web import-certificate` fails on certs produced by `start-cli net ssl generate-certificate --ed25519` with:

```
OpenSSL Internal Error: error:030000EA:digital envelope routines:EVP_DigestVerifyFinal:provider signature failure:...:ECDSA digest_verify_final:,
error:06880006:asn1 encoding routines:ASN1_item_verify_ctx:EVP lib:...,
error:068000C8:asn1 encoding routines:ASN1_item_verify_ctx:wrong public key type:...
```

## Cause

`import_certificate_cli` in `core/src/tunnel/web.rs` runs a self-signed sentinel check on every pasted cert:

```rust
let is_root = cert.0.verify(&pubkey)?;   // pubkey = cert.public_key()
```

OpenSSL's `X509_verify` returns an `Err` (not `Ok(false)`) when the cert's signature algorithm is incompatible with the candidate pubkey type. An Ed25519 leaf is signed with ECDSA-SHA256 (its p256 intermediate's algorithm) but its own pubkey is Ed25519, so verifying the leaf against itself trips ASN1_item_verify_ctx → `wrong public key type`. The `?` then aborts the whole import.

## Fix

Treat any verify error on the self-signed-detection path as "not self-signed". This is purely an end-of-chain sentinel and a type-mismatch trivially implies "not self-signed". The real chain-verification step (`prev.verify(&pubkey)?`) is untouched and continues to fail loudly on actual chain mismatches.

## Test

- `cargo check -p start-os --lib` passes.
- Default p256 leaves continue to work (verify returns `Ok(false)` on the leaf, `Ok(true)` on the self-signed root, exactly as before).
- Ed25519 leaves no longer error on the sentinel; the loop terminates at the actual root cert, which is p256 and self-verifies normally.

Reported by @<user> on Matrix; reproduced locally only after passing `--ed25519` to `start-cli net ssl generate-certificate`.