### PR TITLE
chore: bump StartOS to 0.4.0-beta.9

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6482,7 +6482,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "start-os"
-version = "0.4.0-beta.8"
+version = "0.4.0-beta.9"
 dependencies = [
  "aes",
  "async-acme",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 name = "start-os"
 readme = "README.md"
 repository = "https://github.com/Start9Labs/start-os"
-version = "0.4.0-beta.8" # VERSION_BUMP
+version = "0.4.0-beta.9" # VERSION_BUMP
 
 [lib]
 name = "startos"

--- a/core/src/version/mod.rs
+++ b/core/src/version/mod.rs
@@ -72,8 +72,9 @@ mod v0_4_0_beta_5;
 mod v0_4_0_beta_6;
 mod v0_4_0_beta_7;
 mod v0_4_0_beta_8;
+mod v0_4_0_beta_9;
 
-pub type Current = v0_4_0_beta_8::Version; // VERSION_BUMP
+pub type Current = v0_4_0_beta_9::Version; // VERSION_BUMP
 
 impl Current {
     #[instrument(skip(self, db))]
@@ -213,7 +214,8 @@ enum Version {
     V0_4_0_beta_5(Wrapper<v0_4_0_beta_5::Version>),
     V0_4_0_beta_6(Wrapper<v0_4_0_beta_6::Version>),
     V0_4_0_beta_7(Wrapper<v0_4_0_beta_7::Version>),
-    V0_4_0_beta_8(Wrapper<v0_4_0_beta_8::Version>), // VERSION_BUMP
+    V0_4_0_beta_8(Wrapper<v0_4_0_beta_8::Version>),
+    V0_4_0_beta_9(Wrapper<v0_4_0_beta_9::Version>), // VERSION_BUMP
     Other(exver::Version),
 }
 
@@ -288,7 +290,8 @@ impl Version {
             Self::V0_4_0_beta_5(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_6(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_7(v) => DynVersion(Box::new(v.0)),
-            Self::V0_4_0_beta_8(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
+            Self::V0_4_0_beta_8(v) => DynVersion(Box::new(v.0)),
+            Self::V0_4_0_beta_9(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
             Self::Other(v) => {
                 return Err(Error::new(
                     eyre!("unknown version {v}"),
@@ -355,7 +358,8 @@ impl Version {
             Version::V0_4_0_beta_5(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_6(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_7(Wrapper(x)) => x.semver(),
-            Version::V0_4_0_beta_8(Wrapper(x)) => x.semver(), // VERSION_BUMP
+            Version::V0_4_0_beta_8(Wrapper(x)) => x.semver(),
+            Version::V0_4_0_beta_9(Wrapper(x)) => x.semver(), // VERSION_BUMP
             Version::Other(x) => x.clone(),
         }
     }

--- a/core/src/version/v0_4_0_beta_9.rs
+++ b/core/src/version/v0_4_0_beta_9.rs
@@ -1,0 +1,37 @@
+use exver::{PreReleaseSegment, VersionRange};
+
+use super::v0_3_5::V0_3_0_COMPAT;
+use super::{VersionT, v0_4_0_beta_8};
+use crate::prelude::*;
+
+lazy_static::lazy_static! {
+    static ref V0_4_0_beta_9: exver::Version = exver::Version::new(
+        [0, 4, 0],
+        [PreReleaseSegment::String("beta".into()), 9.into()]
+    );
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Version;
+
+impl VersionT for Version {
+    type Previous = v0_4_0_beta_8::Version;
+    type PreUpRes = ();
+
+    async fn pre_up(self) -> Result<Self::PreUpRes, Error> {
+        Ok(())
+    }
+    fn semver(self) -> exver::Version {
+        V0_4_0_beta_9.clone()
+    }
+    fn compat(self) -> &'static VersionRange {
+        &V0_3_0_COMPAT
+    }
+    #[instrument(skip_all)]
+    fn up(self, _db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+        Ok(Value::Null)
+    }
+    fn down(self, _db: &mut Value) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/sdk/package/lib/StartSdk.ts
+++ b/sdk/package/lib/StartSdk.ts
@@ -69,7 +69,7 @@ import { createVolumes } from './util/Volume'
 import { getDataVersion, setDataVersion } from './version'
 
 /** The minimum StartOS version required by this SDK release */
-export const OSVersion = testTypeVersion('0.4.0-beta.8')
+export const OSVersion = testTypeVersion('0.4.0-beta.9')
 
 // prettier-ignore
 type AnyNeverCond<T extends any[], Then, Else> = 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.8",
+  "version": "0.4.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startos-ui",
-      "version": "0.4.0-beta.8",
+      "version": "0.4.0-beta.9",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^21.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.8",
+  "version": "0.4.0-beta.9",
   "author": "Start9 Labs, Inc",
   "homepage": "https://start9.com/",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bumps StartOS to `0.4.0-beta.9` across `core/Cargo.toml`, `core/Cargo.lock`, `core/src/version/mod.rs` + new `v0_4_0_beta_9.rs` migration stub, `web/package.json`, and `web/package-lock.json`.
- Bumps the SDK's `OSVersion` constant in `sdk/package/lib/StartSdk.ts` to `0.4.0-beta.9` because in-flight SDK changes (`sdk.notification.create`) rely on this OS release.

No DB migration logic is needed — the new `v0_4_0_beta_9` version's `up`/`down` are no-ops.

The SDK npm package version is left at `1.4.3`; the notification PR will bump it (to 1.5.0) when it lands.

## Test plan

- [x] `cargo check --lib -p start-os` (compiles clean)
- [x] Full `make` / ISO build verified by a reviewer with cached web/dist