### PR TITLE
fix(web/ui): derive url plugin protocol label from address scheme

### DIFF
--- a/web/projects/ui/src/app/routes/portal/components/interfaces/addresses/plugin/item.component.ts
+++ b/web/projects/ui/src/app/routes/portal/components/interfaces/addresses/plugin/item.component.ts
@@ -16,7 +16,12 @@ import { PluginActionsComponent } from './actions.component'
 @Component({
   selector: 'tr[pluginAddress]',
   template: `
-    <td>{{ address().hostnameInfo.ssl ? 'HTTPS' : 'HTTP' }}</td>
+    <td>
+      {{
+        address().scheme?.toUpperCase() ??
+          (address().hostnameInfo.ssl ? 'SSL' : 'TCP/UDP')
+      }}
+    </td>
     <td [style.grid-area]="'2 / 1 / 2 / 2'">
       <div class="url">
         @if (address().masked && currentlyMasked()) {

--- a/web/projects/ui/src/app/routes/portal/components/interfaces/interface.service.ts
+++ b/web/projects/ui/src/app/routes/portal/components/interfaces/interface.service.ts
@@ -177,6 +177,8 @@ export class InterfaceService {
     const masked = serviceInterface.masked
     const groupMap = new Map<string, PluginAddress[]>()
 
+    const { scheme, sslScheme } = serviceInterface.addressInfo
+
     for (const h of addr.available) {
       if (h.metadata.kind !== 'plugin') continue
 
@@ -189,6 +191,7 @@ export class InterfaceService {
 
       groupMap.get(pluginId)!.push({
         url,
+        scheme: h.ssl ? sslScheme : scheme,
         hostnameInfo: h,
         masked,
       })
@@ -336,6 +339,7 @@ export type GatewayAddressGroup = {
 
 export type PluginAddress = {
   url: string
+  scheme: string | null
   hostnameInfo: T.HostnameInfo
   masked: boolean
 }


### PR DESCRIPTION
## Summary

Fixes #3181. The URL plugin tile previously rendered every address as `HTTP`/`HTTPS` based on `hostnameInfo.ssl` alone, mislabeling raw TCP serves (e.g. tailscale `--tcp`) as HTTP.

Per dr-bonez's guidance on the issue:
- Carry the effective scheme on `PluginAddress` (derived from `addressInfo.scheme`/`sslScheme` per the host's `ssl` flag, same logic the SDK uses to build the URL).
- Render the scheme capitalized.
- Fall back to `SSL` / `TCP/UDP` when no scheme is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)