### PR TITLE
Retry alternate package mirrors after download failures

### DIFF
--- a/core/src/registry/asset.rs
+++ b/core/src/registry/asset.rs
@@ -248,9 +248,6 @@ impl ArchiveSource for BufferedHttpSource {
     }
 }
 
-/// Retry policy for `DownloadHandle::download_from`. Walks the mirror list and,
-/// within each mirror, tries: full download → resume via `Range` (if the previous
-/// attempt got truncated mid-stream) → one full retry → next mirror.
 struct MirrorRetry {
     urls: Vec<Url>,
     client: Client,
@@ -260,11 +257,8 @@ struct MirrorRetry {
 
 #[derive(Clone, Copy)]
 enum MirrorState {
-    /// Try the next URL with a fresh full request.
     NextFull(usize),
-    /// The previous attempt on `urls[idx]` failed mid-body. Try a Range resume next.
     TryResume(usize),
-    /// Resume on `urls[idx]` failed (or wasn't applicable). Try a full retry next.
     RetryFull(usize),
 }
 

--- a/core/src/registry/asset.rs
+++ b/core/src/registry/asset.rs
@@ -3,8 +3,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use futures::StreamExt;
 use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
 use tokio::io::AsyncWrite;
 use ts_rs::TS;
 use url::Url;
@@ -14,12 +16,15 @@ use crate::progress::PhaseProgressTrackerHandle;
 use crate::registry::signer::AcceptSigners;
 use crate::s9pk::S9pk;
 use crate::s9pk::merkle_archive::source::http::HttpSource;
+use crate::s9pk::merkle_archive::source::multi_cursor_file::MultiCursorFile;
+use crate::s9pk::merkle_archive::source::TmpSource;
 use crate::s9pk::merkle_archive::source::{ArchiveSource, Section};
 use crate::sign::commitment::merkle_archive::MerkleArchiveCommitment;
 use crate::sign::commitment::{Commitment, Digestable};
 use crate::sign::{AnySignature, AnyVerifyingKey};
 use crate::upload::UploadingFile;
 use crate::util::future::NonDetachingJoinHandle;
+use crate::util::io::{TmpDir, create_file, open_file};
 
 #[derive(Clone, Debug, Deserialize, Serialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -84,6 +89,72 @@ impl<Commitment> RegistryAsset<Commitment> {
             ErrorKind::Network,
         ))
     }
+    async fn download_to_path(
+        &self,
+        path: impl AsRef<Path>,
+        client: Client,
+        mut progress: PhaseProgressTrackerHandle,
+    ) -> Result<MultiCursorFile, Error> {
+        let mut errors = Vec::new();
+        for url in &self.urls {
+            progress.set_done(0);
+            match Self::download_url_to_path(url, path.as_ref(), client.clone(), &mut progress).await
+            {
+                Ok(file) => return Ok(file),
+                Err(e) => {
+                    tracing::warn!("Failed to download {url}; trying next mirror: {e}");
+                    errors.push(format!("{url}: {e}"));
+                }
+            }
+        }
+        Err(Error::new(
+            eyre!(
+                "failed to download package from any mirror: {}",
+                errors.join("; ")
+            ),
+            ErrorKind::Network,
+        ))
+    }
+    async fn download_url_to_path(
+        url: &Url,
+        path: &Path,
+        client: Client,
+        progress: &mut PhaseProgressTrackerHandle,
+    ) -> Result<MultiCursorFile, Error> {
+        let response = client
+            .get(url.clone())
+            .send()
+            .await
+            .with_kind(ErrorKind::Network)?
+            .error_for_status()
+            .with_kind(ErrorKind::Network)?;
+        let expected_size = response.content_length();
+        if let Some(size) = expected_size {
+            progress.set_total(size);
+        }
+
+        let mut file = create_file(path).await?;
+        let mut downloaded = 0;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_kind(ErrorKind::Network)?;
+            file.write_all(&chunk).await?;
+            downloaded += chunk.len() as u64;
+            *progress += chunk.len() as u64;
+        }
+        file.sync_all().await?;
+        drop(file);
+
+        if let Some(expected_size) = expected_size {
+            ensure_code!(
+                downloaded == expected_size,
+                ErrorKind::Network,
+                "download ended after {downloaded} bytes, expected {expected_size}"
+            );
+        }
+
+        Ok(MultiCursorFile::from(open_file(path).await?))
+    }
 }
 impl<Commitment: Digestable> RegistryAsset<Commitment> {
     pub fn validate(&self, context: &str, mut accept: AcceptSigners) -> Result<&Commitment, Error> {
@@ -120,12 +191,14 @@ impl RegistryAsset<MerkleArchiveCommitment> {
         &self,
         client: Client,
         progress: PhaseProgressTrackerHandle,
-    ) -> Result<S9pk<Section<Arc<BufferedHttpSource>>>, Error> {
-        S9pk::deserialize(
-            &Arc::new(self.load_buffered_http_source(client, progress).await?),
-            Some(&self.commitment),
-        )
-        .await
+    ) -> Result<S9pk<Section<TmpSource<MultiCursorFile>>>, Error> {
+        let tmp_dir = Arc::new(TmpDir::new().await?);
+        let source = TmpSource::new(
+            tmp_dir.clone(),
+            self.download_to_path(tmp_dir.join("download.s9pk"), client, progress)
+                .await?,
+        );
+        S9pk::deserialize(&source, Some(&self.commitment)).await
     }
     pub async fn download_to(
         &self,
@@ -134,19 +207,13 @@ impl RegistryAsset<MerkleArchiveCommitment> {
         progress: PhaseProgressTrackerHandle,
     ) -> Result<
         (
-            S9pk<Section<Arc<BufferedHttpSource>>>,
-            Arc<BufferedHttpSource>,
+            S9pk<Section<MultiCursorFile>>,
+            MultiCursorFile,
         ),
         Error,
     > {
-        let source = Arc::new(
-            self.load_buffered_http_source_with_path(path, client, progress)
-                .await?,
-        );
-        Ok((
-            S9pk::deserialize(&source, Some(&self.commitment)).await?,
-            source,
-        ))
+        let source = self.download_to_path(path, client, progress).await?;
+        Ok((S9pk::deserialize(&source, Some(&self.commitment)).await?, source))
     }
 }
 
@@ -199,5 +266,81 @@ impl ArchiveSource for BufferedHttpSource {
     }
     async fn fetch(&self, position: u64, size: u64) -> Result<Self::FetchReader, Error> {
         self.file.fetch(position, size).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use crate::progress::FullProgressTracker;
+    use crate::s9pk::merkle_archive::source::ArchiveSource;
+
+    async fn spawn_test_server() -> Result<Url, Error> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0; 1024];
+                    let Ok(n) = stream.read(&mut buf).await else {
+                        return;
+                    };
+                    let request = String::from_utf8_lossy(&buf[..n]);
+                    let path = request
+                        .lines()
+                        .next()
+                        .and_then(|line| line.split_whitespace().nth(1))
+                        .unwrap_or("/");
+                    match path {
+                        "/truncated" => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
+                                .await;
+                        }
+                        "/complete" => {
+                            let _ = stream
+                                .write_all(
+                                    b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello world",
+                                )
+                                .await;
+                        }
+                        _ => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                                .await;
+                        }
+                    }
+                });
+            }
+        });
+        Url::parse(&format!("http://{addr}")).with_kind(ErrorKind::ParseUrl)
+    }
+
+    #[tokio::test]
+    async fn download_to_path_falls_back_after_truncated_mirror() -> Result<(), Error> {
+        let base_url = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![base_url.join("truncated")?, base_url.join("complete")?],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+        let progress = FullProgressTracker::new().add_phase("Downloading".into(), Some(100));
+        let tmp_dir = TmpDir::new().await?;
+
+        let source = asset
+            .download_to_path(tmp_dir.join("package.s9pk"), Client::new(), progress)
+            .await?;
+        let mut contents = Vec::new();
+        source.fetch_all().await?.read_to_end(&mut contents).await?;
+
+        assert_eq!(contents, b"hello world");
+        Ok(())
     }
 }

