### PR TITLE
fix(cifs): use vers=3 to support older SMB servers

### DIFF
--- a/core/src/disk/mount/filesystem/cifs.rs
+++ b/core/src/disk/mount/filesystem/cifs.rs
@@ -55,7 +55,7 @@ pub async fn mount_cifs(
         .arg(format!("//{}{}", ip, absolute_path.display()))
         .arg(mountpoint.as_ref());
     let mut opts = String::from(
-        "vers=3.1.1,hard,actimeo=0,wsize=1048576,rsize=1048576,nobrl,noserverino",
+        "vers=3,hard,actimeo=0,wsize=1048576,rsize=1048576,nobrl,noserverino",
     );
     match mount_type {
         ReadOnly => opts.push_str(",ro,cache=strict"),


### PR DESCRIPTION
## Summary

- Change the CIFS mount option from `vers=3.1.1` to `vers=3` in `core/src/disk/mount/filesystem/cifs.rs` so the kernel negotiates any SMB 3.x dialect (3.0 / 3.0.2 / 3.1.1) instead of pinning to 3.1.1.
- This lets StartOS mount shares from older SMB servers that don't speak 3.1.1, while still using SMB3 (no fallback to insecure SMB1/2).

## Test plan

- [ ] Verify backups/restore against an SMB 3.0 server (older NAS)
- [ ] Verify backups/restore still work against an SMB 3.1.1 server