### PR TITLE
fix(os-install): preserve picks rightmost free region before data partition

### DIFF
--- a/core/src/os_install/gpt.rs
+++ b/core/src/os_install/gpt.rs
@@ -14,6 +14,168 @@ const ROOT_MIN_BYTES: u64 = 12 * 1024 * 1024 * 1024;
 /// 1 MiB at 512-byte sectors.
 const PARTITION_ALIGNMENT_LBA: u64 = 2048;
 
+/// Synchronous core of `partition()`: writes a fresh GPT to `device` placing
+/// efi/bios + boot + root, then either re-creates the protected data partition
+/// at its existing LBAs or fills the trailing free space with a new one.
+///
+/// Split out so unit tests can drive it against a sparse file without going
+/// through `quiesce_disk` / `partx --update`, which need a real block device.
+fn build_gpt_layout(
+    device: Box<dyn gpt::DiskDevice + Send>,
+    capacity: u64,
+    disk_path: &Path,
+    protected_partition_info: Option<(u64, u64, PathBuf)>,
+    use_efi: bool,
+) -> Result<(bool, Option<PathBuf>), Error> {
+    let mut device = device;
+    let mbr = gpt::mbr::ProtectiveMBR::with_lb_size(
+        u32::try_from((capacity / 512) - 1).unwrap_or(0xFF_FF_FF_FF),
+    );
+    mbr.overwrite_lba0(&mut device)?;
+    let mut gpt = GptConfig::new()
+        .writable(true)
+        .logical_block_size(LogicalBlockSize::Lb512)
+        .create_from_device(device, None)?;
+
+    gpt.update_partitions(Default::default())?;
+
+    let efi = if use_efi {
+        gpt.add_partition(
+            "efi",
+            100 * 1024 * 1024,
+            gpt::partition_types::EFI,
+            0,
+            Some(PARTITION_ALIGNMENT_LBA),
+        )?;
+        true
+    } else {
+        gpt.add_partition(
+            "bios-grub",
+            8 * 1024 * 1024,
+            gpt::partition_types::BIOS,
+            0,
+            Some(PARTITION_ALIGNMENT_LBA),
+        )?;
+        false
+    };
+    gpt.add_partition(
+        "boot",
+        2 * 1024 * 1024 * 1024,
+        gpt::partition_types::LINUX_FS,
+        0,
+        Some(PARTITION_ALIGNMENT_LBA),
+    )?;
+
+    // Elastic root: shrink within [ROOT_MIN_BYTES, ROOT_TARGET_BYTES] if a
+    // protected partition's first_lba sits inside the planned root region.
+    let lb_size: u64 = (*gpt.logical_block_size()).into();
+    let target_root_lba = ROOT_TARGET_BYTES.div_ceil(lb_size);
+    let min_root_lba = ROOT_MIN_BYTES.div_ceil(lb_size);
+    let root_size_bytes = if let Some((protect_first_lba, _, ref path)) = protected_partition_info {
+        // Pick the rightmost free region before the protected partition: it's
+        // the slot abutting the protected partition, so the only candidate that
+        // bounds how big root can grow without overlapping. Earlier slivers
+        // (e.g. the 2014-LBA gap that 2048-alignment leaves between LBA 34 and
+        // the EFI partition) would over-report `available_lba` and let root
+        // land past `protect_first_lba`, after which add_partition_at fails
+        // with NotEnoughSpace.
+        let last_free_start = gpt
+            .find_free_sectors()
+            .into_iter()
+            .filter(|(start, _)| *start < protect_first_lba)
+            .map(|(start, _)| start)
+            .max()
+            .ok_or_else(|| {
+                Error::new(
+                    eyre!("{}", t!("os-install.no-free-space-for-os-root")),
+                    crate::ErrorKind::BlockDevice,
+                )
+            })?;
+        let aligned_start = last_free_start.next_multiple_of(PARTITION_ALIGNMENT_LBA);
+        let available_lba = protect_first_lba.saturating_sub(aligned_start);
+        if available_lba < min_root_lba {
+            let available_bytes = available_lba.saturating_mul(lb_size);
+            return Err(Error::new(
+                eyre!(
+                    "{}",
+                    t!(
+                        "os-install.protected-partition-overlaps-os-root-bytes",
+                        path = path.display(),
+                        first_lba = protect_first_lba,
+                        available_bytes = available_bytes,
+                        min_bytes = ROOT_MIN_BYTES,
+                    )
+                ),
+                crate::ErrorKind::DiskManagement,
+            ));
+        }
+        available_lba.min(target_root_lba).saturating_mul(lb_size)
+    } else {
+        ROOT_TARGET_BYTES
+    };
+    gpt.add_partition(
+        "root",
+        root_size_bytes,
+        match crate::ARCH {
+            "x86_64" => gpt::partition_types::LINUX_ROOT_X64,
+            "aarch64" => gpt::partition_types::LINUX_ROOT_ARM_64,
+            _ => gpt::partition_types::LINUX_FS,
+        },
+        0,
+        Some(PARTITION_ALIGNMENT_LBA),
+    )?;
+
+    let data_part = if let Some((first_lba, last_lba, path)) = protected_partition_info {
+        // Re-create the data partition entry at the same location
+        let length_lba = last_lba - first_lba + 1;
+        let next_id = gpt.partitions().keys().max().map(|k| k + 1).unwrap_or(1);
+        gpt.add_partition_at(
+            "data",
+            next_id,
+            first_lba,
+            length_lba,
+            gpt::partition_types::LINUX_LVM,
+            0,
+        )?;
+        Some(path)
+    } else {
+        // Account for alignment offset so add_partition's length check passes
+        // when the largest free block isn't already 2048-aligned.
+        let lb_size_bytes: u64 = (*gpt.logical_block_size()).into();
+        let data_size_bytes = gpt
+            .find_free_sectors()
+            .iter()
+            .map(|(start, length_lba)| {
+                let alignment_offset = (PARTITION_ALIGNMENT_LBA
+                    - (start % PARTITION_ALIGNMENT_LBA))
+                    % PARTITION_ALIGNMENT_LBA;
+                length_lba.saturating_sub(alignment_offset) * lb_size_bytes
+            })
+            .max()
+            .filter(|s| *s > 0)
+            .ok_or_else(|| {
+                Error::new(
+                    eyre!("No free space left on device"),
+                    crate::ErrorKind::BlockDevice,
+                )
+            })?;
+        gpt.add_partition(
+            "data",
+            data_size_bytes,
+            gpt::partition_types::LINUX_LVM,
+            0,
+            Some(PARTITION_ALIGNMENT_LBA),
+        )?;
+        gpt.partitions()
+            .last_key_value()
+            .map(|(num, _)| partition_for(disk_path, *num))
+    };
+
+    gpt.write()?;
+
+    Ok((efi, data_part))
+}
+
 pub async fn partition(
     disk_path: &Path,
     capacity: u64,
@@ -69,154 +231,20 @@ pub async fn partition(
                 None
             };
 
-        let mut device = Box::new(
+        let device = Box::new(
             std::fs::File::options()
                 .read(true)
                 .write(true)
                 .open(&disk_path)?,
         );
 
-        let mbr = gpt::mbr::ProtectiveMBR::with_lb_size(
-            u32::try_from((capacity / 512) - 1).unwrap_or(0xFF_FF_FF_FF),
-        );
-        mbr.overwrite_lba0(&mut device)?;
-        let mut gpt = GptConfig::new()
-            .writable(true)
-            .logical_block_size(LogicalBlockSize::Lb512)
-            .create_from_device(device, None)?;
-
-        gpt.update_partitions(Default::default())?;
-
-        let efi = if use_efi {
-            gpt.add_partition(
-                "efi",
-                100 * 1024 * 1024,
-                gpt::partition_types::EFI,
-                0,
-                Some(PARTITION_ALIGNMENT_LBA),
-            )?;
-            true
-        } else {
-            gpt.add_partition(
-                "bios-grub",
-                8 * 1024 * 1024,
-                gpt::partition_types::BIOS,
-                0,
-                Some(PARTITION_ALIGNMENT_LBA),
-            )?;
-            false
-        };
-        gpt.add_partition(
-            "boot",
-            2 * 1024 * 1024 * 1024,
-            gpt::partition_types::LINUX_FS,
-            0,
-            Some(PARTITION_ALIGNMENT_LBA),
-        )?;
-
-        // Elastic root: shrink within [ROOT_MIN_BYTES, ROOT_TARGET_BYTES] if a
-        // protected partition's first_lba sits inside the planned root region.
-        let lb_size: u64 = (*gpt.logical_block_size()).into();
-        let target_root_lba = ROOT_TARGET_BYTES.div_ceil(lb_size);
-        let min_root_lba = ROOT_MIN_BYTES.div_ceil(lb_size);
-        let root_size_bytes = if let Some((protect_first_lba, _, ref path)) =
-            protected_partition_info
-        {
-            let earliest_free_start = gpt
-                .find_free_sectors()
-                .into_iter()
-                .filter(|(start, _)| *start < protect_first_lba)
-                .map(|(start, _)| start)
-                .min()
-                .ok_or_else(|| {
-                    Error::new(
-                        eyre!("{}", t!("os-install.no-free-space-for-os-root")),
-                        crate::ErrorKind::BlockDevice,
-                    )
-                })?;
-            let aligned_start = earliest_free_start.next_multiple_of(PARTITION_ALIGNMENT_LBA);
-            let available_lba = protect_first_lba.saturating_sub(aligned_start);
-            if available_lba < min_root_lba {
-                let available_bytes = available_lba.saturating_mul(lb_size);
-                return Err(Error::new(
-                    eyre!(
-                        "{}",
-                        t!(
-                            "os-install.protected-partition-overlaps-os-root-bytes",
-                            path = path.display(),
-                            first_lba = protect_first_lba,
-                            available_bytes = available_bytes,
-                            min_bytes = ROOT_MIN_BYTES,
-                        )
-                    ),
-                    crate::ErrorKind::DiskManagement,
-                ));
-            }
-            available_lba.min(target_root_lba).saturating_mul(lb_size)
-        } else {
-            ROOT_TARGET_BYTES
-        };
-        gpt.add_partition(
-            "root",
-            root_size_bytes,
-            match crate::ARCH {
-                "x86_64" => gpt::partition_types::LINUX_ROOT_X64,
-                "aarch64" => gpt::partition_types::LINUX_ROOT_ARM_64,
-                _ => gpt::partition_types::LINUX_FS,
-            },
-            0,
-            Some(PARTITION_ALIGNMENT_LBA),
-        )?;
-
-        let data_part = if let Some((first_lba, last_lba, path)) = protected_partition_info {
-            // Re-create the data partition entry at the same location
-            let length_lba = last_lba - first_lba + 1;
-            let next_id = gpt.partitions().keys().max().map(|k| k + 1).unwrap_or(1);
-            gpt.add_partition_at(
-                "data",
-                next_id,
-                first_lba,
-                length_lba,
-                gpt::partition_types::LINUX_LVM,
-                0,
-            )?;
-            Some(path)
-        } else {
-            // Account for alignment offset so add_partition's length check passes
-            // when the largest free block isn't already 2048-aligned.
-            let lb_size_bytes: u64 = (*gpt.logical_block_size()).into();
-            let data_size_bytes = gpt
-                .find_free_sectors()
-                .iter()
-                .map(|(start, length_lba)| {
-                    let alignment_offset =
-                        (PARTITION_ALIGNMENT_LBA - (start % PARTITION_ALIGNMENT_LBA))
-                            % PARTITION_ALIGNMENT_LBA;
-                    length_lba.saturating_sub(alignment_offset) * lb_size_bytes
-                })
-                .max()
-                .filter(|s| *s > 0)
-                .ok_or_else(|| {
-                    Error::new(
-                        eyre!("No free space left on device"),
-                        crate::ErrorKind::BlockDevice,
-                    )
-                })?;
-            gpt.add_partition(
-                "data",
-                data_size_bytes,
-                gpt::partition_types::LINUX_LVM,
-                0,
-                Some(PARTITION_ALIGNMENT_LBA),
-            )?;
-            gpt.partitions()
-                .last_key_value()
-                .map(|(num, _)| partition_for(&disk_path, *num))
-        };
-
-        gpt.write()?;
-
-        Ok::<_, Error>((efi, data_part))
+        build_gpt_layout(
+            device,
+            capacity,
+            &disk_path,
+            protected_partition_info,
+            use_efi,
+        )
     })
     .await
     .unwrap()?;
