### PR TITLE
fix(net/vhost): bound application-idle proxy connections via TimeoutStream

### DIFF
--- a/core/src/net/http.rs
+++ b/core/src/net/http.rs
@@ -296,12 +296,21 @@ where
                         tokio::task::spawn(async move {
                             if let Some((from, to)) = futures::future::try_join(from, to).await.ok()
                             {
-                                tokio::io::copy_bidirectional(
-                                    &mut TokioIo::new(from),
-                                    &mut TokioIo::new(to),
-                                )
-                                .await
-                                .ok();
+                                // See vhost::IDLE_PROXY_TIMEOUT — bound the
+                                // hang on application-idle upgraded
+                                // connections (HTTP/2 → CONNECT/UDP, WS),
+                                // resetting on every byte transferred.
+                                let mut from = Box::pin(crate::util::io::TimeoutStream::new(
+                                    TokioIo::new(from),
+                                    crate::net::vhost::IDLE_PROXY_TIMEOUT,
+                                ));
+                                let mut to = Box::pin(crate::util::io::TimeoutStream::new(
+                                    TokioIo::new(to),
+                                    crate::net::vhost::IDLE_PROXY_TIMEOUT,
+                                ));
+                                tokio::io::copy_bidirectional(&mut from, &mut to)
+                                    .await
+                                    .ok();
                             }
                         });
                     }
@@ -393,12 +402,23 @@ where
                                     .await
                                     .ok();
                                 } else {
-                                    tokio::io::copy_bidirectional(
-                                        &mut TokioIo::new(from),
-                                        &mut TokioIo::new(to),
-                                    )
-                                    .await
-                                    .ok();
+                                    // See vhost::IDLE_PROXY_TIMEOUT — bound
+                                    // the hang on application-idle WebSocket
+                                    // upgrades, resetting on every byte
+                                    // transferred.
+                                    let mut from =
+                                        Box::pin(crate::util::io::TimeoutStream::new(
+                                            TokioIo::new(from),
+                                            crate::net::vhost::IDLE_PROXY_TIMEOUT,
+                                        ));
+                                    let mut to =
+                                        Box::pin(crate::util::io::TimeoutStream::new(
+                                            TokioIo::new(to),
+                                            crate::net::vhost::IDLE_PROXY_TIMEOUT,
+                                        ));
+                                    tokio::io::copy_bidirectional(&mut from, &mut to)
+                                        .await
+                                        .ok();
                                 }
                             }
                         });

