### PR TITLE
fix(net): apply tuned TCP keepalive on every accepted listener socket

### DIFF
--- a/core/src/net/gateway.rs
+++ b/core/src/net/gateway.rs
@@ -2146,7 +2146,9 @@ impl Accept for WildcardListener {
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(Self::Metadata, AcceptStream), Error>> {
         if let Poll::Ready((stream, peer_addr)) = TcpListener::poll_accept(&self.listener, cx)? {
-            if let Err(e) = socket2::SockRef::from(&stream).set_keepalive(true) {
+            if let Err(e) = socket2::SockRef::from(&stream)
+                .set_tcp_keepalive(&crate::net::utils::default_keepalive())
+            {
                 tracing::error!("Failed to set tcp keepalive: {e}");
                 tracing::debug!("{e:?}");
             }

--- a/core/src/net/utils.rs
+++ b/core/src/net/utils.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::path::Path;
+use std::time::Duration;
 
 use async_stream::try_stream;
 use color_eyre::eyre::eyre;
@@ -46,6 +47,14 @@ pub fn bind_mio_listener(addr: SocketAddr) -> std::io::Result<mio::net::TcpListe
 /// otherwise reach for `tokio::net::TcpListener::bind`.
 pub fn bind_tokio_listener(addr: SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
     tokio::net::TcpListener::from_std(build_listen_socket(addr)?)
+}
+
+/// Detect silent peer death within ~2 min instead of the Linux default ~2h.
+pub fn default_keepalive() -> socket2::TcpKeepalive {
+    socket2::TcpKeepalive::new()
+        .with_time(Duration::from_secs(60))
+        .with_interval(Duration::from_secs(10))
+        .with_retries(6)
 }
 
 pub async fn load_ip_info() -> Result<BTreeMap<GatewayId, IpInfo>, Error> {

--- a/core/src/net/vhost.rs
+++ b/core/src/net/vhost.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::net::{IpAddr, SocketAddr, SocketAddrV6};
 use std::sync::{Arc, Weak};
 use std::task::{Poll, ready};
-use std::time::Duration;
 
 use async_acme::acme::ACME_TLS_ALPN_NAME;
 use clap::Parser;
@@ -522,7 +521,8 @@ impl Accept for VHostBindListener {
             match listener.poll_accept(cx) {
                 Poll::Ready(Ok((stream, peer_addr))) => {
                     if let Err(e) =
-                        socket2::SockRef::from(&stream).set_tcp_keepalive(&proxy_keepalive())
+                        socket2::SockRef::from(&stream)
+                            .set_tcp_keepalive(&crate::net::utils::default_keepalive())
                     {
                         tracing::error!("Failed to set tcp keepalive: {e}");
                         tracing::debug!("{e:?}");
@@ -777,8 +777,8 @@ where
             .await
             .with_ctx(|_| (ErrorKind::Network, self.addr))
             .log_err()?;
-        if let Err(e) =
-            socket2::SockRef::from(&tcp_stream).set_tcp_keepalive(&proxy_keepalive())
+        if let Err(e) = socket2::SockRef::from(&tcp_stream)
+            .set_tcp_keepalive(&crate::net::utils::default_keepalive())
         {
             tracing::error!("Failed to set tcp keepalive: {e}");
             tracing::debug!("{e:?}");
@@ -865,7 +865,7 @@ where
                     // return until both directions have settled. Without a
                     // per-connection escape hatch that would normally risk
                     // leaking if one peer stayed idle forever — but both
-                    // TCP sockets have tuned SO_KEEPALIVE (proxy_keepalive)
+                    // TCP sockets have tuned SO_KEEPALIVE (default_keepalive)
                     // so a silent peer errors out within ~2 min, bounding
                     // the hang without losing in-flight bytes.
                     tokio::io::copy_bidirectional(&mut stream, &mut prev)
@@ -876,15 +876,6 @@ where
             .await
         });
     }
-}
-
-/// Detect silent peer death in ~2 min instead of the Linux default ~2h.
-/// 60s idle + 10s × 6 probes.
-fn proxy_keepalive() -> socket2::TcpKeepalive {
-    socket2::TcpKeepalive::new()
-        .with_time(Duration::from_secs(60))
-        .with_interval(Duration::from_secs(10))
-        .with_retries(6)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, TS)]
@@ -1301,8 +1292,10 @@ impl<A: Accept> VHostServer<A> {
 
 #[tokio::test]
 async fn copy_bidirectional_hangs_without_keepalive_when_peer_idle() {
-    // Documents why we tune TCP keepalive on both proxy sockets (see
-    // proxy_keepalive()). `tokio::io::copy_bidirectional` drains each
+    use std::time::Duration;
+    // Documents why we tune TCP keepalive on every accepted/connected
+    // socket (see `crate::net::utils::default_keepalive`).
+    // `tokio::io::copy_bidirectional` drains each
     // direction to EOF, half-closes the destination, and only returns
     // once both directions have settled. If one peer closes but the other
     // stays open (idle HTTP keep-alive, stuck WebSocket, misbehaving

--- a/core/src/net/web_server.rs
+++ b/core/src/net/web_server.rs
@@ -107,7 +107,9 @@ impl Accept for TcpListener {
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(Self::Metadata, AcceptStream), Error>> {
         if let Poll::Ready((stream, peer_addr)) = TcpListener::poll_accept(self, cx)? {
-            if let Err(e) = socket2::SockRef::from(&stream).set_keepalive(true) {
+            if let Err(e) = socket2::SockRef::from(&stream)
+                .set_tcp_keepalive(&crate::net::utils::default_keepalive())
+            {
                 tracing::error!("Failed to set tcp keepalive: {e}");
                 tracing::debug!("{e:?}");
             }


### PR DESCRIPTION
## Summary

`Accept for TcpListener` (`core/src/net/web_server.rs`) and `Accept for WildcardListener` (`core/src/net/gateway.rs`) only set `SO_KEEPALIVE` as a boolean, so half-open sockets sit idle for the Linux default (~2h) before the kernel notices the peer is gone. `proxy_keepalive` (60s + 6×10s ≈ 2 min) was tuned correctly but was a private helper in `vhost.rs` and only applied on vhost-managed sockets.

This promotes the helper to `crate::net::utils::default_keepalive` and applies it on every accepted socket in core, so half-open connections from NAT rebinds, dropped Wi-Fi, and slept laptops surface as I/O errors within ~2 min on every listener path — including the basic `WebServer` path used by setup mode and downstream consumers.

No behavioral change for vhost: the timing is identical, the helper is just shared.

## Test plan

- [x] `cargo check -p start-os --lib` — clean
- [x] `cargo test -p start-os --lib net::vhost::copy_bidirectional` — keepalive regression test still passes
- [ ] Confirm under live load that half-open inbound connections to `WebServer` (e.g. setup mode) reap within ~2 min instead of hours