### PR TITLE
fix(i18n): break language-change restart-banner loop

### DIFF
--- a/core/src/system/mod.rs
+++ b/core/src/system/mod.rs
@@ -1376,6 +1376,9 @@ pub async fn set_language(
     ctx.db
         .mutate(|db| {
             let server_info = db.as_public_mut().as_server_info_mut();
+            if server_info.as_language().de()?.as_ref() == Some(&language) {
+                return Ok(());
+            }
             server_info.as_language_mut().ser(&Some(language.clone()))?;
             server_info
                 .as_status_info_mut()

--- a/web/projects/shared/src/i18n/i18n.service.ts
+++ b/web/projects/shared/src/i18n/i18n.service.ts
@@ -46,25 +46,22 @@ export class i18nService extends TuiLanguageSwitcherService {
     )
   }
 
-  setLang(language: Languages = 'en_US'): void {
+  setLangLocal(language: Languages = 'en_US'): void {
     const tuiLang = LANGUAGE_TO_TUI[language]
-    const current = this.language
-
     super.setLanguage(tuiLang)
     this.loading.set(true)
+    this.i18nLoader(tuiLang).then(value => {
+      this.i18n.set(value)
+      this.loading.set(false)
+    })
+  }
 
-    if (current === tuiLang) {
-      this.i18nLoader(tuiLang).then(value => {
-        this.i18n.set(value)
-        this.loading.set(false)
-      })
+  setLang(language: Languages = 'en_US'): void {
+    const tuiLang = LANGUAGE_TO_TUI[language]
+    if (this.language === tuiLang) {
+      this.setLangLocal(language)
     } else {
-      this.store(language).then(() =>
-        this.i18nLoader(tuiLang).then(value => {
-          this.i18n.set(value)
-          this.loading.set(false)
-        }),
-      )
+      this.store(language).then(() => this.setLangLocal(language))
     }
   }
 }

--- a/web/projects/ui/src/app/app.component.ts
+++ b/web/projects/ui/src/app/app.component.ts
@@ -45,6 +45,6 @@ export class AppComponent {
     .watch$('serverInfo', 'language')
     .pipe(takeUntilDestroyed())
     .subscribe(language => {
-      this.i18n.setLang(language || 'en_US')
+      this.i18n.setLangLocal(language || 'en_US')
     })
 }


### PR DESCRIPTION
## Summary

Fixes a bug where the "Language changed, restart for installed services to use the new language" banner kept reappearing on every restart when the system locale was non-English (e.g. German). New browsers/devices logging in would re-trigger the banner across all connected clients.

### Root cause

A write-back loop between two innocent-looking pieces of code:

- `set_language` in [core/src/system/mod.rs](core/src/system/mod.rs) unconditionally raised `RestartReason::Language`, even when the new language equalled the stored language.
- The patch-db watch on `serverInfo.language` in [web/projects/ui/src/app/app.component.ts](web/projects/ui/src/app/app.component.ts) called `i18nService.setLang()` to apply the server's language locally — but `setLang()` also calls the `I18N_STORAGE` hook, which is wired to `api.setLanguage()`. So a passive read triggered an active write.

A fresh browser's Taiga `current` language defaults to `english`. If the server's stored language was non-English, every new connection would call `setLang(de_DE)`, which saw `english !== german`, called `store(de_DE)`, and the server happily re-set the restart banner. Patch-db then propagated the new restart reason to every connected client.

English never reproduced because the Taiga default already matched the server's stored locale, so the `current === tuiLang` branch in `setLang` skipped the store.

### Fixes

- **Server-side guard** in `set_language`: skip the mutation when the language is unchanged. Defense in depth — setting a value to itself should never raise a restart prompt.
- **Client-side split**: extracted `setLangLocal()` (loads dictionary, no server write) out of `setLang()`, and use it in `AppComponent`'s patch-db watch so passive sync can no longer write back. `setLang()` is preserved for user-initiated changes in the settings UI and setup wizard.

## Test plan

- [ ] On a server set to English: change language to German via the UI; banner appears.
- [ ] Restart; banner clears.
- [ ] After restart, open a fresh browser/incognito tab and log in; banner does **not** reappear.
- [ ] Open from a second device (e.g. mobile + desktop simultaneously); banner does not reappear on either.
- [ ] Switch back to English; banner appears, restart clears it, fresh browser login does not retrigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)