### PR TITLE
chore(debian): add diagnose-hang capture script

### DIFF
--- a/build/lib/scripts/diagnose-hang
+++ b/build/lib/scripts/diagnose-hang
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Capture the state of startbox when it is unresponsive. Uses only /proc
+# and basic system tools — does not rely on start-cli (which routes
+# through startd and will hang if startd is hung).
+#
+# Usage: sudo /usr/lib/startos/scripts/diagnose-hang
+# Produces: /tmp/startbox-hang-<timestamp>.tar.gz
+
+set -u
+
+if [ "$(id -u)" -ne 0 ]; then
+    exec sudo bash "$0" "$@"
+fi
+
+PID="$(pidof startbox || true)"
+if [ -z "$PID" ]; then
+    echo "startbox is not running — nothing to diagnose" >&2
+    exit 1
+fi
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="/tmp/startbox-hang-$TS"
+mkdir -p "$OUT"
+
+echo "Capturing startbox state (pid=$PID) to $OUT" >&2
+
+# ---- Process-level summary ----
+{
+    echo "timestamp: $TS"
+    echo "pid:       $PID"
+    echo "uptime:    $(uptime)"
+    awk '/^Name|^State|^Threads|^VmRSS|^VmPeak|^Pid|^PPid/' "/proc/$PID/status"
+} > "$OUT/summary.txt"
+
+# ---- Per-thread state, wait channel, and kernel-side stack ----
+# wchan tells us the kernel function each thread is blocked in.
+# /proc/<tid>/stack is the kernel stack — works without gdb and tells
+# us if a thread is in I/O, futex, sleep, etc.
+{
+    for t in /proc/$PID/task/*; do
+        tid="$(basename "$t")"
+        echo "==================== tid $tid ===================="
+        awk '/^Name|^State|^TracerPid|^VoluntaryCtxtSwitches|^NonvoluntaryCtxtSwitches/' \
+            "$t/status" 2>/dev/null
+        echo "wchan: $(cat "$t/wchan" 2>/dev/null)"
+        echo "--- kernel stack ---"
+        cat "$t/stack" 2>/dev/null || echo "(stack unavailable)"
+        echo
+    done
+} > "$OUT/threads.txt"
+
+# ---- Thread summary table (name, %cpu, state) ----
+ps -L -p "$PID" -o tid,pcpu,stat,comm 2>/dev/null \
+    | sort -k4 > "$OUT/threads-summary.txt"
+
+# ---- Open files / sockets ----
+ls -la "/proc/$PID/fd/" > "$OUT/fds.txt" 2>&1 || true
+{
+    echo "--- ss (sockets owned by pid) ---"
+    ss -anpe 2>/dev/null | grep -E "pid=$PID|^Netid" || true
+} > "$OUT/sockets.txt"
+
+# ---- Recent journal output for startd ----
+journalctl -u startd --no-pager -n 500 > "$OUT/startd-journal.txt" 2>&1 || true
+
+# ---- I/O and disk health ----
+dmesg -T 2>/dev/null | tail -200 > "$OUT/dmesg.txt"
+{
+    echo "--- df -h ---"
+    df -h
+    echo
+    echo "--- mount ---"
+    mount
+    echo
+    echo "--- iostat -x 1 3 ---"
+    if command -v iostat >/dev/null 2>&1; then
+        iostat -x 1 3
+    else
+        echo "(iostat not installed)"
+    fi
+} > "$OUT/io.txt" 2>&1
+
+# ---- LXC state (the containers startd was managing) ----
+{
+    echo "--- lxc-ls -f ---"
+    lxc-ls -f 2>/dev/null || echo "(lxc-ls failed)"
+    echo
+    echo "--- container-runtime status per container ---"
+    for c in $(lxc-ls 2>/dev/null); do
+        echo "=== $c ==="
+        lxc-attach "$c" -- systemctl status container-runtime --no-pager 2>&1 \
+            | head -40 || echo "(lxc-attach failed for $c)"
+        echo
+    done
+} > "$OUT/lxc.txt"
+
+# ---- Bundle ----
+tar czf "$OUT.tar.gz" -C /tmp "$(basename "$OUT")"
+rm -rf "$OUT"
+
+echo
+echo "Capture complete: $OUT.tar.gz"
+echo "Share this archive with Start9 support to diagnose the hang."

--- a/debian/startos/postinst
+++ b/debian/startos/postinst
@@ -178,6 +178,7 @@ rm -rf /var/lib/tor/*
 ln -sf /usr/lib/startos/scripts/chroot-and-upgrade /usr/bin/chroot-and-upgrade
 ln -sf /usr/lib/startos/scripts/tor-check /usr/bin/tor-check
 ln -sf /usr/lib/startos/scripts/gather-debug-info /usr/bin/gather-debug-info
+ln -sf /usr/lib/startos/scripts/diagnose-hang /usr/bin/diagnose-hang
 ln -sf /usr/lib/startos/scripts/wireguard-vps-proxy-setup /usr/bin/wireguard-vps-proxy-setup
 
 cat > /etc/sysctl.d/97-startos.conf <<EOF


### PR DESCRIPTION
## Summary

When `startd` hangs — webserver freezes, journal stops, services stuck mid-init — `start-cli` cannot help because its RPC routes through the very process that is stuck. `gather-debug-info` has the same problem (it calls `start-cli lxc stats`).

Add a dedicated capture script that pulls runtime state entirely via `/proc` and basic system tools, with no dependency on `startbox` being responsive.

## What it captures

- Per-thread state, wait channel (`wchan`), and kernel-side stack from `/proc/<pid>/task/*` — tells us whether each thread is in I/O, futex, sleep, runnable, etc., without needing `gdb` installed.
- Thread summary (TID, cpu%, state, comm) via `ps -L`.
- Open fds and sockets (`ss -anpe` filtered to the pid).
- Last 500 lines of `journalctl -u startd`.
- `dmesg | tail -200`, `df -h`, `mount`, `iostat -x` — to catch disk/FS issues that often underlie patch-db write-lock hangs.
- `lxc-ls -f` plus per-container `systemctl status container-runtime`.

Bundles into `/tmp/startbox-hang-<utc-timestamp>.tar.gz` for support to triage. Symlinked from `/usr/bin/diagnose-hang` in postinst, matching `gather-debug-info`.

## Why

Triggered by a prodbox hang where the journal stops abruptly with the webserver frozen. Diagnosing the failure class (blocking-in-async vs. async deadlock vs. stuck disk fsync inside the patch-db write lock) requires per-thread state from outside the process — `start-cli` and `gather-debug-info` are unusable in this state.