--- a/core/src/net/vhost.rs
+++ b/core/src/net/vhost.rs
@@ -862,12 +862,27 @@ where
                 } else {
                     // copy_bidirectional drains each direction to EOF, then
                     // half-closes the destination (flush + FIN). It won't
-                    // return until both directions have settled. Without a
-                    // per-connection escape hatch that would normally risk
-                    // leaking if one peer stayed idle forever — but both
-                    // TCP sockets have tuned SO_KEEPALIVE (proxy_keepalive)
-                    // so a silent peer errors out within ~2 min, bounding
-                    // the hang without losing in-flight bytes.
+                    // return until both directions have settled, so without
+                    // a per-connection escape hatch a stuck peer would leak
+                    // the proxy task. We bound the hang at two layers:
+                    //
+                    //   1. SO_KEEPALIVE (proxy_keepalive): catches a *silent*
+                    //      peer (kernel detects no probe replies) in ~2 min.
+                    //   2. TimeoutStream wrapper: catches an *application-
+                    //      idle* peer that still ACKs keepalive probes but
+                    //      never moves bytes — the failure mode keepalive
+                    //      alone can't see. The timer resets on every
+                    //      successful read/write, so long-lived flows that
+                    //      occasionally exchange data (WebSockets, SSE,
+                    //      long-polling RPC) stay open indefinitely.
+                    let mut stream = Box::pin(crate::util::io::TimeoutStream::new(
+                        stream,
+                        IDLE_PROXY_TIMEOUT,
+                    ));
+                    let mut prev = Box::pin(crate::util::io::TimeoutStream::new(
+                        prev,
+                        IDLE_PROXY_TIMEOUT,
+                    ));
                     tokio::io::copy_bidirectional(&mut stream, &mut prev)
                         .await
                         .ok();
@@ -886,6 +901,27 @@ fn proxy_keepalive() -> socket2::TcpKeepalive {
         .with_interval(Duration::from_secs(10))
         .with_retries(6)
 }
+
+/// Maximum time a proxied connection may pass without making forward
+/// progress (no bytes read or written in either direction) before we
+/// tear it down. Resets on every successful read/write, so a flow that
+/// is occasionally active (WebSocket heartbeat, SSE event, long-poll
+/// reply) stays open indefinitely.
+///
+/// This complements `proxy_keepalive()`: keepalive catches *silent*
+/// peers (no probe reply); this catches *application-idle* peers that
+/// still ACK at L4 but never advance L7. Without it, a hyper client
+/// pool socket nobody reuses, an abandoned WebSocket upgrade, or a
+/// browser tab whose JS never closed its EventSource pins the proxy
+/// task forever — observed in production as 16k+ ESTABLISHED sockets
+/// piled on `:80` of an internal upstream, all in
+/// `timer:(keepalive,…,0)` (probes succeeding, no L7 progress).
+///
+/// 10 minutes is comfortably longer than any sane keepalive ping in
+/// real protocols (Matrix, Element, Bisq, Nextcloud, gRPC keepalive
+/// defaults are all ≤ 60 s) but tight enough to bound the leak rate
+/// even under aggressive misuse.
+pub(crate) const IDLE_PROXY_TIMEOUT: Duration = Duration::from_secs(600);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -1330,6 +1366,89 @@ async fn copy_bidirectional_hangs_without_keepalive_when_peer_idle() {
         res.is_err(),
         "copy_bidirectional returned without keepalive to break the idle \
          peer out — keepalive tuning is what makes this bounded in prod."
+    );
+
+    proxy.abort();
+}
+
+#[tokio::test]
+async fn idle_timeout_stream_terminates_copy_bidirectional_on_l7_silence() {
+    // Documents the production failure mode that SO_KEEPALIVE alone
+    // cannot catch: both peers ACK keepalive probes (so the kernel
+    // never tears the socket down), but neither side advances a single
+    // L7 byte. The IDLE_PROXY_TIMEOUT wrapper resets on every successful
+    // read/write, so a flow that exchanges *any* data — even a single
+    // heartbeat byte — stays open. A flow that exchanges *nothing* for
+    // longer than the timeout terminates with ErrorKind::TimedOut and
+    // copy_bidirectional returns.
+    //
+    // We use a short timeout (200ms) so the test runs quickly; the
+    // shape is identical to the production 600s default.
+    let (client_facing, _client_side) = tokio::io::duplex(1024);
+    let (backend_facing, _backend_side) = tokio::io::duplex(1024);
+
+    let test_timeout = Duration::from_millis(200);
+    let mut a = Box::pin(crate::util::io::TimeoutStream::new(
+        client_facing,
+        test_timeout,
+    ));
+    let mut b = Box::pin(crate::util::io::TimeoutStream::new(
+        backend_facing,
+        test_timeout,
+    ));
+
+    let started = tokio::time::Instant::now();
+    let res = tokio::time::timeout(
+        Duration::from_secs(2),
+        tokio::io::copy_bidirectional(&mut a, &mut b),
+    )
+    .await;
+
+    assert!(
+        res.is_ok(),
+        "copy_bidirectional should have returned via the idle-progress \
+         timeout, not the outer 2s safety net — leak fix is not wired up"
+    );
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= test_timeout && elapsed < Duration::from_secs(1),
+        "copy_bidirectional returned at {elapsed:?}; expected close to \
+         the {test_timeout:?} idle timeout"
+    );
+}
+
+#[tokio::test]
+async fn idle_timeout_stream_keeps_active_flows_open() {
+    // Inverse of the test above: as long as bytes keep moving (even
+    // sporadically), the idle timer keeps resetting and the proxy stays
+    // open. Models a long-lived WebSocket / SSE stream that sends one
+    // keepalive ping per cycle.
+    let (mut client, client_side) = tokio::io::duplex(1024);
+    let (server_side, mut server) = tokio::io::duplex(1024);
+
+    let idle = Duration::from_millis(100);
+    let mut a = Box::pin(crate::util::io::TimeoutStream::new(client_side, idle));
+    let mut b = Box::pin(crate::util::io::TimeoutStream::new(server_side, idle));
+
+    let proxy = tokio::spawn(async move {
+        tokio::io::copy_bidirectional(&mut a, &mut b).await.ok();
+    });
+
+    // Send a heartbeat byte every 50ms (well within the 100ms idle
+    // window) for 500ms total — would have triggered five timeouts
+    // without resets.
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    for _ in 0..10 {
+        client.write_all(b"x").await.unwrap();
+        let mut buf = [0u8; 1];
+        let _ = server.read_exact(&mut buf).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    assert!(
+        !proxy.is_finished(),
+        "proxy terminated despite continuous heartbeat traffic — the \
+         idle timer is not being reset on byte progress"
     );
 
     proxy.abort();


### PR DESCRIPTION
# bug(net/vhost): idle-but-responsive backend leaks proxy tasks on beta.7

## Summary

`fe6ad5ec fix(core): tune TCP keepalive on vhost proxy sockets` (shipped in `v0.4.0-beta.7`) bounds **silent-peer** death to ~2 min via `SO_KEEPALIVE` (60 s idle / 10 s × 6 probes) but does not bound **application-idle-but-L4-responsive** peers. On a production beta.7 instance proxying a backend HTTP service, this manifests as ~16,600 stuck `ESTABLISHED` sockets pinned in `startd`'s reverse proxy after 6 days, all toward the same `<container_ip>:80`, every one in `timer:(keepalive, …, 0)` (i.e. probes are succeeding), and `startd`'s open-fd count climbing toward the soft limit.

The reproduction is a normal HTTP backend behind the vhost SNI proxy, fronted by long-running clients (browser tabs, hyper client-pool sockets, etc.) that never produce a clean close. Both peers stay alive at L4 — they ACK keepalive probes — but neither side advances a single byte at L7. `tokio::io::copy_bidirectional` parks waiting for one direction to settle, and the proxy task never returns.

The commit that landed in beta.7 acknowledges the gap explicitly:

> // Without a per-connection escape hatch that would normally risk
> // leaking if one peer stayed idle forever — but both
> // TCP sockets have tuned SO_KEEPALIVE (proxy_keepalive)
> // so a silent peer errors out within ~2 min, bounding
> // the hang without losing in-flight bytes.
> *(`core/src/net/vhost.rs` @ beta.7, lines 818-826)*

The "silent peer" assumption is the one that doesn't hold in production: many real upstreams keep the TCP stack alive while the application above it has wandered off.

## Reproduction

A real reproduction is environment-dependent (any backend HTTP service in an internal package container behind the vhost proxy will do), but the diagnostic signature is unambiguous and trivial to read off any affected host.

### Diagnostic signature on a stuck host

```
$ dpkg -s startos | grep Version
Version: 0.4.0-beta.7

$ uptime
… up 6 days, 7:50, …

$ ss -tan state all | awk 'NR>1 {print $1}' | sort | uniq -c | sort -rn
  16680 ESTAB
    258 LISTEN
     14 TIME-WAIT

$ ss -tan state established | awk 'NR>1 {print $4}' \
    | awk -F: '{print $NF}' | sort | uniq -c | sort -rn | head -1
  16661 80
```

>99% of established sockets are on the same destination port (`:80`) — the backend HTTP container fronted by `startd`'s vhost proxy.

### These sockets all belong to `startd`, all to the same container

```
$ sudo ss -tanp state established '( dport = :80 )' | head -5
Recv-Q Send-Q Local Address:Port  Peer Address:Port  Process
0      0      <host>:32768        <container>:80     users:(("startd",pid=1333,fd=7711))
0      0      <host>:32770        <container>:80     users:(("startd",pid=1333,fd=12646))
0      0      <host>:32772        <container>:80     users:(("startd",pid=1333,fd=6282))
0      0      <host>:32773        <container>:80     users:(("startd",pid=1333,fd=14795))
0      0      <host>:32774        <container>:80     users:(("startd",pid=1333,fd=7713))

$ sudo ss -tan state established '( dport = :80 )' \
    | awk 'NR>1 {print $4}' | awk -F: '{print $1}' | sort | uniq -c | sort -rn
  16658 <container_ip>
      2 127.0.0.1
```

Every one is owned by `startd` (pid 1333). The mirror count inside the package container's own netns is identical (`16660 ESTAB`), confirming both ends of these connections are alive in the kernel.

### `startd` fd usage is climbing toward the limit

```
$ sudo ls /proc/1333/fd | wc -l
17023

$ sudo cat /proc/1333/limits | grep 'Max open files'
Max open files            65536                65536                files
```

26% of the process-wide fd budget is held by these stuck sockets. At the observed leak rate (uptime / count ≈ 110 sockets/hour), the soft limit (`65536`) is reachable in ~3 weeks of uninterrupted uptime. We've seen this previously cause the SDK health-check pipeline to fail at `/proc/net/tcp > 1 MB`, which is what surfaced the original bug.

### The smoking-gun socket state — the case `SO_KEEPALIVE` cannot catch

```
$ sudo ss -teno state established '( dport = :80 )' | head -10
Recv-Q Send-Q Local Address:Port  Peer Address:Port
0      0      <host>:53050  127.0.0.1:80   timer:(keepalive,10sec,0) ino:81366100
0      0      <host>:32768  <container>:80 timer:(keepalive,9.360sec,0) ino:43983827
0      0      <host>:32770  <container>:80 timer:(keepalive,16sec,0) ino:68205362
0      0      <host>:32772  <container>:80 timer:(keepalive,,0) ino:35646172
0      0      <host>:32773  <container>:80 timer:(keepalive,16sec,0) ino:76331898
0      0      <host>:32774  <container>:80 timer:(keepalive,9.360sec,0) ino:43983832
0      0      <host>:32776  <container>:80 timer:(keepalive,16sec,0) ino:48685241
0      0      <host>:32778  <container>:80 timer:(keepalive,1.168sec,0) ino:60926048
0      0      <host>:32780  <container>:80 timer:(keepalive,24sec,0) ino:41060407
0      0      <host>:32782  <container>:80 timer:(keepalive,12sec,0) ino:63127470
```

Every stuck socket shows `timer:(keepalive, …, 0)`:

- **The keepalive timer is armed** — `proxy_keepalive()` from beta.7 is active.
- **Retries-pending = `0`** — the peer is *replying* to every probe.
- **`Recv-Q` and `Send-Q` are zero** — neither side has anything queued at L4.

If the peer were silent, the retries column would climb (1 → 2 → … → 6) and the kernel would tear the socket down. It doesn't. The peer is alive and well at L4; it just isn't sending or expecting any L7 bytes. From `tokio::io::copy_bidirectional`'s perspective, both sides are perpetually `Pending`, so it waits forever.

### Concurrent log noise from the surviving paths

```
… startd[1333]: ERROR startos::error: src/error.rs:672:
  Network Error: WebSocket protocol error: Connection reset without
  closing handshake: …
… startd[1333]: ERROR startos::error: src/error.rs:672:
  Network Error: IO error: Connection reset by peer (os error 104): …
```

These fire on the order of every ~40 s. They're the *successful* tear-downs (peer eventually FIN/RSTs); the leak is everything for which that never happens.

## Why beta.7's keepalive doesn't catch this

The beta.7 fix is correct as far as it goes: it replaces `set_keepalive(true)` (which uses the Linux default ~2 h idle) with `set_tcp_keepalive(60 s / 10 s × 6)`, so a *silent* peer is detected within ~2 min. That's a real and useful change — silent peers were a separate failure mode and they are now bounded.

But TCP keepalive only fires when there has been **no activity at all** on the socket for the idle window. The moment the kernel sees a probe reply, the idle timer resets. Probe replies are cheap and fully decoupled from L7 — every modern HTTP server implementation will ACK them as long as the TCP stack is up. So if the upstream is alive enough to answer probes (which is the *normal* state for a healthy HTTP service that just isn't being asked anything), keepalive can never fire.

This is the production state we're observing: 16,661 sockets, all keepalive-armed, retries=0, indefinitely.

The relevant standards-level reference: RFC 1122 §4.2.3.6 says keepalive's only contract is liveness of the peer's TCP implementation, not of any application above it. There is no L4 mechanism for "application made no progress" — that has to be a L7 timer.

## Why a per-connection idle-progress timeout is the right fix

The remaining failure modes for `copy_bidirectional`-fronted proxying are:

| Failure mode                   | Caught by beta.7 keepalive? | Caught by idle-progress timeout? |
|--------------------------------|:--:|:--:|
| Peer crashes / cable cut       | ✅ ~2 min | ✅ |
| Peer's TCP stack is alive, app abandoned (this issue) | ❌ | ✅ |
| Active stream, intermittent bytes (WS heartbeat, SSE) | n/a | ✅ stays open as long as bytes flow |
| Active stream, peak-only bytes (idle minutes between RPCs) | n/a | ⚠️ would close — choose the timeout to bound this |

A per-connection idle-progress timeout (resets on every successful read or write, fires when *no* bytes have moved in either direction for the timeout window) is the natural complement to keepalive. With both:

- Silent peer → keepalive fires in ~2 min.
- L4-responsive but L7-idle peer → idle-progress timer fires.
- Long-lived stream that exchanges any bytes (heartbeats, push events, occasional RPCs) stays open indefinitely.

A 10-minute default is comfortably longer than the keepalive interval used by every long-lived protocol I'm aware of behind StartOS:

| Protocol/service                  | Default keepalive interval |
|-----------------------------------|---------------------------|
| HTTP/2 server-push idle           | varies, typically 30–60 s  |
| WebSocket (RFC 6455) — apps choose | typical 30 s               |
| gRPC client keepalive             | 30 s ping default          |
| Matrix sync long-poll             | 30 s                       |
| SSE retry on disconnect           | 3 s                        |

So a flow that doesn't move at least one byte every 10 minutes is, as a practical matter, leaked.

## Proposed fix

The minimal change is to wrap each side of every `copy_bidirectional` call in the existing `crate::util::io::TimeoutStream` (already in `core/src/util/io.rs`). `TimeoutStream` resets its internal sleep timer on every successful `poll_read` / `poll_write` / `poll_flush` / `poll_shutdown`, returning `ErrorKind::TimedOut` only when the wrapped stream has been silent for the full duration. This is exactly the semantic we want.

There are three call sites in `core/src/net/`:

- `core/src/net/vhost.rs:871` — the SNI passthrough path
- `core/src/net/http.rs:299` — HTTP/2 upgrade tunnel
- `core/src/net/http.rs:396` — HTTP/1 → WebSocket upgrade tunnel

A single shared constant `IDLE_PROXY_TIMEOUT = 600 s` lives next to `proxy_keepalive()` in `vhost.rs`.

(`core/src/net/socks.rs:83` is the SOCKS proxy; same pattern applies but is out of scope for the reported leak.)

**Diff** (against `v0.4.0-beta.8`): see the companion PR.

Two new unit tests verify the shape:

1. **Idle stream → terminates.** Two `tokio::io::duplex` streams with no traffic, both wrapped in `TimeoutStream(200 ms)`, fed to `copy_bidirectional`. Should return within ~200 ms (well below the 2 s outer safety net).
2. **Active stream → stays open.** Heartbeat byte every 50 ms with a 100 ms idle window. After 500 ms the proxy task must still be alive — proves the timer is being reset on byte progress.

The existing beta.7 test (`copy_bidirectional_hangs_without_keepalive_when_peer_idle`) is preserved as documentation of why the keepalive half is necessary in the first place.

## Backward compatibility

- No config surface changes, no new RPC, no SDK change.
- Existing flows are unaffected as long as they exchange ≥ 1 byte per 10 min — true for every long-lived protocol shipped behind StartOS today.
- Connections on the `passthrough: true` path go through the same `copy_bidirectional` site, so they get the same protection. (Worth a sanity check from someone who runs Bisq / Matrix federation through a passthrough binding to make sure 10 min is comfortable; happy to bump the constant if there's a known case below it.)
- This is a host-side behavior change only. No package metadata, no migration, no DB shape change.

## Observed mitigations until this lands

We currently run two ephemeral systemd timers on the StartOS overlay filesystem to bound the leak:

- A 15-minute reaper that `ss -K`s any connection idle > 1 hr on the proxy port.
- A 1-minute watchdog that restarts `startd` if `CLOSE_WAIT` count exceeds a threshold for 3 consecutive checks.

Both work but are crude (the reaper kills *all* idle connections, including legitimate long-lived ones; the watchdog drops every active session on the host when it fires). They also reset on every reboot/upgrade because they live in the overlay. The PR in question makes both unnecessary.

## Source pinpoints

- `core/src/net/vhost.rs` @ `v0.4.0-beta.8`: `proxy_keepalive()` (line 902), `handle_stream` `copy_bidirectional` site (line 871), comment block acknowledging the gap (lines 863-877).
- `core/src/net/http.rs` @ `v0.4.0-beta.8`: `run_http2_proxy` upgrade copy (line 299), `run_http1_proxy` WS upgrade copy (line 396).
- `core/src/util/io.rs` @ `v0.4.0-beta.8`: `TimeoutStream<S>` (line 796) — already in tree, currently unused; this PR would be its first caller.
- `fe6ad5ec` — beta.7 keepalive commit. PR adds a complementary timeout layer on top of, not in place of, that change.

## Offer

PR with the change is in `core/src/net/{vhost,http}.rs`, ~110 lines total including the two new tests. Touches no other layer. Happy to adjust the timeout default, split the `vhost.rs` and `http.rs` halves into two commits, or fold the SOCKS proxy site into the same change if that's preferred.
