### PR TITLE
fix(net): raise TCP listen backlog from mio's hardcoded 128

### DIFF
--- a/core/src/net/gateway.rs
+++ b/core/src/net/gateway.rs
@@ -34,7 +34,7 @@ use crate::db::model::public::{IpInfo, NetworkInterfaceInfo, NetworkInterfaceTyp
 use crate::net::forward::START9_BRIDGE_IFACE;
 use crate::net::gateway::device::DeviceProxy;
 use crate::net::host::all_hosts;
-use crate::net::utils::find_wifi_iface;
+use crate::net::utils::{bind_mio_listener, find_wifi_iface};
 use crate::net::web_server::{Accept, AcceptStream, MetadataVisitor, TcpMetadata};
 use crate::prelude::*;
 use crate::util::Invoke;
@@ -2117,7 +2117,7 @@ pub struct WildcardListener {
 impl WildcardListener {
     pub fn new(port: u16) -> Result<Self, Error> {
         let listener = TcpListener::from_std(
-            mio::net::TcpListener::bind(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port))
+            bind_mio_listener(SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port))
                 .with_kind(ErrorKind::Network)?
                 .into(),
         )

--- a/core/src/net/utils.rs
+++ b/core/src/net/utils.rs
@@ -17,6 +17,37 @@ use crate::db::model::public::{IpInfo, NetworkInterfaceType};
 use crate::prelude::*;
 use crate::util::Invoke;
 
+// mio/tokio's TcpListener::bind hardcodes listen(128), which overflows the
+// accept queue on the vhost proxy under burst load.
+const LISTEN_BACKLOG: i32 = 1024;
+
+fn build_listen_socket(addr: SocketAddr) -> std::io::Result<std::net::TcpListener> {
+    let domain = match addr {
+        SocketAddr::V4(_) => socket2::Domain::IPV4,
+        SocketAddr::V6(_) => socket2::Domain::IPV6,
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+    socket.set_reuse_address(true)?;
+    socket.set_nonblocking(true)?;
+    socket.bind(&addr.into())?;
+    socket.listen(LISTEN_BACKLOG)?;
+    Ok(socket.into())
+}
+
+/// Bind a `mio::net::TcpListener` with an explicit listen backlog
+/// ([`LISTEN_BACKLOG`]) instead of mio's hardcoded 128. Use everywhere we'd
+/// otherwise reach for `mio::net::TcpListener::bind`.
+pub fn bind_mio_listener(addr: SocketAddr) -> std::io::Result<mio::net::TcpListener> {
+    Ok(mio::net::TcpListener::from_std(build_listen_socket(addr)?))
+}
+
+/// Bind a `tokio::net::TcpListener` with an explicit listen backlog
+/// ([`LISTEN_BACKLOG`]) instead of tokio's hardcoded 128. Use everywhere we'd
+/// otherwise reach for `tokio::net::TcpListener::bind`.
+pub fn bind_tokio_listener(addr: SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
+    tokio::net::TcpListener::from_std(build_listen_socket(addr)?)
+}
+
 pub async fn load_ip_info() -> Result<BTreeMap<GatewayId, IpInfo>, Error> {
     let output = String::from_utf8(
         Command::new("ip")

--- a/core/src/net/vhost.rs
+++ b/core/src/net/vhost.rs
@@ -39,7 +39,7 @@ use crate::net::ssl::{CertBranding, CertStore, RootCaTlsHandler};
 use crate::net::tls::{
     ChainedHandler, TlsHandler, TlsHandlerAction, TlsListener, TlsMetadata,
 };
-use crate::net::utils::{ipv6_is_link_local, is_private_ip};
+use crate::net::utils::{bind_mio_listener, ipv6_is_link_local, is_private_ip};
 use crate::net::web_server::{Accept, AcceptStream, ExtractVisitor, TcpMetadata, extract};
 use crate::prelude::*;
 use crate::util::collections::EqSet;
@@ -476,7 +476,7 @@ fn update_vhost_listeners(
                         };
                     } else {
                         let tcp = TcpListener::from_std(
-                            mio::net::TcpListener::bind(addr)
+                            bind_mio_listener(addr)
                                 .with_kind(ErrorKind::Network)?
                                 .into(),
                         )

--- a/core/src/net/web_server.rs
+++ b/core/src/net/web_server.rs
@@ -19,6 +19,7 @@ use tokio::sync::oneshot;
 use visit_rs::{Visit, VisitFields, Visitor};
 
 use crate::net::static_server::{UiContext, ui_router};
+use crate::net::utils::bind_tokio_listener;
 use crate::prelude::*;
 use crate::util::actor::background::BackgroundJobQueue;
 use crate::util::future::NonDetachingJoinHandle;
@@ -300,20 +301,24 @@ impl<A: Accept + Send + Sync + 'static> Acceptor<A> {
 impl Acceptor<Vec<TcpListener>> {
     pub async fn bind(listen: impl IntoIterator<Item = SocketAddr>) -> Result<Self, Error> {
         Ok(Self::new(
-            futures::future::try_join_all(listen.into_iter().map(TcpListener::bind)).await?,
+            listen
+                .into_iter()
+                .map(|addr| bind_tokio_listener(addr).with_kind(ErrorKind::Network))
+                .collect::<Result<Vec<_>, _>>()?,
         ))
     }
 }
 impl Acceptor<Vec<DynAccept>> {
     pub async fn bind_dyn(listen: impl IntoIterator<Item = SocketAddr>) -> Result<Self, Error> {
         Ok(Self::new(
-            futures::future::try_join_all(
-                listen
-                    .into_iter()
-                    .map(TcpListener::bind)
-                    .map(|f| f.map_ok(DynAccept::new)),
-            )
-            .await?,
+            listen
+                .into_iter()
+                .map(|addr| {
+                    bind_tokio_listener(addr)
+                        .with_kind(ErrorKind::Network)
+                        .map(DynAccept::new)
+                })
+                .collect::<Result<Vec<_>, _>>()?,
         ))
     }
 }
@@ -325,17 +330,14 @@ where
         listen: impl IntoIterator<Item = (K, SocketAddr)>,
     ) -> Result<Self, Error> {
         Ok(Self::new(
-            futures::future::try_join_all(listen.into_iter().map(|(key, addr)| async move {
-                Ok::<_, Error>((
-                    key,
-                    TcpListener::bind(addr)
-                        .await
-                        .with_kind(ErrorKind::Network)?,
-                ))
-            }))
-            .await?
-            .into_iter()
-            .collect(),
+            listen
+                .into_iter()
+                .map(|(key, addr)| {
+                    bind_tokio_listener(addr)
+                        .with_kind(ErrorKind::Network)
+                        .map(|l| (key, l))
+                })
+                .collect::<Result<BTreeMap<_, _>, _>>()?,
         ))
     }
 }
@@ -347,18 +349,14 @@ where
         listen: impl IntoIterator<Item = (K, SocketAddr)>,
     ) -> Result<Self, Error> {
         Ok(Self::new(
-            futures::future::try_join_all(listen.into_iter().map(|(key, addr)| async move {
-                Ok::<_, Error>((
-                    key,
-                    TcpListener::bind(addr)
-                        .await
-                        .with_kind(ErrorKind::Network)?,
-                ))
-            }))
-            .await?
-            .into_iter()
-            .map(|(key, listener)| (key, listener.into_dyn()))
-            .collect(),
+            listen
+                .into_iter()
+                .map(|(key, addr)| {
+                    bind_tokio_listener(addr)
+                        .with_kind(ErrorKind::Network)
+                        .map(|l| (key, l.into_dyn()))
+                })
+                .collect::<Result<BTreeMap<_, _>, _>>()?,
         ))
     }
 }


### PR DESCRIPTION
## Summary

Customer-reported `TcpExtListenOverflows` on the StartOS reverse proxy under bursty load. Symptom from `ss -ltn` on the affected host: `Recv-Q > Send-Q=128` on every vhost listener (`*:443`, `*:80`, dynamic service ports), the same port appearing on LAN + WG + lxcbr0 + IPv6 GUA + ULA simultaneously — one queue per (gateway IP, port) pair, all of them 128-deep.

Root cause: mio 1.2.0's `TcpListener::bind` hardcodes `listen(128)`:

```rust
// mio-1.2.0/src/net/tcp/listener.rs:87-94
let backlog = if cfg!(target_os = "horizon") { 20 }
    else if cfg!(target_os = "haiku") { 32 }
    else { 128 };
listen(&listener.inner, backlog)?;
```

`tokio::net::TcpListener::bind` goes through the same path, so it inherits the same 128. `net.core.somaxconn` defaults to 4096 on Debian Trixie and isn't overridden anywhere in the repo, so the kernel isn't the bottleneck — mio is.

## Fix

New `bind_mio_listener` / `bind_tokio_listener` helpers in `core/src/net/utils.rs` build the socket via `socket2` and call `listen(LISTEN_BACKLOG)` explicitly. Every reverse-proxy / web-server listen site is routed through them:

- `core/src/net/vhost.rs` — `VHostBindListener` (per-(gateway IP, port) listener; the listener fingerprint in the report)
- `core/src/net/gateway.rs` — `WildcardListener::new` (used by `startd` for `:80`)
- `core/src/net/web_server.rs` — `Acceptor::{bind, bind_dyn, bind_map, bind_map_dyn}` (registry, tunnel, setup-mode HTTP)

`LISTEN_BACKLOG = 1024` — the historical Rust stdlib value, what most reverse proxies use, and comfortably below the default `somaxconn=4096` so the kernel doesn't truncate it. Not exposed as config; happy to wire that through if there's appetite.

## Out of scope

`core/src/net/dns.rs`, `core/src/net/socks.rs`, `core/src/tunnel/web.rs`, and `core/src/bins/tunnel.rs` use the same mio primitive and would benefit from the same change, but they aren't part of the reported overflow surface and are left for a follow-up to keep this PR focused.

## Test plan

- [x] `cargo check -p start-os --lib` — clean.
- [x] `cargo test -p start-os --lib net::` — all 85 tests pass (including `vhost::copy_bidirectional_hangs_without_keepalive_when_peer_idle`).
- [ ] **Manual verification on an affected box**:
  ```
  nstat -n && sleep 10 && nstat | grep -iE 'listen|overflow'   # quiet after upgrade
  ss -ltn | awk 'NR==1 || $2 > $3'                              # no Recv-Q > Send-Q rows
  ss -ltn                                                       # Send-Q on proxy listeners reads 1024, not 128
  ```
  `TcpExtListenOverflows` should stop incrementing.