### PR TITLE
fix(ui): apply disabled state to options in select dropdown

### DIFF
--- a/web/projects/ui/src/app/routes/portal/components/form/controls/select.component.ts
+++ b/web/projects/ui/src/app/routes/portal/components/form/controls/select.component.ts
@@ -57,6 +57,7 @@ import { HintPipe } from '../pipes/hint.pipe'
                 tuiOption
                 iconEnd="@tui.arrow-right"
                 tuiFluidTypography
+                [disabled]="disabledItemHandler(item)"
                 [routerLink]="inverted[item]?.slice(1)"
               >
                 {{ item }}
@@ -65,6 +66,7 @@ import { HintPipe } from '../pipes/hint.pipe'
               <button
                 tuiOption
                 tuiFluidTypography
+                [disabled]="disabledItemHandler(item)"
                 [style.white-space]="'nowrap'"
                 [value]="item"
               >


### PR DESCRIPTION
## Summary

Dynamic union specs with a `disabled` list (e.g. several model variants greyed out, one selectable) were arriving correctly in the RPC payload but the dropdown showed every variant as enabled.

Root cause: the desktop variant of `form-select` renders its dropdown manually with `<button tuiOption>` / `<a tuiOption>` elements. Taiga's `[disabledItemHandler]` on `tui-textfield` only flows through `TUI_ITEMS_HANDLERS` to native `<select tuiSelect>` / `<select tuiMultiSelect>` controls (which the mobile variant of `form-select` and `form-multiselect` use). The manually rendered options here never saw the disabled state.

Fix is one line on each option: bind `[disabled]="disabledItemHandler(item)"` so the per-item disabled state actually lands on the rendered buttons/anchors. `tuiOption` then sets `[attr.disabled]` (and the button's native `disabled`), so the option both styles disabled and refuses clicks.

Reported example payload — union with `disabled: ["qwen36-35b-a3b", "qwen36-27b", ...]` showed all variants as selectable in the UI before; with this fix the listed keys render as disabled.

## Test plan

- [ ] Open a service whose config exposes a union with a non-empty `disabled` array (or any select with a `string[]` disabled) and confirm those entries are visually disabled and not clickable in the dropdown on desktop.
- [ ] Confirm normal (non-disabled) entries still select correctly.
- [ ] Confirm mobile dropdown (native `<select tuiSelect>`) still works — that path was already correct and is unchanged.
- [ ] Confirm `~/route`-style redirect entries still navigate when not disabled.