### PR TITLE
fix(sdk): stage db dump through /tmp before writing to backup-fs (1.5.2)

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.2 — StartOS 0.4.0-beta.9 (2026-05-15)
+
+### Fixed
+
+- `Backups.withPgDump` and `Backups.withMysqlDump` now stage the dump file in the subcontainer rootfs (`/tmp/<db>-db.dump`) and `cp` it through to the backup target, on both backup and restore. Previously `pg_dump` / `mysqldump` wrote directly to the `backup-fs` FUSE bind mount, where their writes were silently dropped — the process exited 0 but the resulting `<db>-db.dump` was 0 bytes. Every package using these helpers (immich, spliit, synapse, nextcloud, btcpayserver, mempool, ghost) has been shipping empty database dumps since the helpers were introduced; bump to this SDK and rebuild the s9pk to recover. Plain `cp` writes through the FUSE work, so staging through `/tmp` produces an identical on-disk dump file at the same path — no restore-format change
+
 ## 1.5.1 — StartOS 0.4.0-beta.9 (2026-05-13)
 
 ### Fixed

--- a/sdk/package/lib/backup/Backups.ts
+++ b/sdk/package/lib/backup/Backups.ts
@@ -171,6 +171,12 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
     } = config
     const pgdata = `${mountpoint}${pgdataPath}`
     const dumpFile = `${BACKUP_CONTAINER_MOUNT}/${database}-db.dump`