@@ -238,4 +266,160 @@ pub async fn partition(
         extra_boot,
         data: data_part,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use gpt::GptConfig;
+    use gpt::disk::LogicalBlockSize;
+
+    use super::*;
+
+    /// Reproduce Embassy 0.3.5.1's GPT layout so we can test the preserve path
+    /// against the geometry that 0.3.5.1 actually wrote: efi(100M) + boot(1G) +
+    /// root(15G) + data filling the rest, all without 1 MiB partition
+    /// alignment. Returns the data partition's first/last LBA.
+    fn write_0_3_5_1_layout(disk_path: &Path, capacity: u64) -> (u64, u64) {
+        let mut device = Box::new(
+            std::fs::File::options()
+                .read(true)
+                .write(true)
+                .open(disk_path)
+                .unwrap(),
+        );
+        let mbr = gpt::mbr::ProtectiveMBR::with_lb_size(
+            u32::try_from((capacity / 512) - 1).unwrap_or(0xFF_FF_FF_FF),
+        );
+        mbr.overwrite_lba0(&mut device).unwrap();
+        let mut gpt = GptConfig::new()
+            .writable(true)
+            .logical_block_size(LogicalBlockSize::Lb512)
+            .create_from_device(device, None)
+            .unwrap();
+        gpt.update_partitions(Default::default()).unwrap();
+        gpt.add_partition("efi", 100 * 1024 * 1024, gpt::partition_types::EFI, 0, None)
+            .unwrap();
+        gpt.add_partition(
+            "boot",
+            1024 * 1024 * 1024,
+            gpt::partition_types::LINUX_FS,
+            0,
+            None,
+        )
+        .unwrap();
+        gpt.add_partition(
+            "root",
+            15 * 1024 * 1024 * 1024,
+            gpt::partition_types::LINUX_ROOT_X64,
+            0,
+            None,
+        )
+        .unwrap();
+        let data_size_bytes = gpt
+            .find_free_sectors()
+            .iter()
+            .map(|(_, s)| *s * 512)
+            .min()
+            .unwrap();
+        gpt.add_partition(
+            "data",
+            data_size_bytes,
+            gpt::partition_types::LINUX_LVM,
+            0,
+            None,
+        )
+        .unwrap();
+        let data = gpt.partitions().get(&4).unwrap();
+        let (f, l) = (data.first_lba, data.last_lba);
+        gpt.write().unwrap();
+        (f, l)
+    }
+
+    fn make_sparse(path: &Path, capacity: u64) {
+        let f = std::fs::File::create(path).unwrap();
+        f.set_len(capacity).unwrap();
+    }
+
+    /// Regression test for https://github.com/Start9Labs/start-os/pull/3193
+    /// preserve path on 0.3.5.1 disks: the .min() that was originally used to
+    /// pick the free region before the protected data partition picked the
+    /// 2014-LBA sliver between LBA 34 and the new 2048-aligned EFI start, so
+    /// `available_lba` was over-reported and root landed 2014 LBAs past
+    /// `protect_first_lba`, after which add_partition_at("data", ...) returned
+    /// NotEnoughSpace.
+    #[test]
+    fn preserve_data_partition_from_0_3_5_1_layout() {
+        for size_gb in [32u64, 64, 128, 256, 512] {
+            let dir = std::env::temp_dir();
+            let path = dir.join(format!(
+                "startos-gpt-test-{}-{}.img",
+                std::process::id(),
+                size_gb
+            ));
+            let capacity = size_gb * 1024 * 1024 * 1024;
+            make_sparse(&path, capacity);
+
+            let (old_data_first, old_data_last) = write_0_3_5_1_layout(&path, capacity);
+            let protected = (old_data_first, old_data_last, PathBuf::from("/dev/sda4"));
+
+            let device = Box::new(
+                std::fs::File::options()
+                    .read(true)
+                    .write(true)
+                    .open(&path)
+                    .unwrap(),
+            );
+            let result = build_gpt_layout(
+                device,
+                capacity,
+                Path::new("/dev/sda"),
+                Some(protected),
+                true,
+            );
+            assert!(
+                result.is_ok(),
+                "build_gpt_layout({} GiB) failed: {:?}",
+                size_gb,
+                result.err()
+            );
+
+            // Re-open and inspect the produced GPT.
+            let dev = Box::new(std::fs::File::options().read(true).open(&path).unwrap());
+            let new_gpt = GptConfig::new()
+                .writable(false)
+                .logical_block_size(LogicalBlockSize::Lb512)
+                .open_from_device(dev)
+                .unwrap();
+            let parts = new_gpt.partitions();
+            assert_eq!(
+                parts.len(),
+                4,
+                "expected 4 partitions on {} GiB disk",
+                size_gb
+            );
+            let data = parts.get(&4).expect("partition 4 (data) missing");
+            assert_eq!(
+                data.first_lba, old_data_first,
+                "data partition first_lba moved on {} GiB disk",
+                size_gb
+            );
+            assert_eq!(
+                data.last_lba, old_data_last,
+                "data partition last_lba moved on {} GiB disk",
+                size_gb
+            );
+            let root = parts.get(&3).expect("partition 3 (root) missing");
+            assert!(
+                root.last_lba < data.first_lba,
+                "root.last_lba {} >= data.first_lba {} on {} GiB disk",
+                root.last_lba,
+                data.first_lba,
+                size_gb
+            );
+
+            std::fs::remove_file(&path).ok();
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Reported in Matrix: users upgrading from 0.3.5.1 to 0.4.0-beta.8 hit `RPC Error: Disk Management Error Unable to find enough space on drive` whenever they pick **Preserve** in the setup wizard. Workaround so far has been to install an earlier beta first, then update.

I introduced this in #3193 (the elastic-root rewrite of `gpt::partition`). Picking the free region the new root partition will land in used `min()` over `(start, _)` of `find_free_sectors()`. With the new 1 MiB alignment the fresh GPT now has a 2014-LBA sliver between LBA 34 (first_usable) and LBA 2048 (where EFI starts). That sliver wins `min()`, so `available_lba = protect_first_lba - 2048` overshoots the room actually available between boot and the protected partition.

On a 0.3.5.1 EFI install (efi 100M / boot 1G / root 15G, unaligned, data partition at LBA 33759266) `available_lba` becomes 33757218 — larger than the 14 GiB target — so root is sized to 14 GiB, gpt-rs places it at LBA 4401152..33761279 (2014 LBAs *past* `protect_first_lba`), and `add_partition_at("data", first_lba=33759266, ...)` then fails because 33759266 is no longer in any free section. The gpt crate surfaces this as `NotEnoughSpace` → `"Unable to find enough space on drive"`.

The fix is one logical line: take `max()` instead of `min()` so we pick the free region abutting the protected partition (the only one root will actually be placed in). On the 0.3.5.1 EFI layout that gives `available_lba = 29358114` — about 1 MiB under the 14 GiB target — and elastic root shrinks accordingly, leaving the data partition at its original LBAs.

To make this testable without `quiesce_disk` / `partx --update` against a real block device, the synchronous core of `partition()` is split into a `build_gpt_layout` helper that takes any `gpt::DiskDevice`.

- Reproduced the failure end-to-end against a synthesized 0.3.5.1 GPT (32 / 64 / 128 / 256 / 512 GiB sparse files) and confirmed the same error string.
- Added regression test `os_install::gpt::tests::preserve_data_partition_from_0_3_5_1_layout` that lays out the 0.3.5.1-shaped GPT and asserts the rebuilt table keeps `data.first_lba` / `data.last_lba` at their pre-existing values and `root.last_lba < data.first_lba`. Verified the test fails on `master` (with the original `.min()`) and passes after the fix.

The MBR preserve path is unaffected — `mbr.rs` writes partition entries directly, so it doesn't go through `gpt-rs`'s free-region search and is fine for 0.3.5.1's hardcoded MBR layout.

## Test plan

- [x] `cargo check --lib`
- [x] `cargo test --lib --features=test os_install::gpt::tests::preserve_data_partition_from_0_3_5_1_layout` (new test, passes on fix, fails on master)
- [x] `cargo test --lib --features=test` (325 + 1 new = 326 pass)
- [ ] Build a `0.4.0-beta.8 + this patch` ISO and reinstall over a real 0.3.5.1 EFI disk with Preserve selected. I haven't verified end-to-end on hardware/VM yet — the existing 0.3.5.1 ISO + helix-vm template would need to be wired up. Worth doing before tagging beta.9, but the unit test exercises exactly the geometry the failing reports describe.