--- a/core/src/registry/asset.rs
+++ b/core/src/registry/asset.rs
@@ -1,16 +1,12 @@
 use std::collections::HashMap;
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use chrono::{DateTime, Utc};
-use futures::StreamExt;
 use reqwest::header::RANGE;
-use reqwest::{Client, Response, StatusCode};
+use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWrite;
-use tokio::io::{AsyncRead, AsyncSeekExt, AsyncWriteExt, ReadBuf};
 use ts_rs::TS;
 use url::Url;
 
@@ -19,14 +15,14 @@ use crate::progress::PhaseProgressTrackerHandle;
 use crate::registry::signer::AcceptSigners;
 use crate::s9pk::S9pk;
 use crate::s9pk::merkle_archive::source::http::HttpSource;
-use crate::s9pk::merkle_archive::source::multi_cursor_file::MultiCursorFile;
 use crate::s9pk::merkle_archive::source::{ArchiveSource, Section};
 use crate::sign::commitment::merkle_archive::MerkleArchiveCommitment;
 use crate::sign::commitment::{Commitment, Digestable};
 use crate::sign::{AnySignature, AnyVerifyingKey};
-use crate::upload::UploadingFile;
+use crate::upload::{DownloadAttemptContext, DownloadHandle, UploadingFile};
 use crate::util::future::NonDetachingJoinHandle;