+    // pg_dump's writes are silently dropped on the backup-fs FUSE mount —
+    // pg_dump exits 0 but the file stays 0 bytes. `cp` writes through the
+    // FUSE correctly, so we dump to a non-FUSE path inside the subcontainer
+    // rootfs and `cp` the result through. Likewise on restore, `cp` the dump
+    // off the FUSE before pg_restore reads it.
+    const tmpDumpFile = `/tmp/${database}-db.dump`
 
     function dbMounts() {
       return Mounts.of<M>().mountVolume({
@@ -231,17 +237,19 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
           async (sub) => {
             console.log('[pg-dump] mounting backup target')
             await mountBackupTarget(sub.rootfs)
-            await sub.execFail(['touch', dumpFile], { user: 'root' })
-            await sub.execFail(['chown', 'postgres:postgres', dumpFile], {
+            await sub.execFail(['touch', tmpDumpFile], { user: 'root' })
+            await sub.execFail(['chown', 'postgres:postgres', tmpDumpFile], {
               user: 'root',
             })
             await startPg(sub, 'pg-dump')
             console.log('[pg-dump] dumping database')
             await sub.execFail(
-              ['pg_dump', '-U', user, '-Fc', '-f', dumpFile, database],
+              ['pg_dump', '-U', user, '-Fc', '-f', tmpDumpFile, database],
               { user: 'postgres' },
               null,
             )
+            console.log('[pg-dump] copying dump to backup target')
+            await sub.execFail(['cp', tmpDumpFile, dumpFile], { user: 'root' })
             console.log('[pg-dump] stopping postgres')
             await sub.execFail(['pg_ctl', 'stop', '-D', pgdata, '-w'], {
               user: 'postgres',
@@ -259,6 +267,13 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
           'pg-restore',
           async (sub) => {
             await mountBackupTarget(sub.rootfs)
+            // Stage the dump off the FUSE before pg_restore reads it — see
+            // the comment on `tmpDumpFile` above.
+            await sub.execFail(['cp', dumpFile, tmpDumpFile], { user: 'root' })
+            await sub.execFail(
+              ['chown', 'postgres:postgres', tmpDumpFile],
+              { user: 'root' },
+            )
             await sub.execFail(
               ['chown', '-R', 'postgres:postgres', mountpoint],
               { user: 'root' },
@@ -280,7 +295,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 database,
                 '--no-owner',
                 '--no-privileges',
-                dumpFile,
+                tmpDumpFile,
               ],
               { user: 'postgres' },
               null,
@@ -334,6 +349,10 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       mysqldOptions = [],
     } = config
     const dumpFile = `${BACKUP_CONTAINER_MOUNT}/${database}-db.dump`
+    // See the comment on `tmpDumpFile` in withPgDump — backup-fs FUSE
+    // silently drops mysqldump's writes, so stage the dump in the
+    // subcontainer rootfs and `cp` through.
+    const tmpDumpFile = `/tmp/${database}-db.dump`
 
     function dbMounts() {
       return Mounts.of<M>().mountVolume({
@@ -430,12 +449,13 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 user,
                 ...(pw !== null ? [`-p${pw}`] : []),
                 '--single-transaction',
-                `--result-file=${dumpFile}`,
+                `--result-file=${tmpDumpFile}`,
                 database,
               ],
               { user: 'root' },
               null,
             )
+            await sub.execFail(['cp', tmpDumpFile, dumpFile], { user: 'root' })
             // Graceful shutdown via SIGTERM; wait for exit
             await sub.execFail(
               [
@@ -498,12 +518,15 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             await sub.execFail(['mysql', '-u', 'root', '-e', grantSql], {
               user: 'root',
             })
+            // Stage the dump off the FUSE before mysql reads it — see
+            // the comment on `tmpDumpFile` above.
+            await sub.execFail(['cp', dumpFile, tmpDumpFile], { user: 'root' })
             // Restore from dump
             await sub.execFail(
               [
                 'sh',
                 '-c',
-                `mysql -u root ${pw !== null ? `-p'${pw}'` : ''} ${database} < ${dumpFile}`,
+                `mysql -u root ${pw !== null ? `-p'${pw}'` : ''} ${database} < ${tmpDumpFile}`,
               ],
               { user: 'root' },
               null,

--- a/sdk/package/package-lock.json
+++ b/sdk/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/sdk/package/package.json
+++ b/sdk/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./package/lib/index.js",
   "types": "./package/lib/index.d.ts",


### PR DESCRIPTION
## Summary

- `Backups.withPgDump` and `Backups.withMysqlDump` were writing `pg_dump` / `mysqldump` output directly to the `backup-fs` FUSE bind mount at `/backup-target/<db>-db.dump`. The FUSE silently drops those writes — `pg_dump` exits 0 but the resulting file is 0 bytes. `execFail` only inspects the exit code, so the bug was never surfaced.
- Stage the dump in the subcontainer rootfs (`/tmp/<db>-db.dump`) and `cp` it through to the backup target on both backup and restore. Plain `cp` writes/reads through the FUSE work correctly, so this produces a bit-identical dump file at the same path — restores stay compatible with both old (empty, broken) and new (correct) backups.
- Bumps SDK to **1.5.2**; CHANGELOG entry added.

## Blast radius

Every package using `withPgDump` / `withMysqlDump` has been shipping empty database dumps since those helpers were introduced (~7 packages: immich, spliit, synapse, nextcloud, btcpayserver, mempool, ghost). They need to bump `@start9labs/start-sdk` to 1.5.2 and rebuild their s9pks to recover.

## Reproduction & verification

Reported on [Start9Labs/immich-startos#3](https://github.com/Start9Labs/immich-startos/issues/3). Repro on a live dev box:

- Triggered an immich backup → `immich-db.dump` came back **0 bytes** on the encrypted target.
- Patched the package's `setPreBackup` to dump to both `/backup-target/immich-db.dump` and `/tmp/immich-debug.dump` with stderr capture. Result: `/tmp/...` got the full **16,683,539 bytes**, the FUSE path stayed at 0 bytes, exit 0 in both cases, no stderr.
- Confirmed `cp /tmp/...` → FUSE bind writes the full 16 MB through.
- Applied this SDK patch, `npm link`ed into immich, rebuilt the s9pk, retriggered the backup. `immich-db.dump` on the encrypted target is now **16,683,539 bytes**. The new `[pg-dump] copying dump to backup target` log line confirms the patched code path ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)