### PR TITLE
refactor(core/net): expose CertBranding for downstream cert issuance

### DIFF
--- a/core/src/account.rs
+++ b/core/src/account.rs
@@ -7,7 +7,7 @@ use openssl::x509::X509;
 
 use crate::db::model::DatabaseModel;
 use crate::hostname::{ServerHostnameInfo, generate_hostname, generate_id};
-use crate::net::ssl::{gen_nistp256, make_root_cert};
+use crate::net::ssl::{CertBranding, gen_nistp256, make_root_cert};
 use crate::prelude::*;
 use crate::util::serde::Pem;
 
@@ -43,7 +43,8 @@ impl AccountInfo {
             ServerHostnameInfo::from_hostname(generate_hostname())
         };
         let root_ca_key = gen_nistp256()?;
-        let root_ca_cert = make_root_cert(&root_ca_key, &hostname.hostname, start_time)?;
+        let branding = CertBranding::start_os(hostname.hostname.as_ref());
+        let root_ca_cert = make_root_cert(&root_ca_key, &branding, start_time)?;
         let ssh_key = ssh_key::PrivateKey::from(ssh_key::private::Ed25519Keypair::random(
             &mut ssh_key::rand_core::OsRng::default(),
         ));
@@ -107,8 +108,12 @@ impl AccountInfo {
                 .as_root_cert_mut()
                 .ser(Pem::new_ref(&self.root_ca_cert))?;
             let int_key = crate::net::ssl::gen_nistp256()?;
-            let int_cert =
-                crate::net::ssl::make_int_cert((&self.root_ca_key, &self.root_ca_cert), &int_key)?;
+            let branding = CertBranding::start_os(self.hostname.hostname.as_ref());
+            let int_cert = crate::net::ssl::make_int_cert(
+                (&self.root_ca_key, &self.root_ca_cert),
+                &int_key,
+                &branding,
+            )?;
             cert_store.as_int_key_mut().ser(&Pem(int_key))?;
             cert_store.as_int_cert_mut().ser(&Pem(int_cert))?;
             cert_store.as_leaves_mut().ser(&BTreeMap::new())?;

--- a/core/src/net/keys.rs
+++ b/core/src/net/keys.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::account::AccountInfo;
 use crate::net::acme::AcmeCertStore;
-use crate::net::ssl::CertStore;
+use crate::net::ssl::{CertBranding, CertStore};
 use crate::prelude::*;
 
 #[derive(Debug, Deserialize, Serialize, HasModel)]
@@ -15,8 +15,9 @@ pub struct KeyStore {
 }
 impl KeyStore {
     pub fn new(account: &AccountInfo) -> Result<Self, Error> {
+        let branding = CertBranding::start_os(account.hostname.hostname.as_ref());
         Ok(Self {
-            local_certs: CertStore::new(account)?,
+            local_certs: CertStore::new(account, &branding)?,
             acme: AcmeCertStore::new(),
         })
     }

--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -76,20 +76,23 @@ impl NetController {
             ],
         )
         .await?;
-        let passthroughs = db
-            .peek()
-            .await
+        let peek = db.peek().await;
+        let passthroughs = peek
             .as_public()
             .as_server_info()
             .as_network()
             .as_passthroughs()
             .de()?;
+        let hostname = peek.as_public().as_server_info().as_hostname().de()?;
+        drop(peek);
+        let branding = crate::net::ssl::CertBranding::start_os(&hostname);
         Ok(Self {
             db: db.clone(),
             vhost: VHostController::new(
                 db.clone(),
                 net_iface.clone(),
                 crypto_provider,
+                branding,
                 passthroughs,
             ),
             tls_client_config,

--- a/core/src/net/ssl.rs
+++ b/core/src/net/ssl.rs
@@ -37,7 +37,6 @@ use crate::account::AccountInfo;
 use crate::context::{CliContext, RpcContext};
 use crate::db::model::Database;
 use crate::db::{DbAccess, DbAccessMut};
-use crate::hostname::ServerHostname;
 use crate::init::check_time_is_synchronized;
 use crate::net::gateway::GatewayInfo;
 use crate::net::tls::{TlsHandler, TlsHandlerAction};
@@ -56,6 +55,30 @@ pub fn should_use_cert(cert: &X509Ref) -> Result<bool, ErrorStack> {
             == Ordering::Greater)
 }
 
+/// Controls the strings baked into generated certificates (Subject CN, O, OU).
+/// Exposed so downstream consumers can issue certs with their own branding
+/// without having to reimplement the X.509 builders. Not persisted — callers
+/// construct this on demand (typically from hostname + their own labels).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CertBranding {
+    pub organization: InternedString,
+    pub organizational_unit: InternedString,
+    pub root_ca_cn: InternedString,
+    pub intermediate_ca_cn: InternedString,
+}
+impl CertBranding {
+    pub fn start_os(hostname: &str) -> Self {
+        Self {
+            organization: InternedString::intern("Start9"),
+            organizational_unit: InternedString::intern("StartOS"),
+            root_ca_cn: InternedString::from_display(&lazy_format::lazy_format!(
+                "{hostname} Local Root CA"
+            )),
+            intermediate_ca_cn: InternedString::intern("StartOS Local Intermediate CA"),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, HasModel)]
 #[model = "Model<Self>"]
 #[serde(rename_all = "camelCase")]
@@ -67,9 +90,13 @@ pub struct CertStore {
     pub leaves: BTreeMap<JsonKey<BTreeSet<InternedString>>, CertData>,
 }
 impl CertStore {
-    pub fn new(account: &AccountInfo) -> Result<Self, Error> {
+    pub fn new(account: &AccountInfo, branding: &CertBranding) -> Result<Self, Error> {
         let int_key = gen_nistp256()?;
-        let int_cert = make_int_cert((&account.root_ca_key, &account.root_ca_cert), &int_key)?;
+        let int_cert = make_int_cert(
+            (&account.root_ca_key, &account.root_ca_cert),
+            &int_key,
+            branding,
+        )?;
         Ok(Self {
             root_key: Pem::new(account.root_ca_key.clone()),
             root_cert: Pem::new(account.root_ca_cert.clone()),
@@ -84,6 +111,7 @@ impl Model<CertStore> {
     pub fn cert_for(
         &mut self,
         hostnames: &BTreeSet<InternedString>,
+        branding: &CertBranding,
     ) -> Result<FullchainCertData, Error> {
         let keys = if let Some(cert_data) = self
             .as_leaves()
@@ -114,10 +142,12 @@ impl Model<CertStore> {
                 ed25519: make_leaf_cert(
                     (&int_key, &int_cert),
                     (&keys.ed25519, &SANInfo::new(hostnames)),
+                    branding,
                 )?,
                 nistp256: make_leaf_cert(
                     (&int_key, &int_cert),
                     (&keys.nistp256, &SANInfo::new(hostnames)),
+                    branding,
                 )?,
             },
             keys,
@@ -287,7 +317,7 @@ pub fn gen_nistp256() -> Result<PKey<Private>, Error> {
 #[instrument(skip_all)]
 pub fn make_root_cert(
     root_key: &PKey<Private>,
-    hostname: &ServerHostname,
+    branding: &CertBranding,
     start_time: SystemTime,
 ) -> Result<X509, Error> {
     let mut builder = X509Builder::new()?;
@@ -304,10 +334,9 @@ pub fn make_root_cert(
     builder.set_serial_number(&*rand_serial()?)?;
 
     let mut subject_name_builder = X509NameBuilder::new()?;
-    subject_name_builder
-        .append_entry_by_text("CN", &format!("{} Local Root CA", hostname.as_ref()))?;
-    subject_name_builder.append_entry_by_text("O", "Start9")?;
-    subject_name_builder.append_entry_by_text("OU", "StartOS")?;
+    subject_name_builder.append_entry_by_text("CN", &branding.root_ca_cn)?;
+    subject_name_builder.append_entry_by_text("O", &branding.organization)?;
+    subject_name_builder.append_entry_by_text("OU", &branding.organizational_unit)?;
     let subject_name = subject_name_builder.build();
     builder.set_subject_name(&subject_name)?;
 
@@ -346,6 +375,7 @@ pub fn make_root_cert(
 pub fn make_int_cert(
     signer: (&PKey<Private>, &X509),
     applicant: &PKey<Private>,
+    branding: &CertBranding,
 ) -> Result<X509, Error> {
     let mut builder = X509Builder::new()?;
     builder.set_version(CERTIFICATE_VERSION)?;
@@ -357,9 +387,9 @@ pub fn make_int_cert(
     builder.set_serial_number(&*rand_serial()?)?;
 
     let mut subject_name_builder = X509NameBuilder::new()?;
-    subject_name_builder.append_entry_by_text("CN", "StartOS Local Intermediate CA")?;
-    subject_name_builder.append_entry_by_text("O", "Start9")?;
-    subject_name_builder.append_entry_by_text("OU", "StartOS")?;
+    subject_name_builder.append_entry_by_text("CN", &branding.intermediate_ca_cn)?;
+    subject_name_builder.append_entry_by_text("O", &branding.organization)?;
+    subject_name_builder.append_entry_by_text("OU", &branding.organizational_unit)?;
     let subject_name = subject_name_builder.build();
     builder.set_subject_name(&subject_name)?;
 
@@ -471,6 +501,7 @@ impl std::fmt::Display for SANInfo {
 pub fn make_leaf_cert(
     signer: (&PKey<Private>, &X509),
     applicant: (&PKey<Private>, &SANInfo),
+    branding: &CertBranding,
 ) -> Result<X509, Error> {
     let mut builder = X509Builder::new()?;
     builder.set_version(CERTIFICATE_VERSION)?;
@@ -495,8 +526,8 @@ pub fn make_leaf_cert(
             .map(MaybeWildcard::as_str)
             .unwrap_or("localhost"),
     )?;
-    subject_name_builder.append_entry_by_text("O", "Start9")?;
-    subject_name_builder.append_entry_by_text("OU", "StartOS")?;
+    subject_name_builder.append_entry_by_text("O", &branding.organization)?;
+    subject_name_builder.append_entry_by_text("OU", &branding.organizational_unit)?;
     let subject_name = subject_name_builder.build();
     builder.set_subject_name(&subject_name)?;
 
@@ -534,7 +565,10 @@ pub fn make_leaf_cert(
 }
 
 #[instrument(skip_all)]
-pub fn make_self_signed(applicant: (&PKey<Private>, &SANInfo)) -> Result<X509, Error> {
+pub fn make_self_signed(
+    applicant: (&PKey<Private>, &SANInfo),
+    branding: &CertBranding,
+) -> Result<X509, Error> {
     let mut builder = X509Builder::new()?;
     builder.set_version(CERTIFICATE_VERSION)?;
 
@@ -558,8 +592,8 @@ pub fn make_self_signed(applicant: (&PKey<Private>, &SANInfo)) -> Result<X509, E
             .map(MaybeWildcard::as_str)
             .unwrap_or("localhost"),
     )?;
-    subject_name_builder.append_entry_by_text("O", "Start9")?;
-    subject_name_builder.append_entry_by_text("OU", "StartOS")?;
+    subject_name_builder.append_entry_by_text("O", &branding.organization)?;
+    subject_name_builder.append_entry_by_text("OU", &branding.organizational_unit)?;
     let subject_name = subject_name_builder.build();
     builder.set_subject_name(&subject_name)?;
 
@@ -643,19 +677,21 @@ pub async fn generate_certificate(
     let int_key = cert_store.as_int_key().de()?.0;
     let int_cert = cert_store.as_int_cert().de()?.0;
     let root_cert = cert_store.as_root_cert().de()?.0;
+    let server_hostname = peek.as_public().as_server_info().as_hostname().de()?;
     drop(peek);
 
+    let branding = CertBranding::start_os(&server_hostname);
     let hostnames: BTreeSet<InternedString> =
         hostnames.into_iter().map(InternedString::from).collect();
     let san_info = SANInfo::new(&hostnames);
 
     let (key, cert) = if ed25519 {
         let key = PKey::generate_ed25519()?;
-        let cert = make_leaf_cert((&int_key, &int_cert), (&key, &san_info))?;
+        let cert = make_leaf_cert((&int_key, &int_cert), (&key, &san_info), &branding)?;
         (key, cert)
     } else {
         let key = gen_nistp256()?;
-        let cert = make_leaf_cert((&int_key, &int_cert), (&key, &san_info))?;
+        let cert = make_leaf_cert((&int_key, &int_cert), (&key, &san_info), &branding)?;
         (key, cert)
     };
 
@@ -678,12 +714,14 @@ pub async fn generate_certificate(
 pub struct RootCaTlsHandler<M: HasModel> {
     pub db: TypedPatchDb<M>,
     pub crypto_provider: Arc<CryptoProvider>,
+    pub branding: CertBranding,
 }
 impl<M: HasModel> Clone for RootCaTlsHandler<M> {
     fn clone(&self) -> Self {
         Self {
             db: self.db.clone(),
             crypto_provider: self.crypto_provider.clone(),
+            branding: self.branding.clone(),
         }
     }
 }
@@ -722,9 +760,10 @@ where
                     .map(InternedString::from_display),
             )
             .collect();
+        let branding = self.branding.clone();
         let cert = self
             .db
-            .mutate(|db| M::access_mut(db).cert_for(&hostnames))
+            .mutate(move |db| M::access_mut(db).cert_for(&hostnames, &branding))
             .await
             .result
             .log_err()?;

--- a/core/src/net/vhost.rs
+++ b/core/src/net/vhost.rs
@@ -35,7 +35,7 @@ use crate::net::acme::{
 use crate::net::gateway::{
     GatewayInfo, NetworkInterfaceController, NetworkInterfaceListenerAcceptMetadata,
 };
-use crate::net::ssl::{CertStore, RootCaTlsHandler};
+use crate::net::ssl::{CertBranding, CertStore, RootCaTlsHandler};
 use crate::net::tls::{
     ChainedHandler, TlsHandler, TlsHandlerAction, TlsListener, TlsMetadata,
 };
@@ -246,6 +246,7 @@ pub struct VHostController {
     interfaces: Arc<NetworkInterfaceController>,
     crypto_provider: Arc<CryptoProvider>,
     acme_cache: AcmeTlsAlpnCache,
+    branding: CertBranding,
     servers: SyncMutex<BTreeMap<u16, VHostServer<VHostBindListener>>>,
     passthrough_handles: SyncMutex<BTreeMap<(InternedString, u16), PassthroughHandle>>,
 }
@@ -254,6 +255,7 @@ impl VHostController {
         db: TypedPatchDb<Database>,
         interfaces: Arc<NetworkInterfaceController>,
         crypto_provider: Arc<CryptoProvider>,
+        branding: CertBranding,
         passthroughs: Vec<PassthroughInfo>,
     ) -> Self {
         let controller = Self {
@@ -261,6 +263,7 @@ impl VHostController {
             interfaces,
             crypto_provider,
             acme_cache: Arc::new(SyncMutex::new(BTreeMap::new())),
+            branding,
             servers: SyncMutex::new(BTreeMap::new()),
             passthrough_handles: SyncMutex::new(BTreeMap::new()),
         };
@@ -309,6 +312,7 @@ impl VHostController {
             bind_reqs,
             self.db.clone(),
             self.crypto_provider.clone(),
+            self.branding.clone(),
             self.acme_cache.clone(),
         )
     }
@@ -1171,6 +1175,7 @@ impl<A: Accept> VHostServer<A> {
         bind_reqs: Watch<VHostBindRequirements>,
         db: TypedPatchDb<M>,
         crypto_provider: Arc<CryptoProvider>,
+        branding: CertBranding,
         acme_cache: AcmeTlsAlpnCache,
     ) -> Self
     where
@@ -1208,6 +1213,7 @@ impl<A: Accept> VHostServer<A> {
                             RootCaTlsHandler {
                                 db,
                                 crypto_provider: crypto_provider.clone(),
+                                branding,
                             },
                         ),
                         crypto_provider,

--- a/core/src/service/effects/net/ssl.rs
+++ b/core/src/service/effects/net/ssl.rs
@@ -107,10 +107,12 @@ pub async fn get_ssl_certificate(
                     }
                 }
             }
+            let hostname = db.as_public().as_server_info().as_hostname().de()?;
+            let branding = crate::net::ssl::CertBranding::start_os(&hostname);
             db.as_private_mut()
                 .as_key_store_mut()
                 .as_local_certs_mut()
-                .cert_for(&hostnames)
+                .cert_for(&hostnames, &branding)
         })
         .await
         .result?;
@@ -210,10 +212,12 @@ pub async fn get_ssl_key(
                     }
                 }
             }
+            let hostname = db.as_public().as_server_info().as_hostname().de()?;
+            let branding = crate::net::ssl::CertBranding::start_os(&hostname);
             db.as_private_mut()
                 .as_key_store_mut()
                 .as_local_certs_mut()
-                .cert_for(&hostnames)
+                .cert_for(&hostnames, &branding)
         })
         .await
         .result?;

--- a/core/src/tunnel/web.rs
+++ b/core/src/tunnel/web.rs
@@ -18,7 +18,7 @@ use tokio_rustls::rustls::server::ClientHello;
 use ts_rs::TS;
 
 use crate::context::CliContext;
-use crate::hostname::ServerHostname;
+use crate::net::ssl::CertBranding;
 use crate::net::ssl::{SANInfo, root_ca_start_time};
 use crate::net::tls::{TlsHandler, TlsHandlerAction};
 use crate::net::web_server::Accept;
@@ -297,17 +297,17 @@ pub async fn generate_certificate(
 ) -> Result<Pem<Vec<X509>>, Error> {
     let saninfo = SANInfo::new(&subject.into_iter().collect());
 
+    let branding = CertBranding::start_os("start-tunnel");
     let root_key = crate::net::ssl::gen_nistp256()?;
-    let root_cert = crate::net::ssl::make_root_cert(
-        &root_key,
-        &ServerHostname::new("start-tunnel".into())?,
-        root_ca_start_time().await,
-    )?;
+    let root_cert =
+        crate::net::ssl::make_root_cert(&root_key, &branding, root_ca_start_time().await)?;
     let int_key = crate::net::ssl::gen_nistp256()?;
-    let int_cert = crate::net::ssl::make_int_cert((&root_key, &root_cert), &int_key)?;
+    let int_cert =
+        crate::net::ssl::make_int_cert((&root_key, &root_cert), &int_key, &branding)?;
 
     let key = crate::net::ssl::gen_nistp256()?;
-    let cert = crate::net::ssl::make_leaf_cert((&int_key, &int_cert), (&key, &saninfo))?;
+    let cert =
+        crate::net::ssl::make_leaf_cert((&int_key, &int_cert), (&key, &saninfo), &branding)?;
     let chain = Pem(vec![cert, int_cert, root_cert]);
 
     ctx.db


### PR DESCRIPTION
## Summary

- Introduces a public `CertBranding` struct that carries the strings baked into generated certificates (Subject CN, O, OU) and threads it through the cert builders (`make_root_cert`, `make_int_cert`, `make_leaf_cert`, `make_self_signed`) plus `CertStore::new`, `Model<CertStore>::cert_for`, `RootCaTlsHandler`, and `VHostController::new`.
- All in-tree call sites build `CertBranding::start_os(<hostname>)`, so issued certs are byte-for-byte equivalent to before — root CN stays `"<hostname> Local Root CA"`, O=`"Start9"`, OU=`"StartOS"`, intermediate CN=`"StartOS Local Intermediate CA"`.
- Lets downstream consumers (e.g. start-wrt) issue certs with their own branding without forking the X.509 builders.

## Motivation

start-wrt vendors `start-os` as a submodule and generates its own root + leaf certs through these helpers. Hard-coded `"Start9"` / `"StartOS"` literals leak StartOS branding into downstream-issued certs. Making branding a parameter is the smallest change that lets downstreams override CN/O/OU while keeping StartOS behaviour identical.

## Test plan

- [x] `cargo check -p start-os --lib` clean (no new warnings/errors from this change).
- [x] Regenerate a server, confirm Subject of root/intermediate/leaf cert matches the previous values byte-for-byte.
- [x] Smoke test ACME flow + `get-ssl-certificate` / `get-ssl-key` effects unchanged.