### PR TITLE
fix(image-recipe): bump NVIDIA driver to 580.159.03 for kernel 7.0+

### DIFF
--- a/build/image-recipe/build.sh
+++ b/build/image-recipe/build.sh
@@ -231,7 +231,7 @@ if [ "${NVIDIA}" = "1" ]; then
     # install a specific NVIDIA driver version
 
     # ---------------- configuration ----------------
-    NVIDIA_DRIVER_VERSION="\${NVIDIA_DRIVER_VERSION:-580.126.09}"
+    NVIDIA_DRIVER_VERSION="\${NVIDIA_DRIVER_VERSION:-580.159.03}"
 
     BASE_URL="https://download.nvidia.com/XFree86/Linux-${QEMU_ARCH}"
 


### PR DESCRIPTION
## Summary

- Trixie-backports rolled forward to `linux-headers-7.0.4+deb13`, which removed `VMA_LOCK_OFFSET` and changed `__is_vma_write_locked` to a single-argument signature. The pinned `580.126.09` NVIDIA driver still emits the old API and fails to build both nvidia targets in CI:

  ```
  nvidia/nv-mmap.c:868:24: error: 'VMA_LOCK_OFFSET' undeclared
  nvidia/nv-mmap.c:920:9: error: too many arguments to function '__is_vma_write_locked'
  ```

- `580.142+` adds an `NV_VMA_LOCK_OFFSET` shim (`VM_REFCNT_EXCLUDE_READERS_FLAG` on new kernels, legacy `VMA_LOCK_OFFSET` otherwise) that compiles on both old and new headers. Bumping to `580.159.03`, the latest release on the 580 LTS branch.

## Test plan

- [ ] `Debian-based ISO and SquashFS` workflow passes for `x86_64-nvidia`
- [ ] `Debian-based ISO and SquashFS` workflow passes for `aarch64-nvidia`
- [ ] All other platforms (`x86_64`, `aarch64`, `riscv64`, etc.) still build