### PR TITLE
fix(core/disk): skip unmountable partitions when listing backup targets

### DIFF
--- a/core/locales/i18n.yaml
+++ b/core/locales/i18n.yaml
@@ -985,12 +985,12 @@ disk.util.could-not-get-capacity-part:
   fr_FR: "Impossible d'obtenir la capacité de %{part} : %{error}"
   pl_PL: "Nie można pobrać pojemności %{part}: %{error}"
 
-disk.util.could-not-collect-usage-info:
-  en_US: "Could not collect usage information: %{error}"
-  de_DE: "Konnte Nutzungsinformationen nicht sammeln: %{error}"
-  es_ES: "No se pudo recopilar información de uso: %{error}"
-  fr_FR: "Impossible de collecter les informations d'utilisation : %{error}"
-  pl_PL: "Nie można zebrać informacji o użyciu: %{error}"
+disk.util.skipping-unmountable-partition:
+  en_US: "Skipping unmountable partition %{part}: %{error}"
+  de_DE: "Überspringe nicht einhängbare Partition %{part}: %{error}"
+  es_ES: "Omitiendo partición no montable %{part}: %{error}"
+  fr_FR: "Partition non montable %{part} ignorée : %{error}"
+  pl_PL: "Pomijanie niemożliwej do zamontowania partycji %{part}: %{error}"
 
 disk.util.could-not-get-usage:
   en_US: "Could not get usage of %{part}: %{error}"

