### PR TITLE
chore: bump StartOS to 0.4.0-beta.8 and SDK to 1.3.4

### DIFF
--- a/container-runtime/package-lock.json
+++ b/container-runtime/package-lock.json
@@ -37,7 +37,7 @@
     },
     "../sdk/dist": {
       "name": "@start9labs/start-sdk",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6481,7 +6481,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "start-os"
-version = "0.4.0-beta.7"
+version = "0.4.0-beta.8"
 dependencies = [
  "aes",
  "async-acme",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 name = "start-os"
 readme = "README.md"
 repository = "https://github.com/Start9Labs/start-os"
-version = "0.4.0-beta.7" # VERSION_BUMP
+version = "0.4.0-beta.8" # VERSION_BUMP
 
 [lib]
 name = "startos"

--- a/core/src/version/mod.rs
+++ b/core/src/version/mod.rs
@@ -71,8 +71,9 @@ mod v0_4_0_beta_4;
 mod v0_4_0_beta_5;
 mod v0_4_0_beta_6;
 mod v0_4_0_beta_7;
+mod v0_4_0_beta_8;
 
-pub type Current = v0_4_0_beta_7::Version; // VERSION_BUMP
+pub type Current = v0_4_0_beta_8::Version; // VERSION_BUMP
 
 impl Current {
     #[instrument(skip(self, db))]
@@ -211,7 +212,8 @@ enum Version {
     V0_4_0_beta_4(Wrapper<v0_4_0_beta_4::Version>),
     V0_4_0_beta_5(Wrapper<v0_4_0_beta_5::Version>),
     V0_4_0_beta_6(Wrapper<v0_4_0_beta_6::Version>),
-    V0_4_0_beta_7(Wrapper<v0_4_0_beta_7::Version>), // VERSION_BUMP
+    V0_4_0_beta_7(Wrapper<v0_4_0_beta_7::Version>),
+    V0_4_0_beta_8(Wrapper<v0_4_0_beta_8::Version>), // VERSION_BUMP
     Other(exver::Version),
 }
 
@@ -285,7 +287,8 @@ impl Version {
             Self::V0_4_0_beta_4(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_5(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_6(v) => DynVersion(Box::new(v.0)),
-            Self::V0_4_0_beta_7(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
+            Self::V0_4_0_beta_7(v) => DynVersion(Box::new(v.0)),
+            Self::V0_4_0_beta_8(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
             Self::Other(v) => {
                 return Err(Error::new(
                     eyre!("unknown version {v}"),
@@ -351,7 +354,8 @@ impl Version {
             Version::V0_4_0_beta_4(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_5(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_6(Wrapper(x)) => x.semver(),
-            Version::V0_4_0_beta_7(Wrapper(x)) => x.semver(), // VERSION_BUMP
+            Version::V0_4_0_beta_7(Wrapper(x)) => x.semver(),
+            Version::V0_4_0_beta_8(Wrapper(x)) => x.semver(), // VERSION_BUMP
             Version::Other(x) => x.clone(),
         }
     }

--- a/core/src/version/v0_4_0_beta_8.rs
+++ b/core/src/version/v0_4_0_beta_8.rs
@@ -1,0 +1,37 @@
+use exver::{PreReleaseSegment, VersionRange};
+
+use super::v0_3_5::V0_3_0_COMPAT;
+use super::{VersionT, v0_4_0_beta_7};
+use crate::prelude::*;
+
+lazy_static::lazy_static! {
+    static ref V0_4_0_beta_8: exver::Version = exver::Version::new(
+        [0, 4, 0],
+        [PreReleaseSegment::String("beta".into()), 8.into()]
+    );
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Version;
+
+impl VersionT for Version {
+    type Previous = v0_4_0_beta_7::Version;
+    type PreUpRes = ();
+
+    async fn pre_up(self) -> Result<Self::PreUpRes, Error> {
+        Ok(())
+    }
+    fn semver(self) -> exver::Version {
+        V0_4_0_beta_8.clone()
+    }
+    fn compat(self) -> &'static VersionRange {
+        &V0_3_0_COMPAT
+    }
+    #[instrument(skip_all)]
+    fn up(self, _db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+        Ok(Value::Null)
+    }
+    fn down(self, _db: &mut Value) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.3.4 — StartOS 0.4.0-beta.8 (2026-05-02)
+
+### Added
+
+- `ProxyAuth` and `BasicCredential` bindings re-exported from `interfaces/Host`. Pass `auth` on `AddSslOptions` to put a `Bearer` or `Basic` gate in front of an HTTPS bind; the OS reverse proxy validates `Authorization` before forwarding upstream and (for `Basic`) injects the matched username as `X-Forwarded-User`. Setting `auth` implies HTTP-aware proxying. Optional `realm` controls the `WWW-Authenticate` challenge string
+
+### Changed
+
+- Minimum StartOS version bumped to `0.4.0-beta.8` — required for the reverse-proxy auth gate added in this release
+
 ## 1.3.3 — StartOS 0.4.0-beta.6 (2026-04-24)
 
 ### Fixed

--- a/sdk/package/lib/StartSdk.ts
+++ b/sdk/package/lib/StartSdk.ts
@@ -69,7 +69,7 @@ import { createVolumes } from './util/Volume'
 import { getDataVersion, setDataVersion } from './version'
 
 /** The minimum StartOS version required by this SDK release */
-export const OSVersion = testTypeVersion('0.4.0-beta.6')
+export const OSVersion = testTypeVersion('0.4.0-beta.8')
 
 // prettier-ignore
 type AnyNeverCond<T extends any[], Then, Else> = 

--- a/sdk/package/package-lock.json
+++ b/sdk/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -66,7 +66,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1777,7 +1776,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2359,7 +2357,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3531,7 +3528,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -4702,7 +4698,6 @@
       "integrity": "sha512-n7chtCbEoGYRwZZ0i/O3t1cPr6o+d9Xx4Zwy2LYfzv0vjchMBU0tO+qYYyvZloBPcgRgzYvALzGWHe609JjEpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "^10.0.0",
         "source-map-generator": "0.8.0"
@@ -5668,7 +5663,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5797,7 +5791,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6220,7 +6213,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/sdk/package/package.json
+++ b/sdk/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./package/lib/index.js",
   "types": "./package/lib/index.d.ts",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.7",
+  "version": "0.4.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startos-ui",
-      "version": "0.4.0-beta.7",
+      "version": "0.4.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^21.2.1",
@@ -387,7 +387,6 @@
       "integrity": "sha512-xUeKGe4BDQpkz0E6fnAPIJXE0y0nqtap0KhJIBhvN7xi3NenIzTmoi6T9Yv5OOBUdLZbOm4SOel8MhdXiIBpAQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
@@ -415,7 +414,6 @@
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.6.tgz",
       "integrity": "sha512-hk2duJlPJyiMaI9MVWA5XpmlpD9C4n8qgquV/MJ7/n+ZRSwW3w1ndL5qUmA1ki+4Da54v/Rc8Wt5tUS955+93w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.2.6",
         "jsonc-parser": "3.3.1",
@@ -591,7 +589,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.2.tgz",
       "integrity": "sha512-9AsZkwqy07No7+0qPydcJfXB6SpA9qLDBanoesNj5KsiZJ62PJH3oIjVyNeQEEe1HQWmSwBnhwN12OPLNMUlnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -609,7 +606,6 @@
       "integrity": "sha512-I5DOFcIT1HKymyy2f78fjgD0Iv6jG46GbBZ/VxejcnhjubFpuN4CwPdugXf9rIDs8KZQqBzDBFUbq11vnk8h0A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2102.6",
         "@angular-devkit/core": "21.2.6",
@@ -704,7 +700,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.4.tgz",
       "integrity": "sha512-NrP6qOuUpo3fqq14UJ1b2bIRtWsfvxh1qLqOyFV4gfBrHhXd0XffU1LUlUw1qp4w1uBSgPJ0/N5bSPUWrAguVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -721,7 +716,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.4.tgz",
       "integrity": "sha512-9+ulVK3idIo/Tu4X2ic7/V0+Uj7pqrOAbOuIirYe6Ymm3AjexuFRiGBbfcH0VJhQ5cf8TvIJ1fuh+MI4JiRIxA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -735,7 +729,6 @@
       "integrity": "sha512-vGjd7DZo/Ox50pQCm5EycmBu91JclimPtZoyNXu/2hSxz3oAkzwiHCwlHwk2g58eheSSp+lYtYRLmHAqSVZLjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -768,7 +761,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.4.tgz",
       "integrity": "sha512-2+gd67ZuXHpGOqeb2o7XZPueEWEP81eJza2tSHkT5QMV8lnYllDEmaNnkPxnIjSLGP1O3PmiXxo4z8ibHkLZwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -794,7 +786,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.4.tgz",
       "integrity": "sha512-1fOhctA9ADEBYjI3nPQUR5dHsK2+UWAjup37Ksldk/k0w8UpD5YsN7JVNvsDMZRFMucKYcGykPblU7pABtsqnQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -824,7 +815,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.4.tgz",
       "integrity": "sha512-1A9e/cQVu+3BkRCktLcO3RZGuw8NOTHw1frUUrpAz+iMyvIT4sDRFbL+U1g8qmOCZqRNC1Pi1HZfZ1kl6kvrcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -871,7 +861,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.4.tgz",
       "integrity": "sha512-OjWze4XT8i2MThcBXMv7ru1k6/5L6QYZbcXuseqimFCHm2avEJ+mXPovY066fMBZJhqbXdjB82OhHAWkIHjglQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -890,7 +879,6 @@
       "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-21.2.4.tgz",
       "integrity": "sha512-YcPMb0co2hEDwzOG5S27b6f8rotXEUDx88nQuhHDl/ztuzXaxKklJ21qVDVZ0R433YBCRQJl2D6ZrpJojsnBFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -936,7 +924,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1969,7 +1956,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -4277,7 +4263,6 @@
       "resolved": "https://registry.npmjs.org/@taiga-ui/addon-commerce/-/addon-commerce-5.2.0.tgz",
       "integrity": "sha512-2vC630g98yd6sJHppvYASJCUK1JmtzDEX/73pHukuEQpCCXVn/00ZpuGP3ZT2HRswBLHwndbjgWB6E4ZwuSeTw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": ">=2.8.1"
       },
@@ -4344,7 +4329,6 @@
       "resolved": "https://registry.npmjs.org/@taiga-ui/cdk/-/cdk-5.2.0.tgz",
       "integrity": "sha512-9qZQZg/kKemEx0Btgy7UqMTq7Hh1xqPsiD88JEa9Yuwsnp9HCDIKRzR5/1qTCgUn2WfPdkKgG+ZaQFlrwiwsYQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "2.8.1"
       },
@@ -4402,7 +4386,6 @@
       "resolved": "https://registry.npmjs.org/@taiga-ui/core/-/core-5.2.0.tgz",
       "integrity": "sha512-NHfRJIN7z0vkhKrpEE6+bZvTjtQUQ4hQOBuCcwz5tI7NGQjxRQOXOp/lZXMzANzivRjW5mZSbXOLrAcmdBEEpg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": ">=2.8.1"
       },
@@ -4452,7 +4435,6 @@
       "resolved": "https://registry.npmjs.org/@taiga-ui/event-plugins/-/event-plugins-5.0.0.tgz",
       "integrity": "sha512-8AxIUn/lX4kwuDlIFmhElgBNtGDgQVC9/F+3O2A29IcMSt9693KRi8qKwToe9p3UuUsT9nnj5YeE11BtJMG0wA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4518,7 +4500,6 @@
       "resolved": "https://registry.npmjs.org/@taiga-ui/kit/-/kit-5.2.0.tgz",
       "integrity": "sha512-XBAizTCPIHapLo2m9AYLAoad593NntXTmHu5XMvoS1187J8IcPctt6gbwXBm/P7opvvnUYNm80jwXDhf2OL2TQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": ">=2.8.1"
       },
@@ -4549,7 +4530,6 @@
       "resolved": "https://registry.npmjs.org/@taiga-ui/layout/-/layout-5.2.0.tgz",
       "integrity": "sha512-dACdLMg3Fa/vEniKRGGFaBf/BbC3rXtViTUrrjMmEhcFH98M77eybHNdmsF8KBez9PMsnrH2/MhcDy0kzBAdLw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": ">=2.8.1"
       },
@@ -4568,7 +4548,6 @@
       "resolved": "https://registry.npmjs.org/@taiga-ui/polymorpheus/-/polymorpheus-5.0.0.tgz",
       "integrity": "sha512-FRus7OgxYyRuETB17g1/YXYs8PAeF4x8+K4ZDfD3Ede8Vxv/XslAYZvf/Ro0wag6Uiy0kAP4bvSaIGPS1Y8Fyg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.1"
       },
@@ -4707,9 +4686,8 @@
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4740,6 +4718,14 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -5192,7 +5178,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5435,7 +5420,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -6107,7 +6091,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
       "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -6452,7 +6435,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7016,7 +6998,6 @@
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7840,7 +7821,6 @@
       "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.5",
         "parse-node-version": "^1.0.1"
@@ -8227,7 +8207,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -9008,7 +8987,6 @@
       "integrity": "sha512-ASlXEboqt+ZgKzNPx3YCr924xqQRFA5qgm77GHf0Fm13hx7gVFYVm6WCdYZyeX/p9NJjFWAL+mIMfhsx2SHKoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -10079,7 +10057,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10640,7 +10617,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10765,7 +10741,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10789,7 +10764,6 @@
       "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -11580,8 +11554,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -11873,7 +11846,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11896,7 +11868,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/union": {
@@ -12033,7 +12005,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12424,7 +12395,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12443,8 +12413,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.7",
+  "version": "0.4.0-beta.8",
   "author": "Start9 Labs, Inc",
   "homepage": "https://start9.com/",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Releases **StartOS 0.4.0-beta.8** and **SDK 1.3.4**.

### `bump version to beta.8`

Standard version bump per `docs/VERSION_BUMP.md`:

- `core/Cargo.toml` / `core/Cargo.lock` → `0.4.0-beta.8`
- New `core/src/version/v0_4_0_beta_8.rs` migration module (no-op `up`/`down`); `core/src/version/mod.rs` registry updated in all 5 spots, `// VERSION_BUMP` marker moved
- `web/package.json` / `web/package-lock.json` → `0.4.0-beta.8` (lockfile regenerated via `npm install`)

### `bump sdk version to 1.3.4`

- `sdk/package/package.json` → `1.3.4`; lockfile regenerated via `npm install`
- `container-runtime/package-lock.json` → embedded `../sdk/dist` version updated to `1.3.4`
- `sdk/package/lib/StartSdk.ts` → `OSVersion` raised from `0.4.0-beta.6` to `0.4.0-beta.8`
- `sdk/CHANGELOG.md` → new `1.3.4` entry

The SDK surface picked up the reverse-proxy auth gate that landed in master via #3190:

- `ProxyAuth` and `BasicCredential` re-exported from `interfaces/Host`
- New optional `auth: ProxyAuth | null` on `AddSslOptions` — set it on an HTTPS bind to put a `Bearer` or `Basic` gate in front of the upstream service. The OS validates `Authorization` before forwarding and (for `Basic`) injects the matched username as `X-Forwarded-User`. Setting `auth` implies HTTP-aware proxying. Optional `realm` controls the `WWW-Authenticate` challenge

The min-OS bump is required because services using `auth` need the OS reverse proxy on beta.8 to honor it.

## Test plan

- [ ] `make` builds clean (core, web, sdk, container-runtime)
- [ ] `make test-core` passes
- [ ] Existing services (no `auth`) still bind and proxy normally on a beta.8 host
- [ ] A package built with SDK 1.3.4 setting `auth: { type: 'basic', credentials: [...], realm: null }` returns 401 with a `WWW-Authenticate: Basic` challenge to anonymous requests, forwards to upstream with `X-Forwarded-User` once authenticated
- [ ] Bearer flow: `auth: { type: 'bearer', tokens: [...], realm: null }` accepts matching `Authorization: Bearer <token>` and 401s otherwise
- [ ] Database migration from a beta.7 install to beta.8 succeeds (no-op `up()`)