### PR TITLE
fix(sdk): pin zod to 4.3.6

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.1 — StartOS 0.4.0-beta.8 (2026-05-04)
+
+### Fixed
+
+- Pin `zod` to exact version `4.3.6`. Zod 4.4 changed `.catch()` to no longer fire on missing object keys (only on present-but-invalid values), which silently breaks every package's `.merge({})` seed pattern — required fields with `.catch()` defaults throw `"expected nonoptional, received undefined"` instead of falling back to the default. The previous `^4.3.6` range allowed packages installed after 4.4.0 dropped to pick up the new behavior on `npm install`. Pinning ensures consistent behavior across all packages regardless of when they were installed
+
 ## 1.4.0 — StartOS 0.4.0-beta.8 (2026-05-03)
 
 ### Added

--- a/sdk/package/package-lock.json
+++ b/sdk/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -19,7 +19,7 @@
         "isomorphic-fetch": "^3.0.0",
         "mime": "^4.1.0",
         "yaml": "^2.8.3",
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
         "zod-deep-partial": "^1.2.0"
       },
       "devDependencies": {

--- a/sdk/package/package.json
+++ b/sdk/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./package/lib/index.js",
   "types": "./package/lib/index.d.ts",
@@ -40,7 +40,7 @@
     "isomorphic-fetch": "^3.0.0",
     "mime": "^4.1.0",
     "yaml": "^2.8.3",
-    "zod": "^4.3.6",
+    "zod": "4.3.6",
     "zod-deep-partial": "^1.2.0"
   },
   "prettier": {


### PR DESCRIPTION
## Summary

Zod 4.4 changed `.catch()` so it no longer fires on missing object keys — only on present-but-invalid values. This silently breaks every package's `.merge({})` seed pattern: required fields with `.catch()` defaults throw `\"expected nonoptional, received undefined\"` instead of falling back to the default. Pin zod to exact `4.3.6` to lock in the working behavior across all packages.

## How this surfaced

home-assistant-startos's seed wrote `configuration.yaml` with `default_config` and `http`, missing `automation`/`script`/`scene`. After bumping to SDK 1.4.0 and running `npm install`, npm resolved zod to 4.4.2 (latest matching `^4.3.6`). The seed validation that worked under 4.3.6 now throws on the missing keys, breaking install.

## Reproduction (raw zod, no SDK)

```js
const s = z.object({ x: z.literal(true).catch(true) });
s.parse({});
// 4.3.6 → { x: true }              (catch fires on missing key)
// 4.4.2 → throws \"expected nonoptional, received undefined\"
```

Present-but-invalid values still catch correctly in both versions. The change is specifically about *missing* keys.

## Why exact pin (not `~4.3.6`)

The SDK is the dependency every package shares. Different `npm install` times resolving to different patch versions of zod could produce subtly different behavior between packages. Exact pin guarantees every package gets the same behavior. Loosen later if needed.

## Why this isn't theoretical

Every package using `.merge({})` is one `npm install` away from this regression. Audited the registries — searxng, nostr-rs-relay, mempool, gitea, lnd, bitcoin-knots, datum-gateway, spliit, and others all use the pattern. Most are still on older `package-lock.json` entries that resolved zod to 4.3.x; any reinstall would silently break them.

## Test plan

- [x] Reproduced with raw zod 4.3.6 vs 4.4.2 (no SDK shim)
- [x] `make dist` builds clean; resolved zod is 4.3.6 in the bundled `node_modules`
- [x] Type-check passes
- [ ] Reviewer to confirm pinning to exact version (vs `~4.3.6`) is the right call

🤖 Generated with [Claude Code](https://claude.com/claude-code)