### PR TITLE
fix(core/service, sdk): mirror ExtendedVersion uninit-target cascade for range data versions

### DIFF
--- a/container-runtime/package-lock.json
+++ b/container-runtime/package-lock.json
@@ -37,7 +37,7 @@
     },
     "../sdk/dist": {
       "name": "@start9labs/start-sdk",
-      "version": "1.3.4",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -50,7 +50,7 @@
         "isomorphic-fetch": "^3.0.0",
         "mime": "^4.1.0",
         "yaml": "^2.8.3",
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
         "zod-deep-partial": "^1.2.0"
       },
       "devDependencies": {
@@ -58,7 +58,6 @@
         "jest": "^30.0.0",
         "peggy": "^3.0.2",
         "prettier": "^3.8.3",
-        "shx": "^0.4.0",
         "ts-jest": "^29.4.9",
         "ts-node": "^10.9.1",
         "ts-pegjs": "^4.2.1",
@@ -111,7 +110,6 @@
       "integrity": "sha512-l+lkXCHS6tQEc5oUpK28xBOZ6+HwaH7YwoYQbLFiYb4nS2/l1tKnZEtEWkD0GuiYdvArf9qBS0XlQGXzPMsNqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1202,7 +1200,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.17"
@@ -2146,7 +2143,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -3994,7 +3990,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6555,7 +6550,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -137,7 +137,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1899,7 +1899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1942,8 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "exver"
-version = "0.2.0"
-source = "git+https://github.com/Start9Labs/exver-rs.git#5752d5a4f66967e2bc4b9b7bf340fdaa78d48f07"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff7607fd7425bba8dcde3b5ab4e4cc34904a872f896ba8107df8428d164d9c2"
 dependencies = [
  "either",
  "emver",
@@ -3200,7 +3201,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5628,7 +5629,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5710,7 +5711,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6252,7 +6253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6840,7 +6841,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6870,7 +6871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7542,7 +7543,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8073,7 +8074,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -93,9 +93,7 @@ ed25519-dalek = { version = "2.2.0", features = [
   "zeroize",
 ] }
 ed25519-dalek-v1 = { package = "ed25519-dalek", version = "1" }
-exver = { version = "0.2.0", git = "https://github.com/Start9Labs/exver-rs.git", features = [
-  "serde",
-] }
+exver = { version = "0.2.1", features = ["serde"] }
 fd-lock-rs = "0.1.4"
 form_urlencoded = "1.2.1"
 futures = "0.3.28"

--- a/core/src/service/service_map.rs
+++ b/core/src/service/service_map.rs
@@ -324,22 +324,17 @@ impl ServiceMap {
                                 .can_migrate_to;
                             let next_version = &s9pk.as_manifest().version;
                             let next_can_migrate_from = &s9pk.as_manifest().can_migrate_from;
-                            if let Ok(data_ver_ev) = data_ver.parse::<exver::ExtendedVersion>() {
-                                if data_ver_ev.satisfies(next_can_migrate_from) {
-                                    ExitParams::target_str(data_ver)
-                                } else if next_version.satisfies(prev_can_migrate_to) {
-                                    ExitParams::target_version(&s9pk.as_manifest().version)
-                                } else {
-                                    ExitParams::target_range(&VersionRange::and(
-                                        prev_can_migrate_to.clone(),
-                                        next_can_migrate_from.clone(),
-                                    ))
-                                }
+                            let next_accepts_data_ver = if let Ok(data_ver_ev) =
+                                data_ver.parse::<exver::ExtendedVersion>()
+                            {
+                                data_ver_ev.satisfies(next_can_migrate_from)
                             } else if let Ok(data_ver_range) = data_ver.parse::<VersionRange>() {
-                                ExitParams::target_range(&VersionRange::and(
-                                    data_ver_range,
-                                    next_can_migrate_from.clone(),
-                                ))
+                                data_ver_range.intersects(next_can_migrate_from)
+                            } else {
+                                false
+                            };
+                            if next_accepts_data_ver {
+                                ExitParams::target_str(data_ver)
                             } else if next_version.satisfies(prev_can_migrate_to) {
                                 ExitParams::target_version(&s9pk.as_manifest().version)
                             } else {

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.2 — StartOS 0.4.0-beta.8 (2026-05-06)
+
+### Changed
+
+- `VersionGraph.uninit` now throws when handed a range target with no satisfying version, instead of silently returning without advancing the data version. The previous silent behavior masked host bugs that produced contradictory targets (e.g. an `AND` of a flavored on-disk range with a flavor-less destination's `canMigrateFrom`) — uninit would skip the registered cross-flavor migration, leave the on-disk range untouched, and the destination's init would dead-end with `cannot migrate from <range> to <concrete>` with no signal at the source. Throwing surfaces the contract violation at the source where it can be diagnosed. Packages whose host correctly computes uninit targets are unaffected
+
 ## 1.4.1 — StartOS 0.4.0-beta.8 (2026-05-04)
 
 ### Fixed

--- a/sdk/package/lib/version/VersionGraph.ts
+++ b/sdk/package/lib/version/VersionGraph.ts
@@ -332,7 +332,9 @@ export class VersionGraph<CurrentVersion extends string>
   ): Promise<void> {
     if (target) {
       if (isRange(target) && !target.satisfiable()) {
-        return
+        throw new Error(
+          `uninit target range \`${target.toString()}\` is unsatisfiable — no version can satisfy it (host contract violation)`,
+        )
       }
       const from = await getDataVersion(effects)
       if (from) {

--- a/sdk/package/package-lock.json
+++ b/sdk/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/sdk/package/package.json
+++ b/sdk/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./package/lib/index.js",
   "types": "./package/lib/index.d.ts",


### PR DESCRIPTION
## Summary

Two paired fixes for the cross-flavor data-version dead-end:

### Host (`core/src/service/service_map.rs`)

Mirror the three-branch uninit-target dispatch from the `ExtendedVersion` arm of `ServiceMap::install` for range-typed on-disk data versions:

1. **`data_ver_range.intersects(next.canMigrateFrom)`** — hand the data through (analog of `data_ver_ev.satisfies(next.canMigrateFrom)`).
2. **`next_version.satisfies(prev.canMigrateTo)`** — target the concrete `next_version`.
3. **otherwise** — target `prev.canMigrateTo AND next.canMigrateFrom` (meet in the middle).

Diff is now structurally a 1:1 of the `ExtendedVersion` arm directly above, with `data_ver_ev.satisfies(...)` swapped for `data_ver_range.intersects(...)`.

Bumps `exver` from `0.2.0` → `0.2.1` (Start9Labs/exver-rs#2, now on crates.io), which adds `VersionRange::satisfiable()` and `intersects()` — the Rust crate's smart `and`/`or`/`not` constructors only fold `Any`/`None` and don't detect contradictions like `Flavor(#knots) AND Flavor(null)`, so the range arm's branch 1 (intersection test) needed the new primitive.

### SDK (`sdk/package/lib/version/VersionGraph.ts`)

Tighten `VersionGraph.uninit`'s guard on unsatisfiable range targets — throw with a "host contract violation" message instead of silently returning. The silent skip masked host bugs that produced contradictory targets, leaving stale data on disk for the destination's init to choke on. Throwing surfaces the violation at the source with a useful message. Bumps SDK 1.4.1 → 1.4.2.

## Background

Reproduced via Knots ↔ bip-110 round-trip on the Bitcoin packages. After one round-trip the on-disk data version was a flavored range (e.g. `^#knots:29:0`); a subsequent Knots → Core switch then failed with `cannot migrate from ^#knots:29:0 to 29.3:10`.

Walking the chain:

1. `service_map.rs` (pre-PR) computed `target = AND(data_ver_range, next.can_migrate_from)`. With `data_ver_range = ^#knots:29:0` (flavored) and `next.can_migrate_from` flavor-less (Core's), that AND has no satisfying version — flavor-less ranges only match `flavor === null` versions and flavored ranges only match their own flavor; `ExtendedVersion::compare` returns `null` ("incomparable") on flavor mismatch and every comparison helper treats `null` as `false`.
2. The SDK's `VersionGraph.uninit` short-circuited on `!target.satisfiable()`, returning before invoking the registered `migrations.other.down` (the Knots → Core migration the source package owns) and before writing the data version. The on-disk value stayed at the stuck flavored range — and there was no signal to the host that anything had gone wrong.
3. Core's `init` then read that range as `from`, found no graph vertex overlapping it, and `migrate()` threw at the destination — far from the source-side root cause.

The host fix prevents the bad target from being computed; the SDK fix ensures any future host-side bug producing a similar bad target gets surfaced loudly at the source instead of repeating the silent-skip → destination-throw pattern.

## Out of scope (dropped from earlier revisions)

- The first revision had `VersionGraph.init` always rewrite the on-disk data version to the concrete current version after init completed. @drbonez flagged that as semantically suspect — the data version is the data **shape**, not the running version, and a range left on disk by a `migrations.down` edge legitimately means "the data is in a shape any version in this range can read". Forcing it to concrete would mislead future migrations. Reverted.
- A second revision deleted the range arm entirely, falling through to the parse-failure path. That mirrored only the last two branches of the `ExtendedVersion` cascade, dropping the passthrough case. The current revision restores it as branch 1 via `intersects()`.