-use crate::util::io::{TmpDir, create_file, open_file};
+#[cfg(test)]
+use crate::util::io::TmpDir;
 
 #[derive(Clone, Debug, Deserialize, Serialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -143,56 +139,7 @@ impl RegistryAsset<MerkleArchiveCommitment> {
 
 pub struct BufferedHttpSource {
     _download: NonDetachingJoinHandle<()>,
-    file: BufferedHttpFile,
-}
-enum BufferedHttpFile {
-    Uploading(UploadingFile),
-    Complete {
-        _tmp_dir: Option<Arc<TmpDir>>,
-        file: MultiCursorFile,
-    },
-}
-
-struct DownloadFailure {
-    error: Error,
-    written: u64,
-    expected: Option<u64>,
-}
-
-#[pin_project::pin_project(project = BufferedFetchReaderProj)]
-pub enum BufferedFetchReader {
-    Uploading(#[pin] <UploadingFile as ArchiveSource>::FetchReader),
-    Complete(#[pin] <MultiCursorFile as ArchiveSource>::FetchReader),
-}
-impl AsyncRead for BufferedFetchReader {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        match self.project() {
-            BufferedFetchReaderProj::Uploading(reader) => reader.poll_read(cx, buf),
-            BufferedFetchReaderProj::Complete(reader) => reader.poll_read(cx, buf),
-        }
-    }
-}
-
-#[pin_project::pin_project(project = BufferedFetchAllReaderProj)]
-pub enum BufferedFetchAllReader {
-    Uploading(#[pin] <UploadingFile as ArchiveSource>::FetchAllReader),
-    Complete(#[pin] <MultiCursorFile as ArchiveSource>::FetchAllReader),
-}
-impl AsyncRead for BufferedFetchAllReader {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        match self.project() {
-            BufferedFetchAllReaderProj::Uploading(reader) => reader.poll_read(cx, buf),
-            BufferedFetchAllReaderProj::Complete(reader) => reader.poll_read(cx, buf),
-        }
-    }
+    file: UploadingFile,
 }
 
 impl BufferedHttpSource {
@@ -201,17 +148,29 @@ impl BufferedHttpSource {
         url: Url,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        let response = client.get(url).send().await?;
-        Self::from_response(response, progress).await
+        Self::from_urls(std::slice::from_ref(&url), client, progress).await
     }
     pub async fn from_response(
         response: Response,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        let (mut handle, file) = UploadingFile::new(progress).await?;
+        let (mut handle, file) = UploadingFile::new_for_download(progress).await?;
+        let mut response = Some(response);
         Ok(Self {
-            _download: tokio::spawn(async move { handle.download(response).await }).into(),
-            file: BufferedHttpFile::Uploading(file),
+            _download: tokio::spawn(async move {
+                handle
+                    .download_from(|_| {
+                        let next = response.take();
+                        async move {
+                            next.ok_or_else(|| {
+                                Error::new(eyre!("download failed"), ErrorKind::Network)
+                            })
+                        }
+                    })
+                    .await
+            })
+            .into(),
+            file,
         })
     }
     pub async fn from_response_with_path(
@@ -219,10 +178,23 @@ impl BufferedHttpSource {
         response: Response,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        let (mut handle, file) = UploadingFile::with_path(path, progress).await?;
+        let (mut handle, file) = UploadingFile::with_path_for_download(path, progress).await?;
+        let mut response = Some(response);
         Ok(Self {
-            _download: tokio::spawn(async move { handle.download(response).await }).into(),
-            file: BufferedHttpFile::Uploading(file),
+            _download: tokio::spawn(async move {
+                handle
+                    .download_from(|_| {
+                        let next = response.take();
+                        async move {
+                            next.ok_or_else(|| {
+                                Error::new(eyre!("download failed"), ErrorKind::Network)
+                            })
+                        }
+                    })
+                    .await
+            })
+            .into(),
+            file,
         })
     }
     async fn from_urls(
@@ -230,9 +202,8 @@ impl BufferedHttpSource {
         client: Client,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        let tmp_dir = Arc::new(TmpDir::new().await?);
-        let path = tmp_dir.join("download.s9pk");
-        Self::from_urls_inner(Some(tmp_dir), path, urls, client, progress).await
+        let (handle, file) = UploadingFile::new_for_download(progress).await?;
+        Self::spawn_mirror_download(handle, file, urls, client).await
     }
     async fn from_urls_with_path(
         path: impl AsRef<Path>,
@@ -240,253 +211,133 @@ impl BufferedHttpSource {
         client: Client,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        Self::from_urls_inner(None, path.as_ref().to_owned(), urls, client, progress).await
+        let (handle, file) = UploadingFile::with_path_for_download(path, progress).await?;
+        Self::spawn_mirror_download(handle, file, urls, client).await
     }
-    async fn from_urls_inner(
-        tmp_dir: Option<Arc<TmpDir>>,
-        path: impl AsRef<Path>,
+    async fn spawn_mirror_download(
+        mut handle: DownloadHandle,
+        file: UploadingFile,
         urls: &[Url],
         client: Client,
-        mut progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        let mut errors = Vec::new();
-        for url in urls {
-            progress.set_done(0);
-            match Self::download_url_with_retry(url, path.as_ref(), client.clone(), &mut progress)
-                .await
-            {
-                Ok(()) => {
-                    let file = MultiCursorFile::from(open_file(path.as_ref()).await?);
-                    return Ok(Self {
-                        _download: tokio::spawn(async {}).into(),
-                        file: BufferedHttpFile::Complete {
-                            _tmp_dir: tmp_dir,
-                            file,
-                        },
-                    });
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to download {url}; trying next mirror: {e}");
-                    errors.push(format!("{url}: {e}"));
-                }
-            }
-        }
-        Err(Error::new(
-            eyre!(
-                "failed to download package from any mirror: {}",
-                errors.join("; ")
-            ),
-            ErrorKind::Network,
-        ))
-    }
-    async fn download_url_with_retry(
-        url: &Url,
-        path: &Path,
-        client: Client,
-        progress: &mut PhaseProgressTrackerHandle,
-    ) -> Result<(), Error> {
-        match Self::download_full_response(path, client.get(url.clone()).send().await, progress)
-            .await
-        {
-            Ok(_) => Ok(()),
-            Err(first) => {
-                tracing::warn!(
-                    "Failed to download {url}; retrying same mirror: {}",
-                    first.error
-                );
-                if let Some(total) = first.expected {
-                    if first.written > 0 && first.written < total {
-                        match Self::download_range_response(
-                            path,
-                            client
-                                .get(url.clone())
-                                .header(RANGE, format!("bytes={}-", first.written))
-                                .send()
-                                .await,
-                            first.written,
-                            total,
-                            progress,
-                        )
-                        .await
-                        {
-                            Ok(()) => return Ok(()),
-                            Err(range) => {
-                                tracing::warn!(
-                                    "Failed to resume {url}; retrying full download: {}",
-                                    range.error
-                                );
-                            }
-                        }
-                    }
-                }
-                progress.set_done(0);
-                Self::download_full_response(path, client.get(url.clone()).send().await, progress)
-                    .await
-                    .map(|_| ())
-                    .map_err(|retry| retry.error)
-            }
-        }
-    }
-    async fn download_full_response(
-        path: &Path,
-        response: Result<Response, reqwest::Error>,
-        progress: &mut PhaseProgressTrackerHandle,
-    ) -> Result<(), DownloadFailure> {
-        let response = response.map_err(|e| DownloadFailure {
-            error: Error::new(e, ErrorKind::Network),
-            written: 0,
-            expected: None,
-        })?;
-        let response = response.error_for_status().map_err(|e| DownloadFailure {
-            error: Error::new(e, ErrorKind::Network),
-            written: 0,
-            expected: None,
-        })?;
-        let expected = response.content_length();
-        if let Some(total) = expected {
-            progress.set_total(total);
-        }
-        let file = create_file(path).await.map_err(|error| DownloadFailure {
-            error,
-            written: 0,
-            expected,
-        })?;
-        Self::write_response(file, response, 0, expected, progress).await
-    }
-    async fn download_range_response(
-        path: &Path,
-        response: Result<Response, reqwest::Error>,
-        start: u64,
-        expected: u64,
-        progress: &mut PhaseProgressTrackerHandle,
-    ) -> Result<(), DownloadFailure> {
-        let response = response.map_err(|e| DownloadFailure {
-            error: Error::new(e, ErrorKind::Network),
-            written: start,
-            expected: Some(expected),
-        })?;
-        match response.status() {
-            StatusCode::PARTIAL_CONTENT => {
-                let mut file = tokio::fs::OpenOptions::new()
-                    .append(true)
-                    .open(path)
-                    .await
-                    .map_err(|error| DownloadFailure {
-                        error: Error::new(error, ErrorKind::Filesystem),
-                        written: start,
-                        expected: Some(expected),
-                    })?;
-                file.seek(std::io::SeekFrom::End(0))
-                    .await
-                    .map_err(|error| DownloadFailure {
-                        error: Error::new(error, ErrorKind::Filesystem),
-                        written: start,
-                        expected: Some(expected),
-                    })?;
-                progress.set_total(expected);
-                progress.set_done(start);
-                Self::write_response(file, response, start, Some(expected), progress)
-                    .await
-                    .map(|_| ())
-            }
-            StatusCode::OK => {
-                progress.set_done(0);
-                Self::download_full_response(path, Ok(response), progress)
-                    .await
-                    .map(|_| ())
-            }
-            _ => {
-                let status = response.status();
-                Err(DownloadFailure {
-                    error: Error::new(
-                        eyre!("range request failed with {status}"),
-                        ErrorKind::Network,
-                    ),
-                    written: start,
-                    expected: Some(expected),
-                })
-            }
-        }
-    }
-    async fn write_response(
-        mut file: tokio::fs::File,
-        response: Response,
-        start: u64,
-        expected: Option<u64>,
-        progress: &mut PhaseProgressTrackerHandle,
-    ) -> Result<(), DownloadFailure> {
-        let mut written = start;
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|e| DownloadFailure {
-                error: Error::new(e, ErrorKind::Network),
-                written,
-                expected,
-            })?;
-            file.write_all(&chunk)
-                .await
-                .map_err(|error| DownloadFailure {
-                    error: Error::new(error, ErrorKind::Filesystem),
-                    written,
-                    expected,
-                })?;
-            written += chunk.len() as u64;
-            *progress += chunk.len() as u64;
-        }
-        file.sync_all().await.map_err(|error| DownloadFailure {
-            error: Error::new(error, ErrorKind::Filesystem),
-            written,
-            expected,
-        })?;
-        if let Some(expected) = expected {
-            if written != expected {
-                return Err(DownloadFailure {
-                    error: Error::new(
-                        eyre!("download ended after {written} bytes, expected {expected}"),
-                        ErrorKind::Network,
-                    ),
-                    written,
-                    expected: Some(expected),
-                });
-            }
-        }
-        progress.complete();
-        Ok(())
+        handle
+            .download_from(MirrorRetry::new(urls.to_vec(), client).next_response())
+            .await;
+        drop(handle);
+        file.wait_for_complete().await?;
+        Ok(Self {
+            _download: tokio::spawn(async {}).into(),
+            file,
+        })
     }
     pub async fn wait_for_buffered(&self) -> Result<(), Error> {
-        match &self.file {
-            BufferedHttpFile::Uploading(file) => file.wait_for_complete().await,
-            BufferedHttpFile::Complete { .. } => Ok(()),
-        }
+        self.file.wait_for_complete().await
     }
 }
 impl ArchiveSource for BufferedHttpSource {
-    type FetchReader = BufferedFetchReader;
-    type FetchAllReader = BufferedFetchAllReader;
+    type FetchReader = <UploadingFile as ArchiveSource>::FetchReader;
+    type FetchAllReader = <UploadingFile as ArchiveSource>::FetchAllReader;
     async fn size(&self) -> Option<u64> {
-        match &self.file {
-            BufferedHttpFile::Uploading(file) => file.size().await,
-            BufferedHttpFile::Complete { file, .. } => file.size().await,
-        }
+        self.file.size().await
     }
     async fn fetch_all(&self) -> Result<Self::FetchAllReader, Error> {
-        match &self.file {
-            BufferedHttpFile::Uploading(file) => {
-                Ok(BufferedFetchAllReader::Uploading(file.fetch_all().await?))
-            }
-            BufferedHttpFile::Complete { file, .. } => {
-                Ok(BufferedFetchAllReader::Complete(file.fetch_all().await?))
-            }
-        }
+        self.file.fetch_all().await
     }
     async fn fetch(&self, position: u64, size: u64) -> Result<Self::FetchReader, Error> {
-        match &self.file {
-            BufferedHttpFile::Uploading(file) => Ok(BufferedFetchReader::Uploading(
-                file.fetch(position, size).await?,
-            )),
-            BufferedHttpFile::Complete { file, .. } => Ok(BufferedFetchReader::Complete(
-                file.fetch(position, size).await?,
-            )),
+        self.file.fetch(position, size).await
+    }
+}
+
+/// Retry policy for `DownloadHandle::download_from`. Walks the mirror list and,
+/// within each mirror, tries: full download → resume via `Range` (if the previous
+/// attempt got truncated mid-stream) → one full retry → next mirror.
+struct MirrorRetry {
+    urls: Vec<Url>,
+    client: Client,
+    state: MirrorState,
+    errors: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum MirrorState {
+    /// Try the next URL with a fresh full request.
+    NextFull(usize),
+    /// The previous attempt on `urls[idx]` failed mid-body. Try a Range resume next.
+    TryResume(usize),
+    /// Resume on `urls[idx]` failed (or wasn't applicable). Try a full retry next.
+    RetryFull(usize),
+}
+
+impl MirrorRetry {
+    fn new(urls: Vec<Url>, client: Client) -> Self {
+        Self {
+            urls,
+            client,
+            state: MirrorState::NextFull(0),
+            errors: Vec::new(),
+        }
+    }
+    fn next_response(
+        mut self,
+    ) -> impl FnMut(DownloadAttemptContext) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Response, Error>> + Send>,
+    > {
+        move |ctx| {
+            if let Some(err) = &ctx.last_error {
+                let url_idx = match self.state {
+                    MirrorState::NextFull(i) => i.saturating_sub(1),
+                    MirrorState::TryResume(i) | MirrorState::RetryFull(i) => i,
+                };
+                if let Some(url) = self.urls.get(url_idx) {
+                    self.errors.push(format!("{url}: {err}"));
+                    tracing::warn!("Failed to download {url}: {err}");
+                }
+            }
+            let next = self.advance(&ctx);
+            let exhausted = (next.is_none()).then(|| self.errors.join("; "));
+            Box::pin(async move {
+                match next {
+                    Some(req) => req.send().await.map_err(|e| Error::new(e, ErrorKind::Network)),
+                    None => Err(Error::new(
+                        eyre!(
+                            "failed to download package from any mirror: {}",
+                            exhausted.unwrap_or_default()
+                        ),
+                        ErrorKind::Network,
+                    )),
+                }
+            })
+        }
+    }
+    fn advance(&mut self, ctx: &DownloadAttemptContext) -> Option<reqwest::RequestBuilder> {
+        loop {
+            match self.state {
+                MirrorState::NextFull(idx) => {
+                    let url = self.urls.get(idx)?;
+                    let req = self.client.get(url.clone());
+                    self.state = MirrorState::TryResume(idx);
+                    return Some(req);
+                }
+                MirrorState::TryResume(idx) => {
+                    let url = self.urls.get(idx)?;
+                    self.state = MirrorState::RetryFull(idx);
+                    if let (Some(total), written) = (ctx.expected_size, ctx.bytes_written) {
+                        if written > 0 && written < total {
+                            return Some(
+                                self.client
+                                    .get(url.clone())
+                                    .header(RANGE, format!("bytes={written}-")),
+                            );
+                        }
+                    }
+                    continue;
+                }
+                MirrorState::RetryFull(idx) => {
+                    let url = self.urls.get(idx)?;
+                    self.state = MirrorState::NextFull(idx + 1);
+                    return Some(self.client.get(url.clone()));
+                }
+            }
         }
     }
 }

--- a/core/src/registry/asset.rs
+++ b/core/src/registry/asset.rs
@@ -1,13 +1,16 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
-use reqwest::{Client, Response};
+use reqwest::header::RANGE;
+use reqwest::{Client, Response, StatusCode};
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncWriteExt;
 use tokio::io::AsyncWrite;
+use tokio::io::{AsyncRead, AsyncSeekExt, AsyncWriteExt, ReadBuf};
 use ts_rs::TS;
 use url::Url;
 
@@ -17,7 +20,6 @@ use crate::registry::signer::AcceptSigners;
 use crate::s9pk::S9pk;
 use crate::s9pk::merkle_archive::source::http::HttpSource;
 use crate::s9pk::merkle_archive::source::multi_cursor_file::MultiCursorFile;
-use crate::s9pk::merkle_archive::source::TmpSource;
 use crate::s9pk::merkle_archive::source::{ArchiveSource, Section};
 use crate::sign::commitment::merkle_archive::MerkleArchiveCommitment;
 use crate::sign::commitment::{Commitment, Digestable};
@@ -63,15 +65,7 @@ impl<Commitment> RegistryAsset<Commitment> {
         client: Client,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<BufferedHttpSource, Error> {
-        for url in &self.urls {
-            if let Ok(response) = client.get(url.clone()).send().await {
-                return BufferedHttpSource::from_response(response, progress).await;
-            }
-        }
-        Err(Error::new(
-            eyre!("{}", t!("registry.asset.failed-to-load-http-url")),
-            ErrorKind::Network,
-        ))
+        BufferedHttpSource::from_urls(&self.urls, client, progress).await
     }
     pub async fn load_buffered_http_source_with_path(
         &self,
@@ -79,81 +73,7 @@ impl<Commitment> RegistryAsset<Commitment> {
         client: Client,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<BufferedHttpSource, Error> {
-        for url in &self.urls {
-            if let Ok(response) = client.get(url.clone()).send().await {
-                return BufferedHttpSource::from_response_with_path(path, response, progress).await;
-            }
-        }
-        Err(Error::new(
-            eyre!("{}", t!("registry.asset.failed-to-load-http-url")),
-            ErrorKind::Network,
-        ))
-    }
-    async fn download_to_path(
-        &self,
-        path: impl AsRef<Path>,
-        client: Client,
-        mut progress: PhaseProgressTrackerHandle,
-    ) -> Result<MultiCursorFile, Error> {
-        let mut errors = Vec::new();
-        for url in &self.urls {
-            progress.set_done(0);
-            match Self::download_url_to_path(url, path.as_ref(), client.clone(), &mut progress).await
-            {
-                Ok(file) => return Ok(file),
-                Err(e) => {
-                    tracing::warn!("Failed to download {url}; trying next mirror: {e}");
-                    errors.push(format!("{url}: {e}"));
-                }
-            }
-        }
-        Err(Error::new(
-            eyre!(
-                "failed to download package from any mirror: {}",
-                errors.join("; ")
-            ),
-            ErrorKind::Network,
-        ))
-    }
-    async fn download_url_to_path(
-        url: &Url,
-        path: &Path,
-        client: Client,
-        progress: &mut PhaseProgressTrackerHandle,
-    ) -> Result<MultiCursorFile, Error> {
-        let response = client
-            .get(url.clone())
-            .send()
-            .await
-            .with_kind(ErrorKind::Network)?
-            .error_for_status()
-            .with_kind(ErrorKind::Network)?;
-        let expected_size = response.content_length();
-        if let Some(size) = expected_size {
-            progress.set_total(size);
-        }
-
-        let mut file = create_file(path).await?;
-        let mut downloaded = 0;
-        let mut stream = response.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.with_kind(ErrorKind::Network)?;
-            file.write_all(&chunk).await?;
-            downloaded += chunk.len() as u64;
-            *progress += chunk.len() as u64;
-        }
-        file.sync_all().await?;
-        drop(file);
-
-        if let Some(expected_size) = expected_size {
-            ensure_code!(
-                downloaded == expected_size,
-                ErrorKind::Network,
-                "download ended after {downloaded} bytes, expected {expected_size}"
-            );
-        }
-
-        Ok(MultiCursorFile::from(open_file(path).await?))
+        BufferedHttpSource::from_urls_with_path(path, &self.urls, client, progress).await
     }
 }
 impl<Commitment: Digestable> RegistryAsset<Commitment> {
@@ -191,14 +111,12 @@ impl RegistryAsset<MerkleArchiveCommitment> {
         &self,
         client: Client,
         progress: PhaseProgressTrackerHandle,
-    ) -> Result<S9pk<Section<TmpSource<MultiCursorFile>>>, Error> {
-        let tmp_dir = Arc::new(TmpDir::new().await?);
-        let source = TmpSource::new(
-            tmp_dir.clone(),
-            self.download_to_path(tmp_dir.join("download.s9pk"), client, progress)
-                .await?,
-        );
-        S9pk::deserialize(&source, Some(&self.commitment)).await
+    ) -> Result<S9pk<Section<Arc<BufferedHttpSource>>>, Error> {
+        S9pk::deserialize(
+            &Arc::new(self.load_buffered_http_source(client, progress).await?),
+            Some(&self.commitment),
+        )
+        .await
     }
     pub async fn download_to(
         &self,
@@ -207,20 +125,76 @@ impl RegistryAsset<MerkleArchiveCommitment> {
         progress: PhaseProgressTrackerHandle,
     ) -> Result<
         (
-            S9pk<Section<MultiCursorFile>>,
-            MultiCursorFile,
+            S9pk<Section<Arc<BufferedHttpSource>>>,
+            Arc<BufferedHttpSource>,
         ),
         Error,
     > {
-        let source = self.download_to_path(path, client, progress).await?;
-        Ok((S9pk::deserialize(&source, Some(&self.commitment)).await?, source))
+        let source = Arc::new(
+            self.load_buffered_http_source_with_path(path, client, progress)
+                .await?,
+        );
+        Ok((
+            S9pk::deserialize(&source, Some(&self.commitment)).await?,
+            source,
+        ))
     }
 }
 
 pub struct BufferedHttpSource {
     _download: NonDetachingJoinHandle<()>,
-    file: UploadingFile,
+    file: BufferedHttpFile,
 }
+enum BufferedHttpFile {
+    Uploading(UploadingFile),
+    Complete {
+        _tmp_dir: Option<Arc<TmpDir>>,
+        file: MultiCursorFile,
+    },
+}
+
+struct DownloadFailure {
+    error: Error,
+    written: u64,
+    expected: Option<u64>,
+}
+
+#[pin_project::pin_project(project = BufferedFetchReaderProj)]
+pub enum BufferedFetchReader {
+    Uploading(#[pin] <UploadingFile as ArchiveSource>::FetchReader),
+    Complete(#[pin] <MultiCursorFile as ArchiveSource>::FetchReader),
+}
+impl AsyncRead for BufferedFetchReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.project() {
+            BufferedFetchReaderProj::Uploading(reader) => reader.poll_read(cx, buf),
+            BufferedFetchReaderProj::Complete(reader) => reader.poll_read(cx, buf),
+        }
+    }
+}
+
+#[pin_project::pin_project(project = BufferedFetchAllReaderProj)]
+pub enum BufferedFetchAllReader {
+    Uploading(#[pin] <UploadingFile as ArchiveSource>::FetchAllReader),
+    Complete(#[pin] <MultiCursorFile as ArchiveSource>::FetchAllReader),
+}
+impl AsyncRead for BufferedFetchAllReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match self.project() {
+            BufferedFetchAllReaderProj::Uploading(reader) => reader.poll_read(cx, buf),
+            BufferedFetchAllReaderProj::Complete(reader) => reader.poll_read(cx, buf),
+        }
+    }
+}
+
 impl BufferedHttpSource {
     pub async fn new(
         client: Client,
@@ -237,7 +211,7 @@ impl BufferedHttpSource {
         let (mut handle, file) = UploadingFile::new(progress).await?;
         Ok(Self {
             _download: tokio::spawn(async move { handle.download(response).await }).into(),
-            file,
+            file: BufferedHttpFile::Uploading(file),
         })
     }
     pub async fn from_response_with_path(
@@ -248,62 +222,346 @@ impl BufferedHttpSource {
         let (mut handle, file) = UploadingFile::with_path(path, progress).await?;
         Ok(Self {
             _download: tokio::spawn(async move { handle.download(response).await }).into(),
-            file,
+            file: BufferedHttpFile::Uploading(file),
         })
     }
+    async fn from_urls(
+        urls: &[Url],
+        client: Client,
+        progress: PhaseProgressTrackerHandle,
+    ) -> Result<Self, Error> {
+        let tmp_dir = Arc::new(TmpDir::new().await?);
+        let path = tmp_dir.join("download.s9pk");
+        Self::from_urls_inner(Some(tmp_dir), path, urls, client, progress).await
+    }
+    async fn from_urls_with_path(
+        path: impl AsRef<Path>,
+        urls: &[Url],
+        client: Client,
+        progress: PhaseProgressTrackerHandle,
+    ) -> Result<Self, Error> {
+        Self::from_urls_inner(None, path.as_ref().to_owned(), urls, client, progress).await
+    }
+    async fn from_urls_inner(
+        tmp_dir: Option<Arc<TmpDir>>,
+        path: impl AsRef<Path>,
+        urls: &[Url],
+        client: Client,
+        mut progress: PhaseProgressTrackerHandle,
+    ) -> Result<Self, Error> {
+        let mut errors = Vec::new();
+        for url in urls {
+            progress.set_done(0);
+            match Self::download_url_with_retry(url, path.as_ref(), client.clone(), &mut progress)
+                .await
+            {
+                Ok(()) => {
+                    let file = MultiCursorFile::from(open_file(path.as_ref()).await?);
+                    return Ok(Self {
+                        _download: tokio::spawn(async {}).into(),
+                        file: BufferedHttpFile::Complete {
+                            _tmp_dir: tmp_dir,
+                            file,
+                        },
+                    });
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to download {url}; trying next mirror: {e}");
+                    errors.push(format!("{url}: {e}"));
+                }
+            }
+        }
+        Err(Error::new(
+            eyre!(
+                "failed to download package from any mirror: {}",
+                errors.join("; ")
+            ),
+            ErrorKind::Network,
+        ))
+    }
+    async fn download_url_with_retry(
+        url: &Url,
+        path: &Path,
+        client: Client,
+        progress: &mut PhaseProgressTrackerHandle,
+    ) -> Result<(), Error> {
+        match Self::download_full_response(path, client.get(url.clone()).send().await, progress)
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(first) => {
+                tracing::warn!(
+                    "Failed to download {url}; retrying same mirror: {}",
+                    first.error
+                );
+                if let Some(total) = first.expected {
+                    if first.written > 0 && first.written < total {
+                        match Self::download_range_response(
+                            path,
+                            client
+                                .get(url.clone())
+                                .header(RANGE, format!("bytes={}-", first.written))
+                                .send()
+                                .await,
+                            first.written,
+                            total,
+                            progress,
+                        )
+                        .await
+                        {
+                            Ok(()) => return Ok(()),
+                            Err(range) => {
+                                tracing::warn!(
+                                    "Failed to resume {url}; retrying full download: {}",
+                                    range.error
+                                );
+                            }
+                        }
+                    }
+                }
+                progress.set_done(0);
+                Self::download_full_response(path, client.get(url.clone()).send().await, progress)
+                    .await
+                    .map(|_| ())
+                    .map_err(|retry| retry.error)
+            }
+        }
+    }
+    async fn download_full_response(
+        path: &Path,
+        response: Result<Response, reqwest::Error>,
+        progress: &mut PhaseProgressTrackerHandle,
+    ) -> Result<(), DownloadFailure> {
+        let response = response.map_err(|e| DownloadFailure {
+            error: Error::new(e, ErrorKind::Network),
+            written: 0,
+            expected: None,
+        })?;
+        let response = response.error_for_status().map_err(|e| DownloadFailure {
+            error: Error::new(e, ErrorKind::Network),
+            written: 0,
+            expected: None,
+        })?;
+        let expected = response.content_length();
+        if let Some(total) = expected {
+            progress.set_total(total);
+        }
+        let file = create_file(path).await.map_err(|error| DownloadFailure {
+            error,
+            written: 0,
+            expected,
+        })?;
+        Self::write_response(file, response, 0, expected, progress).await
+    }
+    async fn download_range_response(
+        path: &Path,
+        response: Result<Response, reqwest::Error>,
+        start: u64,
+        expected: u64,
+        progress: &mut PhaseProgressTrackerHandle,
+    ) -> Result<(), DownloadFailure> {
+        let response = response.map_err(|e| DownloadFailure {
+            error: Error::new(e, ErrorKind::Network),
+            written: start,
+            expected: Some(expected),
+        })?;
+        match response.status() {
+            StatusCode::PARTIAL_CONTENT => {
+                let mut file = tokio::fs::OpenOptions::new()
+                    .append(true)
+                    .open(path)
+                    .await
+                    .map_err(|error| DownloadFailure {
+                        error: Error::new(error, ErrorKind::Filesystem),
+                        written: start,
+                        expected: Some(expected),
+                    })?;
+                file.seek(std::io::SeekFrom::End(0))
+                    .await
+                    .map_err(|error| DownloadFailure {
+                        error: Error::new(error, ErrorKind::Filesystem),
+                        written: start,
+                        expected: Some(expected),
+                    })?;
+                progress.set_total(expected);
+                progress.set_done(start);
+                Self::write_response(file, response, start, Some(expected), progress)
+                    .await
+                    .map(|_| ())
+            }
+            StatusCode::OK => {
+                progress.set_done(0);
+                Self::download_full_response(path, Ok(response), progress)
+                    .await
+                    .map(|_| ())
+            }
+            _ => {
+                let status = response.status();
+                Err(DownloadFailure {
+                    error: Error::new(
+                        eyre!("range request failed with {status}"),
+                        ErrorKind::Network,
+                    ),
+                    written: start,
+                    expected: Some(expected),
+                })
+            }
+        }
+    }
+    async fn write_response(
+        mut file: tokio::fs::File,
+        response: Response,
+        start: u64,
+        expected: Option<u64>,
+        progress: &mut PhaseProgressTrackerHandle,
+    ) -> Result<(), DownloadFailure> {
+        let mut written = start;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| DownloadFailure {
+                error: Error::new(e, ErrorKind::Network),
+                written,
+                expected,
+            })?;
+            file.write_all(&chunk)
+                .await
+                .map_err(|error| DownloadFailure {
+                    error: Error::new(error, ErrorKind::Filesystem),
+                    written,
+                    expected,
+                })?;
+            written += chunk.len() as u64;
+            *progress += chunk.len() as u64;
+        }
+        file.sync_all().await.map_err(|error| DownloadFailure {
+            error: Error::new(error, ErrorKind::Filesystem),
+            written,
+            expected,
+        })?;
+        if let Some(expected) = expected {
+            if written != expected {
+                return Err(DownloadFailure {
+                    error: Error::new(
+                        eyre!("download ended after {written} bytes, expected {expected}"),
+                        ErrorKind::Network,
+                    ),
+                    written,
+                    expected: Some(expected),
+                });
+            }
+        }
+        progress.complete();
+        Ok(())
+    }
     pub async fn wait_for_buffered(&self) -> Result<(), Error> {
-        self.file.wait_for_complete().await
+        match &self.file {
+            BufferedHttpFile::Uploading(file) => file.wait_for_complete().await,
+            BufferedHttpFile::Complete { .. } => Ok(()),
+        }
     }
 }
 impl ArchiveSource for BufferedHttpSource {
-    type FetchReader = <UploadingFile as ArchiveSource>::FetchReader;
-    type FetchAllReader = <UploadingFile as ArchiveSource>::FetchAllReader;
+    type FetchReader = BufferedFetchReader;
+    type FetchAllReader = BufferedFetchAllReader;
     async fn size(&self) -> Option<u64> {
-        self.file.size().await
+        match &self.file {
+            BufferedHttpFile::Uploading(file) => file.size().await,
+            BufferedHttpFile::Complete { file, .. } => file.size().await,
+        }
     }
     async fn fetch_all(&self) -> Result<Self::FetchAllReader, Error> {
-        self.file.fetch_all().await
+        match &self.file {
+            BufferedHttpFile::Uploading(file) => {
+                Ok(BufferedFetchAllReader::Uploading(file.fetch_all().await?))
+            }
+            BufferedHttpFile::Complete { file, .. } => {
+                Ok(BufferedFetchAllReader::Complete(file.fetch_all().await?))
+            }
+        }
     }
     async fn fetch(&self, position: u64, size: u64) -> Result<Self::FetchReader, Error> {
-        self.file.fetch(position, size).await
+        match &self.file {
+            BufferedHttpFile::Uploading(file) => Ok(BufferedFetchReader::Uploading(
+                file.fetch(position, size).await?,
+            )),
+            BufferedHttpFile::Complete { file, .. } => Ok(BufferedFetchReader::Complete(
+                file.fetch(position, size).await?,
+            )),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
     use crate::progress::FullProgressTracker;
     use crate::s9pk::merkle_archive::source::ArchiveSource;
 
-    async fn spawn_test_server() -> Result<Url, Error> {
+    struct TestServer {
+        url: Url,
+        complete_hits: Arc<AtomicUsize>,
+    }
+
+    async fn spawn_test_server() -> Result<TestServer, Error> {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;
+        let complete_hits = Arc::new(AtomicUsize::new(0));
+        let server_complete_hits = complete_hits.clone();
         tokio::spawn(async move {
             loop {
                 let Ok((mut stream, _)) = listener.accept().await else {
                     break;
                 };
+                let complete_hits = server_complete_hits.clone();
                 tokio::spawn(async move {
                     let mut buf = [0; 1024];
                     let Ok(n) = stream.read(&mut buf).await else {
                         return;
                     };
                     let request = String::from_utf8_lossy(&buf[..n]);
+                    let request_lower = request.to_ascii_lowercase();
                     let path = request
                         .lines()
                         .next()
                         .and_then(|line| line.split_whitespace().nth(1))
                         .unwrap_or("/");
                     match path {
-                        "/truncated" => {
+                        "/resume" if request_lower.contains("range: bytes=5-") => {
+                            let _ = stream
+                                .write_all(
+                                    b"HTTP/1.1 206 Partial Content\r\nContent-Length: 6\r\nContent-Range: bytes 5-10/11\r\n\r\n world",
+                                )
+                                .await;
+                        }
+                        "/resume" => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
+                                .await;
+                        }
+                        "/range-ignored" if request_lower.contains("range: bytes=5-") => {
+                            let _ = stream
+                                .write_all(
+                                    b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello world",
+                                )
+                                .await;
+                        }
+                        "/range-ignored" => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
+                                .await;
+                        }
+                        "/always-truncated" => {
                             let _ = stream
                                 .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
                                 .await;
                         }
                         "/complete" => {
+                            complete_hits.fetch_add(1, Ordering::SeqCst);
                             let _ = stream
                                 .write_all(
                                     b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello world",
@@ -319,28 +577,89 @@ mod tests {
                 });
             }
         });
-        Url::parse(&format!("http://{addr}")).with_kind(ErrorKind::ParseUrl)
+        Ok(TestServer {
+            url: Url::parse(&format!("http://{addr}")).with_kind(ErrorKind::ParseUrl)?,
+            complete_hits,
+        })
     }
 
-    #[tokio::test]
-    async fn download_to_path_falls_back_after_truncated_mirror() -> Result<(), Error> {
-        let base_url = spawn_test_server().await?;
-        let asset = RegistryAsset {
-            published_at: Utc::now(),
-            urls: vec![base_url.join("truncated")?, base_url.join("complete")?],
-            commitment: (),
-            signatures: HashMap::new(),
-        };
+    async fn buffered_contents(asset: RegistryAsset<()>) -> Result<Vec<u8>, Error> {
         let progress = FullProgressTracker::new().add_phase("Downloading".into(), Some(100));
         let tmp_dir = TmpDir::new().await?;
-
         let source = asset
-            .download_to_path(tmp_dir.join("package.s9pk"), Client::new(), progress)
+            .load_buffered_http_source_with_path(
+                tmp_dir.join("package.s9pk"),
+                Client::new(),
+                progress,
+            )
             .await?;
         let mut contents = Vec::new();
         source.fetch_all().await?.read_to_end(&mut contents).await?;
+        Ok(contents)
+    }
 
-        assert_eq!(contents, b"hello world");
+    #[tokio::test]
+    async fn buffered_download_resumes_same_url_after_truncated_response() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![server.url.join("resume")?, server.url.join("complete")?],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        assert_eq!(buffered_contents(asset).await?, b"hello world");
+        assert_eq!(server.complete_hits.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_retries_same_url_when_range_is_ignored() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![
+                server.url.join("range-ignored")?,
+                server.url.join("complete")?,
+            ],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        assert_eq!(buffered_contents(asset).await?, b"hello world");
+        assert_eq!(server.complete_hits.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_falls_back_to_next_mirror_after_retry_fails() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![
+                server.url.join("always-truncated")?,
+                server.url.join("complete")?,
+            ],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        assert_eq!(buffered_contents(asset).await?, b"hello world");
+        assert_eq!(server.complete_hits.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_fails_after_all_mirrors_fail() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![server.url.join("always-truncated")?],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        assert!(buffered_contents(asset).await.is_err());
         Ok(())
     }
 }

--- a/core/src/registry/package/get.rs
+++ b/core/src/registry/package/get.rs
@@ -575,6 +575,7 @@ pub async fn cli_download(
         .await?;
     progress_sink.into_inner().1.complete();
 
+    source.wait_for_buffered().await?;
     tokio::fs::rename(dest_tmp, dest).await?;
 
     progress_tracker.complete();

--- a/core/src/registry/package/get.rs
+++ b/core/src/registry/package/get.rs
@@ -575,7 +575,6 @@ pub async fn cli_download(
         .await?;
     progress_sink.into_inner().1.complete();
 
-    source.wait_for_buffered().await?;
     tokio::fs::rename(dest_tmp, dest).await?;
 
     progress_tracker.complete();

--- a/core/src/upload.rs
+++ b/core/src/upload.rs
@@ -207,10 +207,6 @@ impl UploadingFile {
         file.tmp_dir = Some(tmp_dir);
         Ok((handle, file))
     }
-    /// Reader/writer pair where the writer is a plain `tokio::fs::File`. Used for
-    /// HTTP downloads, which need exact byte-level progress (to construct `Range`
-    /// resume headers) and the ability to truncate the file between retry attempts —
-    /// neither of which is workable with the O_DIRECT buffering used by uploads.
     pub async fn with_path_for_download(
         path: impl AsRef<Path>,
         mut progress: PhaseProgressTrackerHandle,
@@ -500,38 +496,18 @@ impl AsyncWrite for UploadHandle {
     }
 }
 
-/// State passed to a `DownloadHandle::download_from` factory each time it's asked
-/// for the next response. The factory uses these to decide whether to issue a
-/// `Range`-resume request, switch mirrors, or give up.
 pub struct DownloadAttemptContext {
-    /// Bytes already written to disk for this download. Use to construct
-    /// `Range: bytes=N-` when issuing a resume request.
     pub bytes_written: u64,
-    /// Total file size if any prior attempt's response told us. None until the
-    /// first response.
     pub expected_size: Option<u64>,
-    /// The error from the previous attempt, if this isn't the first call.
     pub last_error: Option<Error>,
 }
 
-/// Writer half of an `UploadingFile` pair returned by `UploadingFile::with_path_for_download`.
-/// Backed by a plain `tokio::fs::File` (so it can seek / truncate / report exact
-/// on-disk byte counts) and exposes `download_from`, which loops over a factory
-/// of responses to implement retry-with-fallback.
 pub struct DownloadHandle {
     tmp_dir: Option<Arc<TmpDir>>,
     file: tokio::fs::File,
     progress: watch::Sender<Progress>,
 }
 impl DownloadHandle {
-    /// Download by streaming from a sequence of HTTP responses produced by
-    /// `next_response`. The factory is invoked once at the start, then again
-    /// whenever the previous stream errors or ends before the expected size —
-    /// it implements the retry policy (which URL, whether to send a Range header,
-    /// when to give up). The handle keeps the per-chunk write loop, progress
-    /// tracking, and file truncate/resume bookkeeping. A 206 Partial Content
-    /// response continues at `bytes_written`; anything else truncates the file
-    /// back to zero and restarts.
     pub async fn download_from<F, Fut>(&mut self, mut next_response: F)
     where
         F: FnMut(DownloadAttemptContext) -> Fut,
@@ -664,7 +640,6 @@ impl Drop for DownloadHandle {
     }
 }
 
-/// Parse the total file size from a `Content-Range: bytes <start>-<end>/<total>` header.
 fn parse_content_range_total(headers: &HeaderMap) -> Option<u64> {
     headers
         .get(CONTENT_RANGE)?

--- a/core/src/upload.rs
+++ b/core/src/upload.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::io::SeekFrom;
 use std::path::Path;
 use std::pin::Pin;
@@ -10,7 +11,7 @@ use axum::extract::Request;
 use axum::response::Response;
 use bytes::Bytes;
 use futures::{FutureExt, Stream, StreamExt, ready};
-use http::header::CONTENT_LENGTH;
+use http::header::{CONTENT_LENGTH, CONTENT_RANGE};
 use http::{HeaderMap, StatusCode};
 use imbl_value::InternedString;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
@@ -206,6 +207,48 @@ impl UploadingFile {
         file.tmp_dir = Some(tmp_dir);
         Ok((handle, file))
     }
+    /// Reader/writer pair where the writer is a plain `tokio::fs::File`. Used for
+    /// HTTP downloads, which need exact byte-level progress (to construct `Range`
+    /// resume headers) and the ability to truncate the file between retry attempts —
+    /// neither of which is workable with the O_DIRECT buffering used by uploads.
+    pub async fn with_path_for_download(
+        path: impl AsRef<Path>,
+        mut progress: PhaseProgressTrackerHandle,
+    ) -> Result<(DownloadHandle, Self), Error> {
+        progress.set_units(Some(ProgressUnits::Bytes));
+        let progress = watch::channel(Progress {
+            tracker: progress,
+            expected_size: None,
+            written: 0,
+            error: None,
+            complete: false,
+        });
+        let file = create_file(path).await?;
+        let multi_cursor = MultiCursorFile::open(&file).await?;
+        let uploading = Self {
+            tmp_dir: None,
+            file: multi_cursor,
+            progress: progress.1,
+        };
+        Ok((
+            DownloadHandle {
+                tmp_dir: None,
+                file,
+                progress: progress.0,
+            },
+            uploading,
+        ))
+    }
+    pub async fn new_for_download(
+        progress: PhaseProgressTrackerHandle,
+    ) -> Result<(DownloadHandle, Self), Error> {
+        let tmp_dir = Arc::new(TmpDir::new().await?);
+        let (mut handle, mut file) =
+            Self::with_path_for_download(tmp_dir.join("download.tmp"), progress).await?;
+        handle.tmp_dir = Some(tmp_dir.clone());
+        file.tmp_dir = Some(tmp_dir);
+        Ok((handle, file))
+    }
     pub async fn wait_for_complete(&self) -> Result<(), Error> {
         Progress::ready(&mut self.progress.clone()).await
     }
@@ -350,11 +393,6 @@ impl UploadHandle {
             .await;
         self.progress.send_if_modified(|p| p.complete());
     }
-    pub async fn download(&mut self, response: reqwest::Response) {
-        self.process_headers(response.headers());
-        self.process_body(response.bytes_stream()).await;
-        self.progress.send_if_modified(|p| p.complete());
-    }
     fn process_headers(&mut self, headers: &HeaderMap) {
         if let Some(content_length) = headers
             .get(CONTENT_LENGTH)
@@ -373,10 +411,7 @@ impl UploadHandle {
     ) {
         while let Some(next) = body.next().await {
             if let Err(e) = async {
-                self.write_all(
-                    &next.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
-                )
-                .await?;
+                self.write_all(&next.map_err(std::io::Error::other)?).await?;
                 Ok(())
             }
             .await
@@ -388,7 +423,6 @@ impl UploadHandle {
         if let Err(e) = self.file.sync_all().await {
             self.progress.send_if_modified(|p| p.handle_error(&e));
         }
-        // Update progress with final synced bytes
         self.update_sync_progress();
     }
     fn update_sync_progress(&mut self) {
@@ -464,4 +498,181 @@ impl AsyncWrite for UploadHandle {
             a => a,
         }
     }
+}
+
+/// State passed to a `DownloadHandle::download_from` factory each time it's asked
+/// for the next response. The factory uses these to decide whether to issue a
+/// `Range`-resume request, switch mirrors, or give up.
+pub struct DownloadAttemptContext {
+    /// Bytes already written to disk for this download. Use to construct
+    /// `Range: bytes=N-` when issuing a resume request.
+    pub bytes_written: u64,
+    /// Total file size if any prior attempt's response told us. None until the
+    /// first response.
+    pub expected_size: Option<u64>,
+    /// The error from the previous attempt, if this isn't the first call.
+    pub last_error: Option<Error>,
+}
+
+/// Writer half of an `UploadingFile` pair returned by `UploadingFile::with_path_for_download`.
+/// Backed by a plain `tokio::fs::File` (so it can seek / truncate / report exact
+/// on-disk byte counts) and exposes `download_from`, which loops over a factory
+/// of responses to implement retry-with-fallback.
+pub struct DownloadHandle {
+    tmp_dir: Option<Arc<TmpDir>>,
+    file: tokio::fs::File,
+    progress: watch::Sender<Progress>,
+}
+impl DownloadHandle {
+    /// Download by streaming from a sequence of HTTP responses produced by
+    /// `next_response`. The factory is invoked once at the start, then again
+    /// whenever the previous stream errors or ends before the expected size —
+    /// it implements the retry policy (which URL, whether to send a Range header,
+    /// when to give up). The handle keeps the per-chunk write loop, progress
+    /// tracking, and file truncate/resume bookkeeping. A 206 Partial Content
+    /// response continues at `bytes_written`; anything else truncates the file
+    /// back to zero and restarts.
+    pub async fn download_from<F, Fut>(&mut self, mut next_response: F)
+    where
+        F: FnMut(DownloadAttemptContext) -> Fut,
+        Fut: Future<Output = Result<reqwest::Response, Error>>,
+    {
+        let mut last_error: Option<Error> = None;
+        let outcome: Result<(), Error> = loop {
+            let (bytes_written, expected_size) = {
+                let p = self.progress.borrow();
+                (p.written, p.expected_size)
+            };
+            let response = match next_response(DownloadAttemptContext {
+                bytes_written,
+                expected_size,
+                last_error: last_error.as_ref().map(|e| e.clone_output()),
+            })
+            .await
+            {
+                Ok(r) => r,
+                Err(e) => break Err(e),
+            };
+            let response = match response.error_for_status() {
+                Ok(r) => r,
+                Err(e) => {
+                    last_error = Some(Error::new(e, ErrorKind::Network));
+                    continue;
+                }
+            };
+
+            if response.status() == StatusCode::PARTIAL_CONTENT {
+                if let Some(total) = parse_content_range_total(response.headers()) {
+                    self.progress.send_modify(|p| {
+                        p.expected_size = Some(total);
+                        p.tracker.set_total(total);
+                    });
+                }
+            } else {
+                if let Err(e) = self.file.set_len(0).await {
+                    break Err(Error::new(e, ErrorKind::Filesystem));
+                }
+                if let Err(e) = self.file.seek(SeekFrom::Start(0)).await {
+                    break Err(Error::new(e, ErrorKind::Filesystem));
+                }
+                self.progress.send_modify(|p| {
+                    p.written = 0;
+                    p.tracker.set_done(0);
+                });
+                if let Some(content_length) = response
+                    .headers()
+                    .get(CONTENT_LENGTH)
+                    .and_then(|a| a.to_str().log_err())
+                    .and_then(|a| a.parse::<u64>().log_err())
+                {
+                    self.progress.send_modify(|p| {
+                        p.expected_size = Some(content_length);
+                        p.tracker.set_total(content_length);
+                    });
+                }
+            }
+
+            let stream_result: Result<(), Error> = async {
+                let mut stream = response.bytes_stream();
+                while let Some(next) = stream.next().await {
+                    let chunk = next.map_err(|e| Error::new(e, ErrorKind::Network))?;
+                    self.file
+                        .write_all(&chunk)
+                        .await
+                        .map_err(|e| Error::new(e, ErrorKind::Filesystem))?;
+                    let len = chunk.len() as u64;
+                    self.progress.send_modify(|p| {
+                        p.written += len;
+                        p.tracker += len;
+                    });
+                }
+                Ok(())
+            }
+            .await;
+
+            if let Err(e) = stream_result {
+                last_error = Some(e);
+                continue;
+            }
+
+            let (written, expected) = {
+                let p = self.progress.borrow();
+                (p.written, p.expected_size)
+            };
+            match expected {
+                Some(total) if written < total => {
+                    last_error = Some(Error::new(
+                        eyre!("download ended after {written} bytes, expected {total}"),
+                        ErrorKind::Network,
+                    ));
+                    continue;
+                }
+                Some(total) if written > total => {
+                    break Err(Error::new(
+                        eyre!("Too many bytes received"),
+                        ErrorKind::Network,
+                    ));
+                }
+                _ => break Ok(()),
+            }
+        };
+
+        match outcome {
+            Ok(()) => {
+                if let Err(e) = self.file.sync_all().await {
+                    self.progress
+                        .send_if_modified(|p| p.handle_error(&e));
+                }
+            }
+            Err(e) => {
+                self.progress.send_if_modified(|p| {
+                    if p.error.is_none() {
+                        p.error = Some(e);
+                        true
+                    } else {
+                        false
+                    }
+                });
+            }
+        }
+        self.progress.send_if_modified(|p| p.complete());
+    }
+}
+impl Drop for DownloadHandle {
+    fn drop(&mut self) {
+        self.progress.send_if_modified(|p| p.complete());
+    }
+}
+
+/// Parse the total file size from a `Content-Range: bytes <start>-<end>/<total>` header.
+fn parse_content_range_total(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get(CONTENT_RANGE)?
+        .to_str()
+        .ok()?
+        .rsplit_once('/')?
+        .1
+        .trim()
+        .parse()
+        .ok()
 }


### PR DESCRIPTION
## Summary
- download registry package assets fully to disk before deserializing/verifying them
- retry the next asset URL when an HTTP body stream fails or ends before its advertised content length
- update the CLI download path now that downloads complete before the source is returned

## Context
Repeated package install/update attempts can fail across different services with:

`Network Error: error decoding response body`

<img width="806" height="1031" alt="error" src="https://github.com/user-attachments/assets/f0b208d8-4c8c-43bf-9fcf-198527faff8a" />



This can happen when a registry asset URL responds successfully but the package body fails before the full file has been downloaded. In that case StartOS should try the next mirror URL instead of failing the update immediately.

## Testing
- `cargo test --manifest-path core/Cargo.toml download_to_path_falls_back_after_truncated_mirror --lib`
- `cargo build --manifest-path core/Cargo.toml --bin start-cli`
- `core/target/debug/start-cli --registry https://registry.start9.com/ registry package download bitcoind --target-version '31.0:10' --arch x86_64 --dest /tmp/startos-bitcoind-31.0-10-test.s9pk`
- `core/target/debug/start-cli --cookie-path /tmp/startos-test-cookies.json s9pk inspect /tmp/startos-bitcoind-31.0-10-test.s9pk commitment`