### PR TITLE
fix(marketplace): clear search query when leaving, add clear button to search field

### DIFF
--- a/web/projects/marketplace/src/pages/list/search/search.component.html
+++ b/web/projects/marketplace/src/pages/list/search/search.component.html
@@ -1,11 +1,10 @@
-<div class="search-box">
-  <tui-icon icon="@tui.search" />
+<tui-textfield iconStart="@tui.search" tuiTextfieldSize="m">
   <input
-    type="text"
+    tuiInput
     name="search"
     placeholder="Search..."
     autocomplete="off"
     [ngModel]="query"
     (ngModelChange)="onModelChange($event)"
   />
-</div>
+</tui-textfield>

--- a/web/projects/marketplace/src/pages/list/search/search.component.scss
+++ b/web/projects/marketplace/src/pages/list/search/search.component.scss
@@ -1,32 +1,3 @@
-.search-box {
-  color: rgb(244 244 245);
-  background-color: rgb(113 113 122);
-  padding-left: 0.75rem;
-  padding-right: 0.75rem;
-  border-radius: 9999px;
-  position: relative;
-  display: flex;
-  align-items: center;
-
-  input {
-    margin-top: 0.25rem;
-    background-color: transparent;
-    padding: 0.5rem 0.75rem;
-    &::placeholder {
-      color: rgb(212 212 216);
-    }
-    &:focus {
-      outline: 2px solid transparent;
-      outline-offset: 2px;
-    }
-  }
-
-  *,
-  ::before,
-  ::after {
-    box-sizing: border-box;
-    border-width: 0;
-    border-style: solid;
-    border-color: rgb(var(--tw-color-gray-200) / 1);
-  }
+tui-textfield {
+  border-radius: 100px;
 }

--- a/web/projects/marketplace/src/pages/list/search/search.component.ts
+++ b/web/projects/marketplace/src/pages/list/search/search.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common'
 import {
   ChangeDetectionStrategy,
   Component,
@@ -7,13 +6,13 @@ import {
   Output,
 } from '@angular/core'
 import { FormsModule } from '@angular/forms'
-import { TuiIcon } from '@taiga-ui/core'
+import { TuiInput } from '@taiga-ui/core'
 
 @Component({
   selector: 'marketplace-search',
   templateUrl: 'search.component.html',
   styleUrls: ['search.component.scss'],
-  imports: [FormsModule, CommonModule, TuiIcon],
+  imports: [FormsModule, TuiInput],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SearchComponent {

--- a/web/projects/ui/src/app/routes/portal/routes/marketplace/marketplace.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/marketplace/marketplace.component.ts
@@ -1,5 +1,10 @@
 import { CommonModule } from '@angular/common'
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnDestroy,
+} from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { ActivatedRoute, Router } from '@angular/router'
 import {
@@ -157,7 +162,7 @@ import { ConfigService } from 'src/app/services/config.service'
     i18nPipe,
   ],
 })
-export default class MarketplaceComponent {
+export default class MarketplaceComponent implements OnDestroy {
   private readonly categoryService = inject(AbstractCategoryService)
   private readonly marketplaceService = inject(MarketplaceService)
   private readonly configService = inject(ConfigService)
@@ -205,4 +210,12 @@ export default class MarketplaceComponent {
       return cat?.name ? this.localize.transform(cat.name) : key
     }),
   )
+
+  // Clear the search query when leaving the marketplace entirely. Opening a
+  // service drawer only changes query params (the component stays mounted), so
+  // the query survives that; navigating to another route destroys this
+  // component and resets it.
+  ngOnDestroy() {
+    this.categoryService.resetQuery()
+  }
 }


### PR DESCRIPTION
## Summary

Two related fixes to the marketplace search bar:

- **Clear the search query when leaving the marketplace.** `CategoryService` (which holds the search `query$`) is an app-level singleton, so a typed query stuck around after the marketplace component was destroyed and was still there on return. The marketplace component now calls `categoryService.resetQuery()` on destroy. The service detail view is a drawer overlay (query-param driven), not a child route, so the component stays mounted while it's open — the query still survives that case, as intended (and the existing `?search=` deep-link behavior is unchanged).
- **Add a clear ("X") button to the search input.** The search input was a hand-rolled `<input>` in a custom `.search-box`, so there was nothing for `tuiTextfieldCleaner` to attach to. Converted it to a `<tui-textfield>` + `<input tuiInput>` (the same pattern the form-control components use), which gives the built-in clear button for free (it shows whenever the field is non-empty, and clearing it propagates through `ngModelChange` so the list re-filters immediately). The search icon now comes from `iconStart`; the bespoke pill styling collapses to a one-line `border-radius` override, with focus ring / spacing / colors now coming from Taiga's textfield appearance.

### Note
The search bar's look changes slightly — Taiga textfield appearance (adapts to light/dark `color-scheme`) instead of the old fixed-gray pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)