### PR TITLE
Retry alternate package mirrors after download failures (migrate #3217 to master)

### DIFF
--- a/core/src/registry/asset.rs
+++ b/core/src/registry/asset.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use reqwest::header::RANGE;
 use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWrite;
@@ -18,8 +19,10 @@ use crate::s9pk::merkle_archive::source::{ArchiveSource, Section};
 use crate::sign::commitment::merkle_archive::MerkleArchiveCommitment;
 use crate::sign::commitment::{Commitment, Digestable};
 use crate::sign::{AnySignature, AnyVerifyingKey};
-use crate::upload::UploadingFile;
+use crate::upload::{DownloadAttemptContext, DownloadHandle, UploadingFile};
 use crate::util::future::NonDetachingJoinHandle;
+#[cfg(test)]
+use crate::util::io::TmpDir;
 
 #[derive(Clone, Debug, Deserialize, Serialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -58,15 +61,7 @@ impl<Commitment> RegistryAsset<Commitment> {
         client: Client,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<BufferedHttpSource, Error> {
-        for url in &self.urls {
-            if let Some(response) = client.get(url.clone()).send().await.log_err() {
-                return BufferedHttpSource::from_response(response, progress).await;
-            }
-        }
-        Err(Error::new(
-            eyre!("{}", t!("registry.asset.failed-to-load-http-url")),
-            ErrorKind::Network,
-        ))
+        BufferedHttpSource::from_urls(&self.urls, client, progress).await
     }
     pub async fn load_buffered_http_source_with_path(
         &self,
@@ -74,15 +69,7 @@ impl<Commitment> RegistryAsset<Commitment> {
         client: Client,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<BufferedHttpSource, Error> {
-        for url in &self.urls {
-            if let Ok(response) = client.get(url.clone()).send().await {
-                return BufferedHttpSource::from_response_with_path(path, response, progress).await;
-            }
-        }
-        Err(Error::new(
-            eyre!("{}", t!("registry.asset.failed-to-load-http-url")),
-            ErrorKind::Network,
-        ))
+        BufferedHttpSource::from_urls_with_path(path, &self.urls, client, progress).await
     }
 }
 impl<Commitment: Digestable> RegistryAsset<Commitment> {
@@ -154,22 +141,35 @@ pub struct BufferedHttpSource {
     _download: NonDetachingJoinHandle<()>,
     file: UploadingFile,
 }
+
 impl BufferedHttpSource {
     pub async fn new(
         client: Client,
         url: Url,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        let response = client.get(url).send().await?;
-        Self::from_response(response, progress).await
+        Self::from_urls(std::slice::from_ref(&url), client, progress).await
     }
     pub async fn from_response(
         response: Response,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        let (mut handle, file) = UploadingFile::new(progress).await?;
+        let (mut handle, file) = UploadingFile::new_for_download(progress).await?;
+        let mut response = Some(response);
         Ok(Self {
-            _download: tokio::spawn(async move { handle.download(response).await }).into(),
+            _download: tokio::spawn(async move {
+                handle
+                    .download_from(|_| {
+                        let next = response.take();
+                        async move {
+                            next.ok_or_else(|| {
+                                Error::new(eyre!("download failed"), ErrorKind::Network)
+                            })
+                        }
+                    })
+                    .await
+            })
+            .into(),
             file,
         })
     }
@@ -178,9 +178,55 @@ impl BufferedHttpSource {
         response: Response,
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
-        let (mut handle, file) = UploadingFile::with_path(path, progress).await?;
+        let (mut handle, file) = UploadingFile::with_path_for_download(path, progress).await?;
+        let mut response = Some(response);
         Ok(Self {
-            _download: tokio::spawn(async move { handle.download(response).await }).into(),
+            _download: tokio::spawn(async move {
+                handle
+                    .download_from(|_| {
+                        let next = response.take();
+                        async move {
+                            next.ok_or_else(|| {
+                                Error::new(eyre!("download failed"), ErrorKind::Network)
+                            })
+                        }
+                    })
+                    .await
+            })
+            .into(),
+            file,
+        })
+    }
+    async fn from_urls(
+        urls: &[Url],
+        client: Client,
+        progress: PhaseProgressTrackerHandle,
+    ) -> Result<Self, Error> {
+        let (handle, file) = UploadingFile::new_for_download(progress).await?;
+        Self::spawn_mirror_download(handle, file, urls, client).await
+    }
+    async fn from_urls_with_path(
+        path: impl AsRef<Path>,
+        urls: &[Url],
+        client: Client,
+        progress: PhaseProgressTrackerHandle,
+    ) -> Result<Self, Error> {
+        let (handle, file) = UploadingFile::with_path_for_download(path, progress).await?;
+        Self::spawn_mirror_download(handle, file, urls, client).await
+    }
+    async fn spawn_mirror_download(
+        mut handle: DownloadHandle,
+        file: UploadingFile,
+        urls: &[Url],
+        client: Client,
+    ) -> Result<Self, Error> {
+        handle
+            .download_from(MirrorRetry::new(urls.to_vec(), client).next_response())
+            .await;
+        drop(handle);
+        file.wait_for_complete().await?;
+        Ok(Self {
+            _download: tokio::spawn(async {}).into(),
             file,
         })
     }
@@ -199,5 +245,266 @@ impl ArchiveSource for BufferedHttpSource {
     }
     async fn fetch(&self, position: u64, size: u64) -> Result<Self::FetchReader, Error> {
         self.file.fetch(position, size).await
+    }
+}
+
+struct MirrorRetry {
+    urls: Vec<Url>,
+    client: Client,
+    state: MirrorState,
+    errors: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum MirrorState {
+    NextFull(usize),
+    TryResume(usize),
+    RetryFull(usize),
+}
+
+impl MirrorRetry {
+    fn new(urls: Vec<Url>, client: Client) -> Self {
+        Self {
+            urls,
+            client,
+            state: MirrorState::NextFull(0),
+            errors: Vec::new(),
+        }
+    }
+    fn next_response(
+        mut self,
+    ) -> impl FnMut(DownloadAttemptContext) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Response, Error>> + Send>,
+    > {
+        move |ctx| {
+            if let Some(err) = &ctx.last_error {
+                let url_idx = match self.state {
+                    MirrorState::NextFull(i) => i.saturating_sub(1),
+                    MirrorState::TryResume(i) | MirrorState::RetryFull(i) => i,
+                };
+                if let Some(url) = self.urls.get(url_idx) {
+                    self.errors.push(format!("{url}: {err}"));
+                    tracing::warn!("Failed to download {url}: {err}");
+                }
+            }
+            let next = self.advance(&ctx);
+            let exhausted = (next.is_none()).then(|| self.errors.join("; "));
+            Box::pin(async move {
+                match next {
+                    Some(req) => req.send().await.map_err(|e| Error::new(e, ErrorKind::Network)),
+                    None => Err(Error::new(
+                        eyre!(
+                            "failed to download package from any mirror: {}",
+                            exhausted.unwrap_or_default()
+                        ),
+                        ErrorKind::Network,
+                    )),
+                }
+            })
+        }
+    }
+    fn advance(&mut self, ctx: &DownloadAttemptContext) -> Option<reqwest::RequestBuilder> {
+        loop {
+            match self.state {
+                MirrorState::NextFull(idx) => {
+                    let url = self.urls.get(idx)?;
+                    let req = self.client.get(url.clone());
+                    self.state = MirrorState::TryResume(idx);
+                    return Some(req);
+                }
+                MirrorState::TryResume(idx) => {
+                    let url = self.urls.get(idx)?;
+                    self.state = MirrorState::RetryFull(idx);
+                    if let (Some(total), written) = (ctx.expected_size, ctx.bytes_written) {
+                        if written > 0 && written < total {
+                            return Some(
+                                self.client
+                                    .get(url.clone())
+                                    .header(RANGE, format!("bytes={written}-")),
+                            );
+                        }
+                    }
+                    continue;
+                }
+                MirrorState::RetryFull(idx) => {
+                    let url = self.urls.get(idx)?;
+                    self.state = MirrorState::NextFull(idx + 1);
+                    return Some(self.client.get(url.clone()));
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use crate::progress::FullProgressTracker;
+    use crate::s9pk::merkle_archive::source::ArchiveSource;
+
+    struct TestServer {
+        url: Url,
+        complete_hits: Arc<AtomicUsize>,
+    }
+
+    async fn spawn_test_server() -> Result<TestServer, Error> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let complete_hits = Arc::new(AtomicUsize::new(0));
+        let server_complete_hits = complete_hits.clone();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let complete_hits = server_complete_hits.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0; 1024];
+                    let Ok(n) = stream.read(&mut buf).await else {
+                        return;
+                    };
+                    let request = String::from_utf8_lossy(&buf[..n]);
+                    let request_lower = request.to_ascii_lowercase();
+                    let path = request
+                        .lines()
+                        .next()
+                        .and_then(|line| line.split_whitespace().nth(1))
+                        .unwrap_or("/");
+                    match path {
+                        "/resume" if request_lower.contains("range: bytes=5-") => {
+                            let _ = stream
+                                .write_all(
+                                    b"HTTP/1.1 206 Partial Content\r\nContent-Length: 6\r\nContent-Range: bytes 5-10/11\r\n\r\n world",
+                                )
+                                .await;
+                        }
+                        "/resume" => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
+                                .await;
+                        }
+                        "/range-ignored" if request_lower.contains("range: bytes=5-") => {
+                            let _ = stream
+                                .write_all(
+                                    b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello world",
+                                )
+                                .await;
+                        }
+                        "/range-ignored" => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
+                                .await;
+                        }
+                        "/always-truncated" => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
+                                .await;
+                        }
+                        "/complete" => {
+                            complete_hits.fetch_add(1, Ordering::SeqCst);
+                            let _ = stream
+                                .write_all(
+                                    b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello world",
+                                )
+                                .await;
+                        }
+                        _ => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
+                                .await;
+                        }
+                    }
+                });
+            }
+        });
+        Ok(TestServer {
+            url: Url::parse(&format!("http://{addr}")).with_kind(ErrorKind::ParseUrl)?,
+            complete_hits,
+        })
+    }
+
+    async fn buffered_contents(asset: RegistryAsset<()>) -> Result<Vec<u8>, Error> {
+        let progress = FullProgressTracker::new().add_phase("Downloading".into(), Some(100));
+        let tmp_dir = TmpDir::new().await?;
+        let source = asset
+            .load_buffered_http_source_with_path(
+                tmp_dir.join("package.s9pk"),
+                Client::new(),
+                progress,
+            )
+            .await?;
+        let mut contents = Vec::new();
+        source.fetch_all().await?.read_to_end(&mut contents).await?;
+        Ok(contents)
+    }
+
+    #[tokio::test]
+    async fn buffered_download_resumes_same_url_after_truncated_response() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![server.url.join("resume")?, server.url.join("complete")?],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        assert_eq!(buffered_contents(asset).await?, b"hello world");
+        assert_eq!(server.complete_hits.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_retries_same_url_when_range_is_ignored() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![
+                server.url.join("range-ignored")?,
+                server.url.join("complete")?,
+            ],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        assert_eq!(buffered_contents(asset).await?, b"hello world");
+        assert_eq!(server.complete_hits.load(Ordering::SeqCst), 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_falls_back_to_next_mirror_after_retry_fails() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![
+                server.url.join("always-truncated")?,
+                server.url.join("complete")?,
+            ],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        assert_eq!(buffered_contents(asset).await?, b"hello world");
+        assert_eq!(server.complete_hits.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_fails_after_all_mirrors_fail() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![server.url.join("always-truncated")?],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        assert!(buffered_contents(asset).await.is_err());
+        Ok(())
     }
 }

--- a/core/src/upload.rs
+++ b/core/src/upload.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::io::SeekFrom;
 use std::path::Path;
 use std::pin::Pin;
@@ -10,7 +11,7 @@ use axum::extract::Request;
 use axum::response::Response;
 use bytes::Bytes;
 use futures::{FutureExt, Stream, StreamExt, ready};
-use http::header::CONTENT_LENGTH;
+use http::header::{CONTENT_LENGTH, CONTENT_RANGE};
 use http::{HeaderMap, StatusCode};
 use imbl_value::InternedString;
 use tokio::io::{AsyncRead, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt};
@@ -206,6 +207,44 @@ impl UploadingFile {
         file.tmp_dir = Some(tmp_dir);
         Ok((handle, file))
     }
+    pub async fn with_path_for_download(
+        path: impl AsRef<Path>,
+        mut progress: PhaseProgressTrackerHandle,
+    ) -> Result<(DownloadHandle, Self), Error> {
+        progress.set_units(Some(ProgressUnits::Bytes));
+        let progress = watch::channel(Progress {
+            tracker: progress,
+            expected_size: None,
+            written: 0,
+            error: None,
+            complete: false,
+        });
+        let file = create_file(path).await?;
+        let multi_cursor = MultiCursorFile::open(&file).await?;
+        let uploading = Self {
+            tmp_dir: None,
+            file: multi_cursor,
+            progress: progress.1,
+        };
+        Ok((
+            DownloadHandle {
+                tmp_dir: None,
+                file,
+                progress: progress.0,
+            },
+            uploading,
+        ))
+    }
+    pub async fn new_for_download(
+        progress: PhaseProgressTrackerHandle,
+    ) -> Result<(DownloadHandle, Self), Error> {
+        let tmp_dir = Arc::new(TmpDir::new().await?);
+        let (mut handle, mut file) =
+            Self::with_path_for_download(tmp_dir.join("download.tmp"), progress).await?;
+        handle.tmp_dir = Some(tmp_dir.clone());
+        file.tmp_dir = Some(tmp_dir);
+        Ok((handle, file))
+    }
     pub async fn wait_for_complete(&self) -> Result<(), Error> {
         Progress::ready(&mut self.progress.clone()).await
     }
@@ -350,11 +389,6 @@ impl UploadHandle {
             .await;
         self.progress.send_if_modified(|p| p.complete());
     }
-    pub async fn download(&mut self, response: reqwest::Response) {
-        self.process_headers(response.headers());
-        self.process_body(response.bytes_stream()).await;
-        self.progress.send_if_modified(|p| p.complete());
-    }
     fn process_headers(&mut self, headers: &HeaderMap) {
         if let Some(content_length) = headers
             .get(CONTENT_LENGTH)
@@ -373,10 +407,7 @@ impl UploadHandle {
     ) {
         while let Some(next) = body.next().await {
             if let Err(e) = async {
-                self.write_all(
-                    &next.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
-                )
-                .await?;
+                self.write_all(&next.map_err(std::io::Error::other)?).await?;
                 Ok(())
             }
             .await
@@ -388,7 +419,6 @@ impl UploadHandle {
         if let Err(e) = self.file.sync_all().await {
             self.progress.send_if_modified(|p| p.handle_error(&e));
         }
-        // Update progress with final synced bytes
         self.update_sync_progress();
     }
     fn update_sync_progress(&mut self) {
@@ -464,4 +494,160 @@ impl AsyncWrite for UploadHandle {
             a => a,
         }
     }
+}
+
+pub struct DownloadAttemptContext {
+    pub bytes_written: u64,
+    pub expected_size: Option<u64>,
+    pub last_error: Option<Error>,
+}
+
+pub struct DownloadHandle {
+    tmp_dir: Option<Arc<TmpDir>>,
+    file: tokio::fs::File,
+    progress: watch::Sender<Progress>,
+}
+impl DownloadHandle {
+    pub async fn download_from<F, Fut>(&mut self, mut next_response: F)
+    where
+        F: FnMut(DownloadAttemptContext) -> Fut,
+        Fut: Future<Output = Result<reqwest::Response, Error>>,
+    {
+        let mut last_error: Option<Error> = None;
+        let outcome: Result<(), Error> = loop {
+            let (bytes_written, expected_size) = {
+                let p = self.progress.borrow();
+                (p.written, p.expected_size)
+            };
+            let response = match next_response(DownloadAttemptContext {
+                bytes_written,
+                expected_size,
+                last_error: last_error.as_ref().map(|e| e.clone_output()),
+            })
+            .await
+            {
+                Ok(r) => r,
+                Err(e) => break Err(e),
+            };
+            let response = match response.error_for_status() {
+                Ok(r) => r,
+                Err(e) => {
+                    last_error = Some(Error::new(e, ErrorKind::Network));
+                    continue;
+                }
+            };
+
+            if response.status() == StatusCode::PARTIAL_CONTENT {
+                if let Some(total) = parse_content_range_total(response.headers()) {
+                    self.progress.send_modify(|p| {
+                        p.expected_size = Some(total);
+                        p.tracker.set_total(total);
+                    });
+                }
+            } else {
+                if let Err(e) = self.file.set_len(0).await {
+                    break Err(Error::new(e, ErrorKind::Filesystem));
+                }
+                if let Err(e) = self.file.seek(SeekFrom::Start(0)).await {
+                    break Err(Error::new(e, ErrorKind::Filesystem));
+                }
+                self.progress.send_modify(|p| {
+                    p.written = 0;
+                    p.tracker.set_done(0);
+                });
+                if let Some(content_length) = response
+                    .headers()
+                    .get(CONTENT_LENGTH)
+                    .and_then(|a| a.to_str().log_err())
+                    .and_then(|a| a.parse::<u64>().log_err())
+                {
+                    self.progress.send_modify(|p| {
+                        p.expected_size = Some(content_length);
+                        p.tracker.set_total(content_length);
+                    });
+                }
+            }
+
+            let stream_result: Result<(), Error> = async {
+                let mut stream = response.bytes_stream();
+                while let Some(next) = stream.next().await {
+                    let chunk = next.map_err(|e| Error::new(e, ErrorKind::Network))?;
+                    self.file
+                        .write_all(&chunk)
+                        .await
+                        .map_err(|e| Error::new(e, ErrorKind::Filesystem))?;
+                    let len = chunk.len() as u64;
+                    self.progress.send_modify(|p| {
+                        p.written += len;
+                        p.tracker += len;
+                    });
+                }
+                Ok(())
+            }
+            .await;
+
+            if let Err(e) = stream_result {
+                last_error = Some(e);
+                continue;
+            }
+
+            let (written, expected) = {
+                let p = self.progress.borrow();
+                (p.written, p.expected_size)
+            };
+            match expected {
+                Some(total) if written < total => {
+                    last_error = Some(Error::new(
+                        eyre!("download ended after {written} bytes, expected {total}"),
+                        ErrorKind::Network,
+                    ));
+                    continue;
+                }
+                Some(total) if written > total => {
+                    break Err(Error::new(
+                        eyre!("Too many bytes received"),
+                        ErrorKind::Network,
+                    ));
+                }
+                _ => break Ok(()),
+            }
+        };
+
+        match outcome {
+            Ok(()) => {
+                if let Err(e) = self.file.sync_all().await {
+                    self.progress
+                        .send_if_modified(|p| p.handle_error(&e));
+                }
+            }
+            Err(e) => {
+                self.progress.send_if_modified(|p| {
+                    if p.error.is_none() {
+                        p.error = Some(e);
+                        true
+                    } else {
+                        false
+                    }
+                });
+            }
+        }
+        self.progress.send_if_modified(|p| p.complete());
+    }
+}
+impl Drop for DownloadHandle {
+    fn drop(&mut self) {
+        self.progress.send_if_modified(|p| p.complete());
+    }
+}
+
+fn parse_content_range_total(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get(CONTENT_RANGE)?
+        .to_str()
+        .ok()?
+        .rsplit_once('/')?
+        .1
+        .trim()
+        .parse()
+        .ok()
 }


### PR DESCRIPTION
Migrates the change from #3217, which was merged into `next/major` by mistake, onto `master`.

Cherry-picked merge commit `52cf86dc6993efc79e542a9fee2c0ce5570613c0` (squash of @aschjonhaug + @drbonez's work). One trivial conflict in `core/src/registry/asset.rs::load_buffered_http_source` (master had been swapped to `if let Some(_) = ….log_err()` after the PR branched; both sides agree on calling the new `BufferedHttpSource::from_urls` so the resolution is to drop the master version of the per-URL loop entirely).

## Summary
- download registry package assets fully to disk before deserializing/verifying them
- retry the next asset URL when an HTTP body stream fails or ends before its advertised content length
- update the CLI download path now that downloads complete before the source is returned

## Testing
- `cargo test --manifest-path core/Cargo.toml --lib registry::asset::` — 4 new tests (`buffered_download_resumes_same_url_after_truncated_response`, `buffered_download_retries_same_url_when_range_is_ignored`, `buffered_download_falls_back_to_next_mirror_after_retry_fails`, `buffered_download_fails_after_all_mirrors_fail`) all pass.
- `cargo check --manifest-path core/Cargo.toml --lib` clean (warnings unchanged from master baseline).

Original PR for review context: https://github.com/Start9Labs/start-os/pull/3217