### PR TITLE
fix(sdk/fileHelper): scope abort listener to one watch iteration

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.3 — StartOS 0.4.0-beta.8 (2026-05-07)
+
+### Fixed
+
+- `FileHelper.produce` no longer leaks an `abort` listener on its parent `AbortSignal` per `fs.watch` event. The listener was registered inside the `while` loop and never detached, so after ~11 file changes during a single `.const()` lifetime Node emitted `MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]`. The listener is now scoped to a single iteration via `try`/`finally` so it is removed before the next iteration registers its own. Fixes [#3182](https://github.com/Start9Labs/start-os/issues/3182)
+
 ## 1.4.2 — StartOS 0.4.0-beta.8 (2026-05-06)
 
 ### Changed

--- a/sdk/package/lib/util/fileHelper.ts
+++ b/sdk/package/lib/util/fileHelper.ts
@@ -288,20 +288,25 @@ class FileHelperImpl<A> implements FileHelper<A> {
         while (this.effects.isInContext && !abort.aborted) {
           if (await exists(filePath)) {
             const ctrl = new AbortController()
-            abort.addEventListener('abort', () => ctrl.abort())
-            const watch = fs.watch(filePath, {
-              persistent: false,
-              signal: ctrl.signal,
-            })
-            yield await doRead()
-            await Promise.resolve()
-              .then(async () => {
-                for await (const _ of watch) {
-                  ctrl.abort()
-                  return null
-                }
+            const onAbort = () => ctrl.abort()
+            abort.addEventListener('abort', onAbort, { once: true })
+            try {
+              const watch = fs.watch(filePath, {
+                persistent: false,
+                signal: ctrl.signal,
               })
-              .catch((e) => console.error(asError(e)))
+              yield await doRead()
+              await Promise.resolve()
+                .then(async () => {
+                  for await (const _ of watch) {
+                    ctrl.abort()
+                    return null
+                  }
+                })
+                .catch((e) => console.error(asError(e)))
+            } finally {
+              abort.removeEventListener('abort', onAbort)
+            }
           } else {
             yield null
             await onCreated(filePath).catch((e) => console.error(asError(e)))

--- a/sdk/package/package.json
+++ b/sdk/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./package/lib/index.js",
   "types": "./package/lib/index.d.ts",


### PR DESCRIPTION
## Summary

`FileHelper.produce` registered a fresh `abort` listener on the parent `AbortSignal` inside its `while` loop, once per `fs.watch` event, and never detached it. After ~11 file changes during a single `.const()` lifetime Node emits:

```
MaxListenersExceededWarning: Possible EventTarget memory leak detected.
11 abort listeners added to [AbortSignal]. MaxListeners is 10.
```

The listeners are GC'd when the outer subscription ends, so this is cosmetic — but the warning is real and masks genuine listener leaks elsewhere in package logs.

Wrap the iteration in `try`/`finally` and `removeEventListener` the `onAbort` handler before looping. `{ once: true }` alone isn't enough: non-abort exits (the watch emitting an event) leave the listener attached.

Bumps SDK to `1.4.3` with a `### Fixed` changelog entry.

Fixes #3182.

## Test plan

- [x] `npm run check` (tsc) in `sdk/package`
- [x] `jest` in `sdk/package` — 42/42 pass
- [ ] Manual: rapid file writes against a `FileHelper` model with an active `.const()` should no longer trip `MaxListenersExceededWarning`