### PR TITLE
fix(core/service): bound boot-time service init concurrency at 4

### DIFF
--- a/core/src/service/service_map.rs
+++ b/core/src/service/service_map.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use color_eyre::eyre::eyre;
 use exver::VersionRange;
 use futures::future::{BoxFuture, Fuse};
-use futures::stream::FuturesUnordered;
+use futures::stream;
 use futures::{Future, FutureExt, StreamExt, TryFutureExt};
 use imbl::OrdMap;
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, oneshot};
@@ -34,6 +34,8 @@ use crate::status::{DesiredStatus, StatusInfo};
 use crate::util::future::NonDetachingJoinHandle;
 use crate::util::serde::{Base32, Pem};
 use crate::util::sync::SyncMutex;
+
+const SERVICE_INIT_CONCURRENCY: usize = 4;
 
 pub type DownloadInstallFuture = BoxFuture<'static, Result<InstallFuture, Error>>;
 pub type InstallFuture = BoxFuture<'static, Result<(), Error>>;
@@ -89,16 +91,14 @@ impl ServiceMap {
     #[instrument(skip_all)]
     pub async fn init(&self, ctx: &RpcContext) -> Result<(), Error> {
         let ids = ctx.db.peek().await.as_public().as_package_data().keys()?;
-        let mut jobs = FuturesUnordered::new();
-        for id in &ids {
-            jobs.push(self.load(ctx, id, LoadDisposition::Retry));
-        }
-        while let Some(res) = jobs.next().await {
-            if let Err(e) = res {
-                tracing::error!("Error loading installed package as service: {e}");
-                tracing::debug!("{e:?}");
-            }
-        }
+        stream::iter(&ids)
+            .for_each_concurrent(Some(SERVICE_INIT_CONCURRENCY), |id| async move {
+                if let Err(e) = self.load(ctx, id, LoadDisposition::Retry).await {
+                    tracing::error!("Error loading installed package as service: {e}");
+                    tracing::debug!("{e:?}");
+                }
+            })
+            .await;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- `ServiceMap::init` loaded every installed package via `FuturesUnordered`, firing N parallel `LxcContainer::new` + `connect_rpc` + volume/asset/image mount calls at once.
- On prodboxes with many services, contention prevented the in-LXC `container-runtime` systemd unit from reaching its `listen()` call within `RPC_CONNECT_TIMEOUT`, surfacing as "timed out waiting for socket" for *most* (but not all) services on every boot.
- The "Rebuild container" UI button calls the same `load()` one service at a time and always recovers — strong evidence the cause is concurrency, not budget. Previous timeout bumps (30 → 60 → 120s) confirmed budget wasn't the limiter.

## Fix

Cap parallelism at 4 via `for_each_concurrent(Some(SERVICE_INIT_CONCURRENCY), …)`. Preserves boot speed for small deployments while keeping LXC/disk contention bounded. Pairs naturally with the existing 120s `RPC_CONNECT_TIMEOUT` as a safety net.