### PR TITLE
fix(web/wifi): give each access point its own dropdown open state

### DIFF
--- a/web/projects/ui/src/app/routes/portal/routes/system/routes/wifi/table.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/system/routes/wifi/table.component.ts
@@ -76,18 +76,23 @@ import { wifiSpec } from './wifi.const'
           size="s"
           appearance="flat-grayscale"
           iconStart="@tui.ellipsis-vertical"
-          [(tuiDropdownOpen)]="open"
+          [tuiDropdownOpen]="!!opens[network.ssid]"
+          (tuiDropdownOpenChange)="opens[network.ssid] = $event"
         >
           {{ 'More' | i18n }}
           <tui-data-list *tuiDropdown>
-            <button tuiOption iconStart="@tui.wifi" (click)="prompt(network)">
+            <button
+              tuiOption
+              iconStart="@tui.wifi"
+              (click)="opens[network.ssid] = false; prompt(network)"
+            >
               {{ 'Connect' | i18n }}
             </button>
             <button
               tuiOption
               iconStart="@tui.trash"
               class="g-negative"
-              (click)="forget(network)"
+              (click)="opens[network.ssid] = false; forget(network)"
             >
               {{ 'Forget' | i18n }}
             </button>
@@ -166,7 +171,7 @@ export class WifiTableComponent {
   @Input()
   wifi: readonly Wifi[] = []
 
-  open = false
+  opens: Record<string, boolean> = {}
 
   getSignal(signal: number) {
     if (signal < 5) {

--- a/web/projects/ui/src/app/routes/portal/routes/system/routes/wifi/table.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/system/routes/wifi/table.component.ts
@@ -73,26 +73,21 @@ import { wifiSpec } from './wifi.const'
         <button
           tuiIconButton
           tuiDropdown
+          tuiDropdownAuto
           size="s"
           appearance="flat-grayscale"
           iconStart="@tui.ellipsis-vertical"
-          [tuiDropdownOpen]="!!opens[network.ssid]"
-          (tuiDropdownOpenChange)="opens[network.ssid] = $event"
         >
           {{ 'More' | i18n }}
-          <tui-data-list *tuiDropdown>
-            <button
-              tuiOption
-              iconStart="@tui.wifi"
-              (click)="opens[network.ssid] = false; prompt(network)"
-            >
+          <tui-data-list *tuiDropdown="let close" (click)="close()">
+            <button tuiOption iconStart="@tui.wifi" (click)="prompt(network)">
               {{ 'Connect' | i18n }}
             </button>
             <button
               tuiOption
               iconStart="@tui.trash"
               class="g-negative"
-              (click)="opens[network.ssid] = false; forget(network)"
+              (click)="forget(network)"
             >
               {{ 'Forget' | i18n }}
             </button>
@@ -170,8 +165,6 @@ export class WifiTableComponent {
 
   @Input()
   wifi: readonly Wifi[] = []
-
-  opens: Record<string, boolean> = {}
 
   getSignal(signal: number) {
     if (signal < 5) {


### PR DESCRIPTION
## Summary

The "More" dropdown on saved-but-disconnected access points shared a single `open` flag across every row rendered by `WifiTableComponent`. Because one component instance renders the entire list, every `TuiDropdown` directive read and wrote the same boolean, so opening one menu attempted to open every menu, and the resulting outside-click detection collapsed them all almost instantly.

- Switch to a per-SSID `opens` map (the same pattern `BackupNetworkComponent` already uses for a shared-component list with multiple dropdowns).
- Close the menu explicitly when an option is selected so the `Forget` action — which doesn't hand focus off to a modal — leaves the dropdown closed.

## Test plan

- [ ] System → WiFi: with two or more saved networks, disconnect from the active one, tap "More" on a saved-disconnected entry — menu stays open until an option is selected or you tap away.
- [ ] Tapping Connect still opens the password / confirm dialog and closes the menu.
- [ ] Tapping Forget removes the entry and closes the menu without leaving a stuck overlay.
- [ ] Repeat on touch (mobile) — the original report covered Brave, Chrome, and Android.

Fixes #3242.