### PR TITLE
docs(sdk): 1.5.0 changelog requires StartOS 0.4.0-beta.9, not beta.8

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## 1.5.0 — StartOS 0.4.0-beta.8 (2026-05-08)
+## 1.5.0 — StartOS 0.4.0-beta.9 (2026-05-08)
 
 ### Added
 
 - `sdk.notification.create(effects, options)` lets a package post a notification into the StartOS notifications panel, alongside the ones StartOS itself generates (e.g. on backup completion). `options` is `{ level, title, message, data? }`: omit `data` for a plain notification (panel row only) or pass markdown text for `data` to attach a long-form body the UI renders in a "View Details" modal (release notes, post-update changelogs, structured error reports). The host forces `packageId` to the calling service's id, so a package can't spoof another package
-- Backed by a new effect `effects.notification.create(...)` (requires StartOS 0.4.0-beta.8 with the matching backend handler)
+- Backed by a new effect `effects.notification.create(...)` (requires StartOS 0.4.0-beta.9 with the matching backend handler)
+
+### Changed
+
+- Minimum StartOS version bumped to `0.4.0-beta.9` — required for the `notification.create` effect added in this release
 
 ## 1.4.3 — StartOS 0.4.0-beta.8 (2026-05-07)
 


### PR DESCRIPTION
The `## 1.5.0` entry's header and the `effects.notification.create` bullet both said `0.4.0-beta.8` — carried over from the 1.4.x entries. But SDK 1.5.0's `OSVersion` constant (`sdk/package/lib/StartSdk.ts`, written into every manifest by `setupManifest`) is `0.4.0-beta.9` — bumped in #3225, before 1.5.0 (#3221) was cut — and the `notification.create` backend handler (`core/src/service/effects/notification.rs`) landed in #3221 itself, i.e. in beta.9.

So a beta.8 (or older) host can't run a package built on SDK 1.5.0 at all. This corrects the header and the bullet to `0.4.0-beta.9` and adds the usual "minimum StartOS version bumped" note under `### Changed`, matching the 1.3.1 / 1.3.4 entries.

Docs-only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)