--- a/core/src/disk/util.rs
+++ b/core/src/disk/util.rs
@@ -371,10 +371,20 @@ pub async fn list(os: &OsPartitionInfo) -> Result<Vec<DiskInfo>, Error> {
         if index.internal {
             for part in index.parts {
                 let mut disk_info = disk_info(disk.clone()).await;
-                let part_info = part_info(part).await;
-                disk_info.logicalname = part_info.logicalname.clone();
-                disk_info.capacity = part_info.capacity;
-                if let Some(g) = disk_guids.get(&disk_info.logicalname) {
+                if let Some(g) = disk_guids.get(&part) {
+                    disk_info.capacity = get_capacity(&part)
+                        .await
+                        .map_err(|e| {
+                            tracing::warn!(
+                                "{}",
+                                t!(
+                                    "disk.util.could-not-get-capacity-part",
+                                    part = part.display(),
+                                    error = e.source
+                                )
+                            )
+                        })
+                        .unwrap_or_default();
                     disk_info.guid = g.clone();
                     if let Some(guid) = g {
                         disk_info.filesystem = crate::disk::main::probe_package_data_fs(guid)
@@ -384,7 +394,13 @@ pub async fn list(os: &OsPartitionInfo) -> Result<Vec<DiskInfo>, Error> {
                                 None
                             });
                     }
+                    disk_info.logicalname = part;
                 } else {
+                    let Some(part_info) = part_info(part).await else {
+                        continue;
+                    };
+                    disk_info.logicalname = part_info.logicalname.clone();
+                    disk_info.capacity = part_info.capacity;
                     disk_info.partitions = vec![part_info];
                 }
                 res.push(disk_info);
@@ -404,7 +420,9 @@ pub async fn list(os: &OsPartitionInfo) -> Result<Vec<DiskInfo>, Error> {
                 }
             } else {
                 for part in index.parts {
-                    let mut part_info = part_info(part).await;
+                    let Some(mut part_info) = part_info(part).await else {
+                        continue;
+                    };
                     if let Some(g) = disk_guids.get(&part_info.logicalname) {
                         part_info.guid = g.clone();
                         if let Some(guid) = g {
@@ -491,8 +509,7 @@ async fn disk_info(disk: PathBuf) -> DiskInfo {
     }
 }
 
-async fn part_info(part: PathBuf) -> PartitionInfo {
-    let mut start_os = BTreeMap::new();
+async fn part_info(part: PathBuf) -> Option<PartitionInfo> {
     let label = get_label(&part)
         .await
         .map_err(|e| {
@@ -519,52 +536,57 @@ async fn part_info(part: PathBuf) -> PartitionInfo {
             )
         })
         .unwrap_or_default();
-    let mut used = None;
 
-    match TmpMountGuard::mount(&BlockDev::new(&part), ReadOnly).await {
-        Err(e) => tracing::warn!(
-            "{}",
-            t!("disk.util.could-not-collect-usage-info", error = e.source)
-        ),
-        Ok(mount_guard) => {
-            used = get_used(mount_guard.path())
-                .await
-                .map_err(|e| {
-                    tracing::warn!(
-                        "{}",
-                        t!(
-                            "disk.util.could-not-get-usage",
-                            part = part.display(),
-                            error = e.source
-                        )
-                    )
-                })
-                .ok();
-            match recovery_info(mount_guard.path()).await {
-                Ok(a) => {
-                    start_os = a;
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "{}",
-                        t!("disk.util.error-fetching-backup-metadata", error = e)
-                    );
-                }
-            }
-            if let Err(e) = mount_guard.unmount().await {
-                tracing::error!(
-                    "{}",
-                    t!(
-                        "disk.util.error-unmounting-partition",
-                        part = part.display(),
-                        error = e
-                    )
-                );
-            }
+    let mount_guard = match TmpMountGuard::mount(&BlockDev::new(&part), ReadOnly).await {
+        Err(e) => {
+            tracing::warn!(
+                "{}",
+                t!(
+                    "disk.util.skipping-unmountable-partition",
+                    part = part.display(),
+                    error = e.source
+                )
+            );
+            return None;
         }
+        Ok(g) => g,
+    };
+
+    let used = get_used(mount_guard.path())
+        .await
+        .map_err(|e| {
+            tracing::warn!(
+                "{}",
+                t!(
+                    "disk.util.could-not-get-usage",
+                    part = part.display(),
+                    error = e.source
+                )
+            )
+        })
+        .ok();
+    let start_os = match recovery_info(mount_guard.path()).await {
+        Ok(a) => a,
+        Err(e) => {
+            tracing::error!(
+                "{}",
+                t!("disk.util.error-fetching-backup-metadata", error = e)
+            );
+            BTreeMap::new()
+        }
+    };
+    if let Err(e) = mount_guard.unmount().await {
+        tracing::error!(
+            "{}",
+            t!(
+                "disk.util.error-unmounting-partition",
+                part = part.display(),
+                error = e
+            )
+        );
     }
 
-    PartitionInfo {
+    Some(PartitionInfo {
         logicalname: part,
         label,
         capacity,
@@ -572,7 +594,7 @@ async fn part_info(part: PathBuf) -> PartitionInfo {
         start_os,
         guid: None,
         filesystem: None,
-    }
+    })
 }
 
 fn parse_pvscan_output(pvscan_output: &str) -> BTreeMap<PathBuf, Option<InternedString>> {

--- a/core/src/disk/util.rs
+++ b/core/src/disk/util.rs
@@ -372,29 +372,11 @@ pub async fn list(os: &OsPartitionInfo) -> Result<Vec<DiskInfo>, Error> {
             for part in index.parts {
                 let mut disk_info = disk_info(disk.clone()).await;
                 if let Some(g) = disk_guids.get(&part) {
-                    disk_info.capacity = get_capacity(&part)
-                        .await
-                        .map_err(|e| {
-                            tracing::warn!(
-                                "{}",
-                                t!(
-                                    "disk.util.could-not-get-capacity-part",
-                                    part = part.display(),
-                                    error = e.source
-                                )
-                            )
-                        })
-                        .unwrap_or_default();
-                    disk_info.guid = g.clone();
-                    if let Some(guid) = g {
-                        disk_info.filesystem = crate::disk::main::probe_package_data_fs(guid)
-                            .await
-                            .unwrap_or_else(|e| {
-                                tracing::warn!("Failed to probe filesystem for {guid}: {e}");
-                                None
-                            });
-                    }
-                    disk_info.logicalname = part;
+                    let pi = lvm_pv_part_info(part, g.clone()).await;
+                    disk_info.logicalname = pi.logicalname;
+                    disk_info.capacity = pi.capacity;
+                    disk_info.guid = pi.guid;
+                    disk_info.filesystem = pi.filesystem;
                 } else {
                     let Some(part_info) = part_info(part).await else {
                         continue;
@@ -420,20 +402,14 @@ pub async fn list(os: &OsPartitionInfo) -> Result<Vec<DiskInfo>, Error> {
                 }
             } else {
                 for part in index.parts {
-                    let Some(mut part_info) = part_info(part).await else {
-                        continue;
+                    let part_info = if let Some(g) = disk_guids.get(&part) {
+                        lvm_pv_part_info(part, g.clone()).await
+                    } else {
+                        let Some(pi) = part_info(part).await else {
+                            continue;
+                        };
+                        pi
                     };
-                    if let Some(g) = disk_guids.get(&part_info.logicalname) {
-                        part_info.guid = g.clone();
-                        if let Some(guid) = g {
-                            part_info.filesystem = crate::disk::main::probe_package_data_fs(guid)
-                                .await
-                                .unwrap_or_else(|e| {
-                                    tracing::warn!("Failed to probe filesystem for {guid}: {e}");
-                                    None
-                                });
-                        }
-                    }
                     disk_info.partitions.push(part_info);
                 }
             }
@@ -506,6 +482,41 @@ async fn disk_info(disk: PathBuf) -> DiskInfo {
         capacity,
         guid: None,
         filesystem: None,
+    }
+}
+
+async fn lvm_pv_part_info(part: PathBuf, guid: Option<InternedString>) -> PartitionInfo {
+    let capacity = get_capacity(&part)
+        .await
+        .map_err(|e| {
+            tracing::warn!(
+                "{}",
+                t!(
+                    "disk.util.could-not-get-capacity-part",
+                    part = part.display(),
+                    error = e.source
+                )
+            )
+        })
+        .unwrap_or_default();
+    let filesystem = if let Some(ref guid) = guid {
+        crate::disk::main::probe_package_data_fs(guid)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to probe filesystem for {guid}: {e}");
+                None
+            })
+    } else {
+        None
+    };
+    PartitionInfo {
+        logicalname: part,
+        label: None,
+        capacity,
+        used: None,
+        start_os: BTreeMap::new(),
+        guid,
+        filesystem,
     }
 }
 


### PR DESCRIPTION
## Summary

- Tiny non-data partitions on a backup disk (GPT header, ESP, etc.) were appearing as "Available for backup, 0 GB" rows alongside the real data partition on the same physical disk. The backup-target list flattens each disk into one row per partition, with no filter for whether the partition is actually usable.
- `part_info` now returns `Option<PartitionInfo>`, returning `None` when the read-only mount probe fails; `list()` filters those out.
- The OS-disk LVM-PV path in `list()` is restructured to compute capacity directly via `get_capacity` rather than going through `part_info` — raw PVs can't mount anyway, and we only needed `logicalname` + `capacity` on that branch. This keeps the existing behavior for the embassy data disk.
- i18n key `disk.util.could-not-collect-usage-info` is renamed/reworded to `disk.util.skipping-unmountable-partition` to reflect the new "skip" semantic, across all 5 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)