### PR TITLE
feat(sdk): Daemons.dynamic + lazy SubContainer.of + hold/release (2.0.0)

### DIFF
--- a/container-runtime/src/Adapters/Systems/SystemForEmbassy/DockerProcedureContainer.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForEmbassy/DockerProcedureContainer.ts
@@ -7,7 +7,7 @@ import { Volume } from "./matchVolume"
 import {
   CommandOptions,
   ExecOptions,
-  SubContainerOwned,
+  SubContainer as SubContainerNS,
 } from "@start9labs/start-sdk/package/lib/util/SubContainer"
 import { Mounts } from "@start9labs/start-sdk/package/lib/mainFn/Mounts"
 import { Manifest } from "@start9labs/start-sdk/base/lib/osBindings"
@@ -50,7 +50,7 @@ export class DockerProcedureContainer extends Drop {
     volumes: { [id: string]: Volume },
     name: string,
   ) {
-    const subcontainer = await SubContainerOwned.of(
+    const subcontainer = await SubContainerNS.eager(
       effects as BackupEffects,
       { imageId: data.image },
       null,

--- a/container-runtime/src/Adapters/Systems/SystemForEmbassy/MainLoop.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForEmbassy/MainLoop.ts
@@ -7,7 +7,7 @@ import { Effects } from "../../../Models/Effects"
 import { off } from "node:process"
 import { CommandController } from "@start9labs/start-sdk/package/lib/mainFn/CommandController"
 import { SDKManifest } from "@start9labs/start-sdk/base/lib/types"
-import { SubContainerRc } from "@start9labs/start-sdk/package/lib/util/SubContainer"
+import { SubContainer } from "@start9labs/start-sdk/package/lib/util/SubContainer"
 
 const EMBASSY_HEALTH_INTERVAL = 15 * 1000
 /**
@@ -16,13 +16,13 @@ const EMBASSY_HEALTH_INTERVAL = 15 * 1000
  * Also, this has an ability to clean itself up too if need be.
  */
 export class MainLoop {
-  private subcontainerRc?: SubContainerRc<SDKManifest>
+  private subcontainerHandle?: SubContainer<SDKManifest>
   get mainSubContainerHandle() {
-    this.subcontainerRc =
-      this.subcontainerRc ??
-      this.mainEvent?.daemon?.subcontainerRc() ??
+    this.subcontainerHandle =
+      this.subcontainerHandle ??
+      this.mainEvent?.daemon?.subcontainer ??
       undefined
-    return this.subcontainerRc
+    return this.subcontainerHandle
   }
   private healthLoops?: {
     name: string

--- a/sdk/ARCHITECTURE.md
+++ b/sdk/ARCHITECTURE.md
@@ -200,7 +200,7 @@ The `.build()` method returns an object containing the entire SDK surface area, 
 |----------|---------|---------|
 | **Manifest** | `manifest`, `volumes` | Access manifest data and volume paths |
 | **Actions** | `Action.withInput`, `Action.withoutInput`, `Actions`, `action.run`, `action.createTask`, `action.createOwnTask`, `action.clearTask` | Define and manage user actions |
-| **Daemons** | `Daemons.of`, `Daemon.of`, `setupMain` | Configure service processes |
+| **Daemons** | `Daemons.of`, `Daemons.dynamic`, `Daemon.of`, `setupMain` | Configure service processes (static or reactive) |
 | **Health** | `healthCheck.checkPortListening`, `.checkWebUrl`, `.runHealthScript` | Built-in health checks |
 | **Interfaces** | `createInterface`, `MultiHost.of`, `setupInterfaces`, `serviceInterface.*` | Network endpoint management |
 | **Backups** | `setupBackups`, `Backups.ofVolumes`, `Backups.ofSyncs`, `Backups.withOptions` | Backup configuration |
@@ -242,6 +242,34 @@ Features:
 - Ready probes (wait for a daemon to be ready before starting dependents)
 - Graceful shutdown with configurable signals and timeouts
 - One-shot commands that run before daemons start
+
+Internally the builder is record-then-materialize: `.addDaemon()` appends a recorded entry, `Daemons.build()` walks the entries to construct `HealthDaemon`s with correct dependency wiring and runs `updateStatus()`. Side-effects start at `build()`, so the timing is identical to the prior eager builder for `setupMain` users.
+
+**`Daemons.dynamic`** makes the daemon set a reactive function of on-disk state. The builder returns a regular `Daemons.of(...).addDaemon(...)` chain; the reconciler diffs its entries against the running set on every `effects.constRetry` trigger:
+
+```typescript
+export const main = sdk.Daemons.dynamic(async ({ effects }) => {
+  const { instances } = (await instancesYaml.read().const(effects)) ?? { instances: [] }
+  let daemons = sdk.Daemons.of<Manifest>({ effects })
+  for (const inst of instances) {
+    daemons = daemons.addDaemon(`reg-${inst.id}`, {
+      subcontainer: sdk.SubContainer.of(effects, { imageId: 'reg', sharedRun: true }, mounts, `reg-${inst.id}-sub`),
+      exec: { command: ['start-registryd'] },
+      ready: { display: inst.label, fn: () => sdk.healthCheck.checkPortListening(effects, inst.port, {}) },
+      requires: [],
+    })
+  }
+  return daemons
+})
+```
+
+Diff semantics per id: absent→present **start**, present→absent **stop**, same `configHash` **leave alone**, different `configHash` **restart**. Dependents of any restarted/stopped daemon are also restarted. `configHash` is a canonical-JSON hash over the subcontainer descriptor (`imageId`, `sharedRun`, `name`, `mounts.build()`), exec, `requires`, and the structural parts of `ready` — closures (`ready.fn`, `ready.trigger`) are excluded so a watched-file touch with unchanged content doesn't bounce every daemon. Lazy `SubContainer`s ({@link SubContainer.of}) are required under `Daemons.dynamic`; eager handles produced inside the builder would defeat the "leave alone" guarantee and the reconciler throws if it sees one.
+
+**SubContainers** come in two flavors:
+- `SubContainer.of(effects, image, mounts, name)` — lazy, the default. Returns a `SubContainerLazy<M>` synchronously; `createFs` happens on first method call. Lazy handles produced inside `Daemons.dynamic` that diff to "leave alone" are GC'd without ever materializing.
+- `SubContainer.eager(effects, image, mounts, name)` — materializes immediately. Returns `Promise<SubContainerEager<M>>`. Use when you need sync `rootfs` / `guid` / `subpath()` or `createFs` failures at construction time.
+
+The unified `SubContainer<M>` interface widens `rootfs` / `guid` / `subpath()` to `T | Promise<T>`; concrete classes narrow. Multiple consumers share a SubContainer by passing the same instance to multiple `addDaemon` calls — each takes a `hold()` and releases on `term`; the container's `destroyFs` fires when `destroy()` has been called and the last hold is released.
 
 **Mounts** declares what to attach to a container:
 ```typescript

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 2.0.0 — StartOS 0.4.0-beta.9 (2026-05-20)
+
+### Added
+
+- `sdk.Daemons.dynamic(fn)` builds a reactive `main` entrypoint whose daemon set is a function of on-disk state. The supplied builder returns a regular `sdk.Daemons.of({ effects }).addDaemon(...)` chain (now record-then-materialize — see below), and the SDK diffs its entries against the running set on every `effects.constRetry` trigger (typically fired by a `FileHelper.read().const(effects)` watcher). Per id: absent → present **start**, present → absent **stop**, same `configHash` **leave alone**, different `configHash` **restart**. Dependents of any restarted or stopped daemon are also restarted to keep `requires` wiring consistent. Re-runs coalesce while one is in flight. Designed for multi-tenant packages like the registry-portal s9pk that add, rename, and delete sub-instance daemons without restarting the service
+- `configHash` covers the subcontainer descriptor (`imageId`, `sharedRun`, `name`, structural `mounts.build()`), exec (`command`, `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`), `requires` (sorted), and the structural parts of `ready` (`display`, `gracePeriod`). Closures (`ready.fn`, `ready.trigger`, function-form `exec.fn`) and pre-built `Daemon` instances are intentionally excluded — surface a value through one of the hashed fields if you want the reconciler to react to it changing
+- `sdk.SubContainer.eager(...)` creates a SubContainer with its filesystem materialized immediately. Use when you need `createFs` failures to surface at the construction site instead of at first method call, or when you need sync access to `rootfs` / `guid` / `subpath()` before running any methods
+- `SubContainerLazy.eager(): Promise<SubContainerEager<M>>` forces materialization on a lazy handle and returns the underlying eager subcontainer for callers that need the narrowed sync interface
+
+### Changed
+
+- **Breaking — `sdk.SubContainer.of(...)` is now lazy by default.** Returns a `SubContainerLazy<M>` *synchronously* (no `Promise<>` wrapper) whose filesystem is materialized on first method call. `rootfs` / `guid` / `subpath()` on the unified `SubContainer<M>` interface widen to `T | Promise<T>`; the concrete classes narrow (`SubContainerEager` to `T`, `SubContainerLazy` to `Promise<T>`). Code holding the generic interface must `await` those accessors; code holding `SubContainerEager` keeps sync access. Migration: most callers already use only async methods (`.exec`, `.writeFile`, `.spawn`, `.launch`) and need no change beyond dropping the redundant `await` on `SubContainer.of(...)`; callers that read `.rootfs` / `.guid` / `.subpath()` add an `await` or switch to `sdk.SubContainer.eager(...)`. The lazy default enables `Daemons.dynamic`'s "leave alone is load-bearing" guarantee: unchanged daemons across reconciles never materialize a fresh subcontainer
+- **Breaking — `SubContainerOwned` / `SubContainerRc` collapsed into `SubContainerEager`.** The reference-counted handle (`SubContainerRc`, `.rc()`, `.isOwned()`) is replaced by an internal hold-count on the unified `SubContainer`. Multiple consumers each call `sub.hold()` (returns a release fn); the container's `destroyFs` fires when `destroy()` has been called and the last hold is released, in either order. `Daemon.start()` takes its own hold for the daemon's lifetime and releases it on `term()`. The `destroySubcontainer` flag on `Daemon.term` / `HealthDaemon.term` is gone — `Daemons.term()` calls `destroy()` on each unique subcontainer in its entries, and the hold machinery handles sharing safely
+- **Breaking — `Daemon.sharesSubcontainerWith` removed.** Two `Daemon`s share a subcontainer when constructed with the same `SubContainer` instance (compare `daemon.subcontainer.identity`). Daemons' internal "should I destroy this subc?" branching is gone — it always calls `destroy()`, and hold-count decides
+- **Breaking — `Daemons` is record-then-materialize.** `.addDaemon()` / `.addOneshot()` / `.addHealthCheck()` append a recorded entry without constructing `HealthDaemon` or `Daemon`. `Daemons.build()` walks the entries and constructs the chain in one pass. Functionally identical for `setupMain` callers — the original "construct on addDaemon, kick off on build" timing is invisible because nothing actually starts until `build()`'s `updateStatus()` calls anyway. The change is load-bearing for `Daemons.dynamic`, which needs to diff entries without paying the cost of building them eagerly each reconcile
+- **Breaking — `SubContainer` adds `identity: symbol`.** Sync, stable handle preserved across `SubContainerLazy.eager()` materialization. Use for sharing checks that must work before materialization (replaces `Daemon.sharesSubcontainerWith`'s previous `guid` comparison, which couldn't fire pre-materialization)
+- Container-runtime updated: `SubContainerOwned` → `SubContainer.eager`; `SubContainerRc<M>` → `SubContainer<M>`; `daemon.subcontainerRc()` → `daemon.subcontainer`
+
+### Removed
+
+- `SubContainerOwned`, `SubContainerRc`, `SubContainer.rc()`, `SubContainer.isOwned()` — folded into the unified `SubContainerEager` / `SubContainerLazy` with hold/release lifecycle
+- `Daemon.subcontainerRc()`, `Daemon.markManaged()`, `Daemon.sharesSubcontainerWith()` — superseded by `daemon.subcontainer` (public readonly) and the hold-count model
+- `destroySubcontainer` option on `Daemon.term` / `HealthDaemon.term` — `Daemons` calls `subcontainer.destroy()` for each unique subc on shutdown, and the hold-count decides actual timing
+
 ## 1.5.3 — StartOS 0.4.0-beta.9 (2026-05-20)
 
 ### Fixed

--- a/sdk/package/lib/StartSdk.ts
+++ b/sdk/package/lib/StartSdk.ts
@@ -844,6 +844,19 @@ export class StartSdk<Manifest extends T.SDKManifest> {
         of(effects: Effects) {
           return Daemons.of<Manifest>({ effects })
         },
+        /**
+         * Build a reactive `main` entrypoint that reconciles its daemon set
+         * against a `Daemons` chain on every `effects.constRetry` trigger.
+         * See {@link Daemons.dynamic} for diff semantics and the rule that
+         * `fn`'s subcontainers must be lazy (`sdk.SubContainer.of(...)`).
+         *
+         * @param fn Async builder invoked on startup and on every constRetry
+         */
+        dynamic(
+          fn: (o: { effects: Effects }) => Promise<Daemons<Manifest, any>> | Daemons<Manifest, any>,
+        ) {
+          return Daemons.dynamic<Manifest>(fn)
+        },
       },
       SubContainer: {
         /**

--- a/sdk/package/lib/StartSdk.ts
+++ b/sdk/package/lib/StartSdk.ts
@@ -63,7 +63,8 @@ import {
   CommandOptions,
   ExitError,
   SubContainer,
-  SubContainerOwned,
+  SubContainerEager,
+  SubContainerLazy,
 } from './util/SubContainer'
 import { createVolumes } from './util/Volume'
 import { getDataVersion, setDataVersion } from './version'
@@ -860,32 +861,62 @@ export class StartSdk<Manifest extends T.SDKManifest> {
           },
           mounts: Mounts<Manifest> | null,
           name: string,
-        ) {
-          return SubContainerOwned.of<Manifest, Effects>(
+        ): SubContainerLazy<Manifest, Effects> {
+          return SubContainer.of<Manifest, Effects>(
             effects,
             image,
             mounts,
             name,
-          ).then((subc) => subc.rc())
+          )
         },
         /**
-         * @description Run a function with a temporary SubContainer
-         * @param effects
-         * @param image - what container image to use
-         * @param mounts - what to mount to the subcontainer
-         * @param name - a name to use to refer to the ephemeral subcontainer for debugging purposes
+         * Create an eager SubContainer, materializing its backing
+         * filesystem immediately. Use when you need synchronous access to
+         * `rootfs` / `guid` / `subpath()` before running any methods, or
+         * want `createFs` failures to surface here instead of at first
+         * method call.
+         *
+         * **Do not pass an eager SubContainer to `Daemons.dynamic`'s `fn`** —
+         * see {@link SubContainer.eager}.
          */
-        withTemp<T>(
-          effects: T.Effects,
+        eager(
+          effects: Effects,
           image: {
             imageId: T.ImageId & keyof Manifest['images']
             sharedRun?: boolean
           },
           mounts: Mounts<Manifest> | null,
           name: string,
-          fn: (subContainer: SubContainer<Manifest>) => Promise<T>,
+        ): Promise<SubContainerEager<Manifest, Effects>> {
+          return SubContainer.eager<Manifest, Effects>(
+            effects,
+            image,
+            mounts,
+            name,
+          )
+        },
+        /**
+         * Run a function with an ephemeral, eager SubContainer. The
+         * container is created before `fn` runs and destroyed in a
+         * `finally` block after.
+         */
+        withTemp<T>(
+          effects: Effects,
+          image: {
+            imageId: T.ImageId & keyof Manifest['images']
+            sharedRun?: boolean
+          },
+          mounts: Mounts<Manifest> | null,
+          name: string,
+          fn: (subContainer: SubContainerEager<Manifest, Effects>) => Promise<T>,
         ): Promise<T> {
-          return SubContainerOwned.withTemp(effects, image, mounts, name, fn)
+          return SubContainer.withTemp<Manifest, T, Effects>(
+            effects,
+            image,
+            mounts,
+            name,
+            fn,
+          )
         },
       },
       List,
@@ -979,7 +1010,7 @@ export async function runCommand<Manifest extends T.SDKManifest>(
     commands = imageMeta.entrypoint ?? []
     commands = commands.concat(...(command.overridCmd ?? imageMeta.cmd ?? []))
   } else commands = splitCommand(command)
-  return SubContainerOwned.withTemp(
+  return SubContainer.withTemp<Manifest, { stdout: string | Buffer; stderr: string | Buffer }>(
     effects,
     image,
     options.mounts,

--- a/sdk/package/lib/backup/Backups.ts
+++ b/sdk/package/lib/backup/Backups.ts
@@ -3,7 +3,7 @@ import * as child_process from 'child_process'
 import * as fs from 'fs/promises'
 import { Affine, asError } from '../util'
 import { InitKind, InitScript } from '../../../base/lib/inits'
-import { SubContainerRc, execFile } from '../util/SubContainer'
+import { SubContainer, execFile } from '../util/SubContainer'
 import { Mounts } from '../mainFn/Mounts'
 
 const BACKUP_HOST_PATH = '/media/startos/backup'
@@ -229,7 +229,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
 
     return new Backups<M>()
       .setPreBackup(async (effects) => {
-        await SubContainerRc.withTemp<M, void, BackupEffects>(
+        await SubContainer.withTemp<M, void, BackupEffects>(
           effects,
           { imageId },
           dbMounts() as any,
@@ -260,7 +260,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       })
       .setPostRestore(async (effects) => {
         const resolvedPassword = await resolvePassword(password)
-        await SubContainerRc.withTemp<M, void, BackupEffects>(
+        await SubContainer.withTemp<M, void, BackupEffects>(
           effects,
           { imageId },
           dbMounts() as any,
@@ -451,7 +451,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
           ...(pw !== null ? [`-p${pw}`] : []),
           '--silent',
         ]
-        await SubContainerRc.withTemp<M, void, BackupEffects>(
+        await SubContainer.withTemp<M, void, BackupEffects>(
           effects,
           { imageId },
           dbMounts() as any,
@@ -491,7 +491,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       })
       .setPostRestore(async (effects) => {
         const pw = await resolvePassword(password)
-        await SubContainerRc.withTemp<M, void, BackupEffects>(
+        await SubContainer.withTemp<M, void, BackupEffects>(
           effects,
           { imageId },
           dbMounts() as any,

--- a/sdk/package/lib/index.ts
+++ b/sdk/package/lib/index.ts
@@ -25,8 +25,13 @@ export {
 }
 export { setupI18n } from './i18n'
 export * as T from './types'
-export { Daemons } from './mainFn/Daemons'
-export { SubContainer } from './util/SubContainer'
+export { Daemons, configHash, DaemonsReconciler } from './mainFn/Daemons'
+export type { DaemonsBuilder } from './mainFn/Daemons'
+export {
+  SubContainer,
+  SubContainerEager,
+  SubContainerLazy,
+} from './util/SubContainer'
 export { StartSdk } from './StartSdk'
 export { setupManifest, buildManifest } from './manifest/setupManifest'
 export { FileHelper } from './util/fileHelper'

--- a/sdk/package/lib/mainFn/CommandController.ts
+++ b/sdk/package/lib/mainFn/CommandController.ts
@@ -47,7 +47,6 @@ export class CommandController<
       subcontainer: C,
       exec: DaemonCommandType<Manifest, C>,
     ) => {
-      try {
         if ('fn' in exec) {
           const abort = new AbortController()
           const cell: { ctrl: CommandController<Manifest, C> } = {
@@ -141,10 +140,6 @@ export class CommandController<
           childProcess,
           exec.sigtermTimeout,
         )
-      } catch (e) {
-        await subcontainer?.destroy()
-        throw e
-      }
     }
   }
   /**
@@ -174,7 +169,6 @@ export class CommandController<
         if (this.process instanceof AbortController) this.process.abort()
         else this.process.kill('SIGKILL')
       }
-      await this.subcontainer?.destroy()
     }
   }
   /**
@@ -187,38 +181,34 @@ export class CommandController<
    * @param options.timeout - Milliseconds before escalating to SIGKILL
    */
   async term({ signal = SIGTERM, timeout = this.sigtermTimeout } = {}) {
-    try {
-      if (!this.state.exited) {
-        if (this.process instanceof AbortController) return this.process.abort()
+    if (!this.state.exited) {
+      if (this.process instanceof AbortController) return this.process.abort()
 
-        if (signal !== 'SIGKILL') {
-          setTimeout(() => {
-            if (this.process instanceof AbortController) this.process.abort()
-            else this.process.kill('SIGKILL')
-          }, timeout)
-        }
-        if (!this.process.kill(signal)) {
-          console.error(
-            `failed to send signal ${signal} to pid ${this.process.pid}`,
-          )
-        }
+      if (signal !== 'SIGKILL') {
+        setTimeout(() => {
+          if (this.process instanceof AbortController) this.process.abort()
+          else this.process.kill('SIGKILL')
+        }, timeout)
       }
-
-      if (this.process instanceof AbortController)
-        await Promise.race([
-          this.runningAnswer,
-          new Promise((_, reject) =>
-            setTimeout(
-              () =>
-                reject(new Error('Timed out waiting for js command to exit')),
-              timeout * 2,
-            ),
-          ),
-        ])
-      else await this.runningAnswer
-    } finally {
-      await this.subcontainer?.destroy()
+      if (!this.process.kill(signal)) {
+        console.error(
+          `failed to send signal ${signal} to pid ${this.process.pid}`,
+        )
+      }
     }
+
+    if (this.process instanceof AbortController)
+      await Promise.race([
+        this.runningAnswer,
+        new Promise((_, reject) =>
+          setTimeout(
+            () =>
+              reject(new Error('Timed out waiting for js command to exit')),
+            timeout * 2,
+          ),
+        ),
+      ])
+    else await this.runningAnswer
   }
   onDrop(): void {
     this.term().catch(logErrorOnce)

--- a/sdk/package/lib/mainFn/Daemon.ts
+++ b/sdk/package/lib/mainFn/Daemon.ts
@@ -31,6 +31,7 @@ export class Daemon<
   private onExitFns: ((success: boolean) => void)[] = []
   private loop: { abort: AbortController; done: Promise<void> } | null = null
   private releaseSubcontainerHold: (() => Promise<void>) | null = null
+  private _managed = false
   protected constructor(
     readonly subcontainer: C,
     private startCommand: () => Promise<CommandController<Manifest, C>>,
@@ -46,9 +47,10 @@ export class Daemon<
    * Factory method to create a new Daemon.
    *
    * Returns a curried function: `(effects, subcontainer, exec) => Daemon`.
-   * Termination on context-leave is handled by the owning `Daemons` instance
-   * (which calls `term()` in dependent-first order); standalone daemons
-   * created outside `Daemons` are responsible for their own teardown.
+   * Registers an `effects.onLeaveContext` hook that terminates the daemon
+   * on parent-context teardown — suppressed when the daemon is adopted by
+   * a {@link Daemons} chain via {@link markManaged}, since `Daemons.term()`
+   * handles dependency-ordered shutdown for those.
    */
   static of<Manifest extends T.SDKManifest>() {
     return <C extends SubContainer<Manifest> | null>(
@@ -58,8 +60,22 @@ export class Daemon<
     ) => {
       const startCommand = () =>
         CommandController.of<Manifest, C>()(effects, subcontainer, exec)
-      return new Daemon<Manifest, C>(subcontainer, startCommand)
+      const res = new Daemon<Manifest, C>(subcontainer, startCommand)
+      effects.onLeaveContext(() => {
+        if (res._managed) return
+        res.term().catch((e) => logErrorOnce(asError(e)))
+      })
+      return res
     }
+  }
+
+  /**
+   * Mark this daemon as managed by a {@link Daemons} instance, suppressing
+   * the per-daemon `onLeaveContext` termination. The owning `Daemons`
+   * handles ordered shutdown via its own `onLeaveContext` registration.
+   */
+  markManaged(): void {
+    this._managed = true
   }
   /**
    * Start the daemon. If it is already running, this is a no-op.
@@ -140,15 +156,14 @@ export class Daemon<
   }
 
   /**
-   * Terminate the daemon, stopping its underlying command and releasing
-   * the SubContainer hold taken at {@link start}.
+   * Terminate the daemon, stopping its underlying command, releasing the
+   * SubContainer hold taken at {@link start}, and requesting the
+   * SubContainer's destruction (`destroy()` is idempotent and defers to
+   * the last hold release, so other daemons sharing the same SubContainer
+   * keep it alive until they also term).
    *
    * Sends the configured signal (default SIGTERM) and waits for the
-   * process to exit. The SubContainer itself is not destroyed by this
-   * call — call `subcontainer.destroy()` separately (typically the
-   * owning `Daemons` instance does that). The container is torn down by
-   * the SubContainer's own machinery when destroy has been requested and
-   * all outstanding holds have been released.
+   * process to exit.
    *
    * @param termOptions Optional termination settings
    * @param termOptions.signal The signal to send (default `SIGTERM`)
@@ -177,6 +192,13 @@ export class Daemon<
       const release = this.releaseSubcontainerHold
       this.releaseSubcontainerHold = null
       await release().catch(logErrorOnce)
+    }
+
+    // Request the SubContainer's destruction. Idempotent + hold-aware:
+    // if another daemon still holds this SubContainer, destroy waits for
+    // the last hold-release before firing `destroyFs`.
+    if (this.subcontainer) {
+      await this.subcontainer.destroy().catch((e) => logErrorOnce(asError(e)))
     }
   }
 

--- a/sdk/package/lib/mainFn/Daemon.ts
+++ b/sdk/package/lib/mainFn/Daemon.ts
@@ -2,19 +2,22 @@ import * as T from '../../../base/lib/types'
 import { asError } from '../../../base/lib/util/asError'
 import { logErrorOnce } from '../../../base/lib/util/logErrorOnce'
 import { Drop } from '../util'
-import { SubContainer, SubContainerRc } from '../util/SubContainer'
+import { SubContainer } from '../util/SubContainer'
 import { CommandController } from './CommandController'
 import { DaemonCommandType } from './Daemons'
 import { Oneshot } from './Oneshot'
 
 const TIMEOUT_INCREMENT_MS = 1000
 const MAX_TIMEOUT_MS = 30000
+
 /**
  * A managed long-running process wrapper around {@link CommandController}.
  *
- * When started, the daemon automatically restarts its underlying command on failure
- * with exponential backoff (up to 30 seconds). When stopped, the command is terminated
- * gracefully. Implements {@link Drop} for automatic cleanup when the context is left.
+ * When started, the daemon automatically restarts its underlying command on
+ * failure with exponential backoff (up to 30 seconds). When stopped, the
+ * command is terminated gracefully. While the daemon is running, it holds a
+ * use-token (`subcontainer.hold()`) on its SubContainer so the container is
+ * not destroyed out from under it. The hold is released on `term()`.
  *
  * @typeParam Manifest - The service manifest type
  * @typeParam C - The subcontainer type, or `null` for JS-only daemons
@@ -27,9 +30,9 @@ export class Daemon<
   protected exitedSuccess = false
   private onExitFns: ((success: boolean) => void)[] = []
   private loop: { abort: AbortController; done: Promise<void> } | null = null
-  private _managed = false
+  private releaseSubcontainerHold: (() => Promise<void>) | null = null
   protected constructor(
-    private subcontainer: C,
+    readonly subcontainer: C,
     private startCommand: () => Promise<CommandController<Manifest, C>>,
     readonly oneshot: boolean = false,
   ) {
@@ -43,8 +46,9 @@ export class Daemon<
    * Factory method to create a new Daemon.
    *
    * Returns a curried function: `(effects, subcontainer, exec) => Daemon`.
-   * Registers an `onLeaveContext` callback that terminates the daemon when the
-   * effects context is left.
+   * Termination on context-leave is handled by the owning `Daemons` instance
+   * (which calls `term()` in dependent-first order); standalone daemons
+   * created outside `Daemons` are responsible for their own teardown.
    */
   static of<Manifest extends T.SDKManifest>() {
     return <C extends SubContainer<Manifest> | null>(
@@ -52,32 +56,25 @@ export class Daemon<
       subcontainer: C,
       exec: DaemonCommandType<Manifest, C>,
     ) => {
-      let subc: SubContainer<Manifest> | null = subcontainer
-      if (subcontainer && subcontainer.isOwned()) subc = subcontainer.rc()
       const startCommand = () =>
-        CommandController.of<Manifest, C>()(
-          effects,
-          (subc?.rc() ?? null) as C,
-          exec,
-        )
-      const res = new Daemon(subc, startCommand)
-      effects.onLeaveContext(() => {
-        if (!res._managed) {
-          res.term({ destroySubcontainer: true }).catch((e) => logErrorOnce(e))
-        }
-      })
-      return res
+        CommandController.of<Manifest, C>()(effects, subcontainer, exec)
+      return new Daemon<Manifest, C>(subcontainer, startCommand)
     }
   }
   /**
    * Start the daemon. If it is already running, this is a no-op.
    *
-   * The daemon will automatically restart on failure with increasing backoff
-   * until {@link term} is called.
+   * Takes a `hold()` on the daemon's SubContainer (if any) so the container
+   * is kept alive while the daemon runs. The hold is released on
+   * {@link term}. The daemon will automatically restart on failure with
+   * increasing backoff until `term` is called.
    */
   async start() {
     if (this.loop) {
       return
+    }
+    if (this.subcontainer && !this.releaseSubcontainerHold) {
+      this.releaseSubcontainerHold = this.subcontainer.hold()
     }
     const abort = new AbortController()
     const done = this.runLoop(abort.signal)
@@ -143,20 +140,23 @@ export class Daemon<
   }
 
   /**
-   * Terminate the daemon, stopping its underlying command.
+   * Terminate the daemon, stopping its underlying command and releasing
+   * the SubContainer hold taken at {@link start}.
    *
-   * Sends the configured signal (default SIGTERM) and waits for the process to exit.
-   * Optionally destroys the subcontainer after termination.
+   * Sends the configured signal (default SIGTERM) and waits for the
+   * process to exit. The SubContainer itself is not destroyed by this call
+   * — call `subcontainer.destroy()` separately (typically the owning
+   * `Daemons` instance does that). The container is torn down by the
+   * SubContainer's own machinery when destroy has been requested and all
+   * outstanding holds have been released.
    *
    * @param termOptions - Optional termination settings
    * @param termOptions.signal - The signal to send (default: SIGTERM)
    * @param termOptions.timeout - Milliseconds to wait before SIGKILL
-   * @param termOptions.destroySubcontainer - Whether to destroy the subcontainer after exit
    */
   async term(termOptions?: {
     signal?: NodeJS.Signals | undefined
     timeout?: number | undefined
-    destroySubcontainer?: boolean
   }) {
     this.exitedSuccess = false
     this.onExitFns = []
@@ -173,28 +173,13 @@ export class Daemon<
       await this.loop.done
     }
 
-    if (termOptions?.destroySubcontainer) {
-      await this.subcontainer?.destroy()
+    if (this.releaseSubcontainerHold) {
+      const release = this.releaseSubcontainerHold
+      this.releaseSubcontainerHold = null
+      await release().catch(logErrorOnce)
     }
   }
-  /**
-   * Mark this daemon as managed by a {@link Daemons} instance.
-   * Suppresses the individual `onLeaveContext` termination since the
-   * `Daemons` instance handles ordered shutdown.
-   */
-  markManaged() {
-    this._managed = true
-  }
-  /** Get a reference-counted handle to the daemon's subcontainer, or null if there is none */
-  subcontainerRc(): SubContainerRc<Manifest> | null {
-    return this.subcontainer?.rc() ?? null
-  }
-  /** Check whether this daemon shares the same subcontainer as another daemon */
-  sharesSubcontainerWith(
-    other: Daemon<Manifest, SubContainer<Manifest> | null>,
-  ): boolean {
-    return this.subcontainer?.guid === other.subcontainer?.guid
-  }
+
   /**
    * Register a callback to be invoked each time the daemon's process exits.
    * @param fn - Callback receiving `true` on clean exit, `false` on error

--- a/sdk/package/lib/mainFn/Daemon.ts
+++ b/sdk/package/lib/mainFn/Daemon.ts
@@ -144,15 +144,15 @@ export class Daemon<
    * the SubContainer hold taken at {@link start}.
    *
    * Sends the configured signal (default SIGTERM) and waits for the
-   * process to exit. The SubContainer itself is not destroyed by this call
-   * — call `subcontainer.destroy()` separately (typically the owning
-   * `Daemons` instance does that). The container is torn down by the
-   * SubContainer's own machinery when destroy has been requested and all
-   * outstanding holds have been released.
+   * process to exit. The SubContainer itself is not destroyed by this
+   * call — call `subcontainer.destroy()` separately (typically the
+   * owning `Daemons` instance does that). The container is torn down by
+   * the SubContainer's own machinery when destroy has been requested and
+   * all outstanding holds have been released.
    *
-   * @param termOptions - Optional termination settings
-   * @param termOptions.signal - The signal to send (default: SIGTERM)
-   * @param termOptions.timeout - Milliseconds to wait before SIGKILL
+   * @param termOptions Optional termination settings
+   * @param termOptions.signal The signal to send (default `SIGTERM`)
+   * @param termOptions.timeout Milliseconds to wait before escalating to `SIGKILL` (default = `Daemon`'s configured `sigtermTimeout`, ultimately `DEFAULT_SIGTERM_TIMEOUT`)
    */
   async term(termOptions?: {
     signal?: NodeJS.Signals | undefined

--- a/sdk/package/lib/mainFn/Daemons.ts
+++ b/sdk/package/lib/mainFn/Daemons.ts
@@ -38,29 +38,98 @@ export const cpExecFile = promisify(CP.execFile)
  * to 1 s before the first non-pending result, then 30 s). During the initial
  * `gracePeriod` window, `failure` results are softened to `starting` so the
  * UI doesn't flash red while a daemon is still booting.
+ *
+ * ### Health check result states
+ *
+ * | Result      | Meaning                                              | UI treatment     |
+ * |-------------|------------------------------------------------------|------------------|
+ * | `success`   | Healthy and fully operational                        | Green / ready    |
+ * | `loading`   | Operational but still catching up (e.g. syncing)     | Progress / amber |
+ * | `disabled`  | Intentionally inactive (excluded by configuration)   | Grey / skipped   |
+ * | `starting`  | Not yet ready, still initializing                    | Spinner          |
+ * | `waiting`   | Blocked on an external dependency                    | Spinner          |
+ * | `failure`   | Unhealthy — something is wrong                       | Red / error      |
  */
 export type Ready = {
+  /**
+   * Human-readable label shown in the StartOS health-check UI.
+   * Set to `null` to hide this check from the UI entirely.
+   */
   display: string | null
+  /**
+   * The function called on each polling interval to determine the daemon's health.
+   *
+   * Return a {@link HealthCheckResult} with a `result` field (`success`, `loading`,
+   * `failure`, etc.) and an optional `message` string shown in the UI.
+   *
+   * The SDK ships several built-in helpers on `sdk.healthCheck`:
+   * - `checkPortListening` — checks whether a TCP/UDP port is bound
+   * - `checkWebUrl` — fetches a URL and succeeds on any HTTP response
+   * - `runHealthScript` — runs a command in a subcontainer and succeeds on exit 0
+   *
+   * @example
+   * ```ts
+   * fn: () =>
+   *   sdk.healthCheck.checkPortListening(effects, 80, {
+   *     successMessage: 'Web server is ready',
+   *     errorMessage: 'Web server is not listening',
+   *   })
+   * ```
+   */
   fn: () => Promise<HealthCheckResult> | HealthCheckResult
+  /**
+   * Duration in milliseconds during which `failure` results are reported
+   * as `starting` instead, giving the daemon time to initialize without
+   * showing errors in the UI.
+   *
+   * @default 10_000
+   */
   gracePeriod?: number
+  /**
+   * Controls the polling interval for this health check.
+   *
+   * Use one of the built-in triggers from `sdk.trigger`:
+   * - `cooldownTrigger(ms)` — fixed interval between checks
+   * - `statusTrigger({ success, loading, failure, ... })` — per-status
+   *   polling intervals
+   *
+   * If omitted, uses the default trigger: 1 s before the first non-pending
+   * result, then 30 s afterward.
+   */
   trigger?: Trigger
 }
 
-/** Options for running a daemon as a shell command inside a subcontainer. */
+/**
+ * Options for running a daemon as a shell command inside a subcontainer.
+ */
 export type ExecCommandOptions = {
+  /** The command and arguments to execute (e.g. `['bitcoind', '-conf=/etc/bitcoin.conf']`) */
   command: T.CommandType
+  /**
+   * How long (ms) to wait for the process to exit after sending SIGTERM
+   * before force-killing it.
+   *
+   * @default 30_000
+   */
   sigtermTimeout?: number
+  /** Run the command as PID 1 inside the container (init process) */
   runAsInit?: boolean
+  /** Environment variables to set for the process */
   env?: { [variable in string]?: string } | undefined
+  /** Working directory for the process */
   cwd?: string | undefined
+  /** Run the process as this user inside the container */
   user?: string | undefined
+  /** Callback invoked with each chunk written to stdout */
   onStdout?: (chunk: Buffer | string | any) => void
+  /** Callback invoked with each chunk written to stderr */
   onStderr?: (chunk: Buffer | string | any) => void
 }
 
 /**
- * Options for running a daemon via an async function that may optionally
- * return a command to execute in the subcontainer.
+ * Options for running a daemon via an async function that may optionally return
+ * a command to execute in the subcontainer. The function receives an `AbortSignal`
+ * for cooperative cancellation.
  */
 export type ExecFnOptions<
   Manifest extends T.SDKManifest,
@@ -70,9 +139,14 @@ export type ExecFnOptions<
     subcontainer: C,
     abort: AbortSignal,
   ) => Promise<C extends null ? null : ExecCommandOptions | null>
+  // Defaults to the DEFAULT_SIGTERM_TIMEOUT = 30_000ms
   sigtermTimeout?: number
 }
 
+/**
+ * The execution specification for a daemon: either an {@link ExecFnOptions} (async function)
+ * or an {@link ExecCommandOptions} (shell command, only valid when a subcontainer is provided).
+ */
 export type DaemonCommandType<
   Manifest extends T.SDKManifest,
   C extends SubContainer<Manifest> | null,
@@ -82,7 +156,7 @@ type NewDaemonParams<
   Manifest extends T.SDKManifest,
   C extends SubContainer<Manifest> | null,
 > = {
-  /** What to run as the daemon: either an async fn or a commandline command */
+  /** What to run as the daemon: either an async fn or a commandline command to run in the subcontainer */
   exec: DaemonCommandType<Manifest, C>
   /** The subcontainer in which the daemon runs */
   subcontainer: C
@@ -115,11 +189,19 @@ type AddOneshotParams<
   Id extends string,
   C extends SubContainer<Manifest> | null,
 > = NewDaemonParams<Manifest, C> & {
+  /**
+   * IDs of prior daemons/oneshots/health checks that must be ready before
+   * this oneshot runs.
+   */
   requires: Exclude<Ids, Id>[]
 }
 
 type AddHealthCheckParams<Ids extends string, Id extends string> = {
   ready: Ready
+  /**
+   * IDs of prior daemons/oneshots/health checks that must be ready before
+   * this health check starts polling.
+   */
   requires: Exclude<Ids, Id>[]
 }
 
@@ -155,7 +237,7 @@ export const runCommand = <Manifest extends T.SDKManifest>() =>
   CommandController.of<Manifest, SubContainer<Manifest>>()
 
 /**
- * Builder for the service's daemon topology.
+ * A class for defining and controlling the service daemons
  *
  * `Daemons` is a record-then-build container: each `.addDaemon(...)` /
  * `.addOneshot(...)` / `.addHealthCheck(...)` call appends an entry to an
@@ -175,7 +257,15 @@ export const runCommand = <Manifest extends T.SDKManifest>() =>
  *   .addDaemon('webui', {
  *     subcontainer: sdk.SubContainer.of(effects, { imageId: 'main' }, mounts, 'webui'),
  *     exec: { command: ['hello-world'] },
- *     ready: { display: 'Web Interface', fn: () => sdk.healthCheck.checkPortListening(effects, 80, {}) },
+ *     ready: {
+ *       display: 'Web Interface',
+ *       // The function to run to determine the health status of the daemon
+ *       fn: () =>
+ *         checkPortListening(effects, 80, {
+ *           successMessage: 'The web interface is ready',
+ *           errorMessage: 'The web interface is not ready',
+ *         }),
+ *     },
  *     requires: [],
  *   })
  * ```

--- a/sdk/package/lib/mainFn/Daemons.ts
+++ b/sdk/package/lib/mainFn/Daemons.ts
@@ -4,7 +4,14 @@ import { HealthCheckResult } from '../health/checkFns'
 
 import { Trigger } from '../trigger'
 import * as T from '../../../base/lib/types'
-import { SubContainer } from '../util/SubContainer'
+import {
+  SubContainer,
+  SubContainerEager,
+  SubContainerLazy,
+} from '../util/SubContainer'
+import { once } from '../../../base/lib/util/once'
+import { logErrorOnce } from '../../../base/lib/util/logErrorOnce'
+import { asError } from '../../../base/lib/util/asError'
 
 import { promisify } from 'node:util'
 import * as CP from 'node:child_process'
@@ -20,6 +27,7 @@ import { Oneshot } from './Oneshot'
 export const cpExec = promisify(CP.exec)
 /** Promisified version of `child_process.execFile` */
 export const cpExecFile = promisify(CP.execFile)
+
 /**
  * Configuration for a daemon's health-check readiness probe.
  *
@@ -30,102 +38,29 @@ export const cpExecFile = promisify(CP.execFile)
  * to 1 s before the first non-pending result, then 30 s). During the initial
  * `gracePeriod` window, `failure` results are softened to `starting` so the
  * UI doesn't flash red while a daemon is still booting.
- *
- * ### Health check result states
- *
- * | Result      | Meaning                                              | UI treatment     |
- * |-------------|------------------------------------------------------|------------------|
- * | `success`   | Healthy and fully operational                        | Green / ready    |
- * | `loading`   | Operational but still catching up (e.g. syncing)     | Progress / amber |
- * | `disabled`  | Intentionally inactive (excluded by configuration)   | Grey / skipped   |
- * | `starting`  | Not yet ready, still initializing                    | Spinner          |
- * | `waiting`   | Blocked on an external dependency                    | Spinner          |
- * | `failure`   | Unhealthy — something is wrong                       | Red / error      |
  */
 export type Ready = {
-  /**
-   * Human-readable label shown in the StartOS health-check UI.
-   * Set to `null` to hide this check from the UI entirely.
-   */
   display: string | null
-  /**
-   * The function called on each polling interval to determine the daemon's health.
-   *
-   * Return a {@link HealthCheckResult} with a `result` field (`success`, `loading`,
-   * `failure`, etc.) and an optional `message` string shown in the UI.
-   *
-   * The SDK ships several built-in helpers on `sdk.healthCheck`:
-   * - `checkPortListening` — checks whether a TCP/UDP port is bound
-   * - `checkWebUrl` — fetches a URL and succeeds on any HTTP response
-   * - `runHealthScript` — runs a command in a subcontainer and succeeds on exit 0
-   *
-   * @example
-   * ```ts
-   * fn: () =>
-   *   sdk.healthCheck.checkPortListening(effects, 80, {
-   *     successMessage: 'Web server is ready',
-   *     errorMessage: 'Web server is not listening',
-   *   })
-   * ```
-   */
   fn: () => Promise<HealthCheckResult> | HealthCheckResult
-  /**
-   * Duration in milliseconds during which `failure` results are reported
-   * as `starting` instead, giving the daemon time to initialize without
-   * showing errors in the UI.
-   *
-   * @default 10_000
-   */
   gracePeriod?: number
-  /**
-   * Controls the polling interval for this health check.
-   *
-   * Use one of the built-in triggers from `sdk.trigger`:
-   * - `cooldownTrigger(ms)` — fixed interval between checks
-   * - `statusTrigger({ success, loading, failure, ... })` — per-status
-   *   polling intervals
-   *
-   * If omitted, uses the default trigger: 1 s before the first non-pending
-   * result, then 30 s afterward.
-   */
   trigger?: Trigger
 }
 
-/**
- * Options for running a daemon as a shell command inside a subcontainer.
- */
+/** Options for running a daemon as a shell command inside a subcontainer. */
 export type ExecCommandOptions = {
-  /** The command and arguments to execute (e.g. `['bitcoind', '-conf=/etc/bitcoin.conf']`) */
   command: T.CommandType
-  /**
-   * How long (ms) to wait for the process to exit after sending SIGTERM
-   * before force-killing it.
-   *
-   * @default 30_000
-   */
   sigtermTimeout?: number
-  /** Run the command as PID 1 inside the container (init process) */
   runAsInit?: boolean
-  /** Environment variables to set for the process */
-  env?:
-    | {
-        [variable in string]?: string
-      }
-    | undefined
-  /** Working directory for the process */
+  env?: { [variable in string]?: string } | undefined
   cwd?: string | undefined
-  /** Run the process as this user inside the container */
   user?: string | undefined
-  /** Callback invoked with each chunk written to stdout */
   onStdout?: (chunk: Buffer | string | any) => void
-  /** Callback invoked with each chunk written to stderr */
   onStderr?: (chunk: Buffer | string | any) => void
 }
 
 /**
- * Options for running a daemon via an async function that may optionally return
- * a command to execute in the subcontainer. The function receives an `AbortSignal`
- * for cooperative cancellation.
+ * Options for running a daemon via an async function that may optionally
+ * return a command to execute in the subcontainer.
  */
 export type ExecFnOptions<
   Manifest extends T.SDKManifest,
@@ -135,14 +70,9 @@ export type ExecFnOptions<
     subcontainer: C,
     abort: AbortSignal,
   ) => Promise<C extends null ? null : ExecCommandOptions | null>
-  // Defaults to the DEFAULT_SIGTERM_TIMEOUT = 30_000ms
   sigtermTimeout?: number
 }
 
-/**
- * The execution specification for a daemon: either an {@link ExecFnOptions} (async function)
- * or an {@link ExecCommandOptions} (shell command, only valid when a subcontainer is provided).
- */
 export type DaemonCommandType<
   Manifest extends T.SDKManifest,
   C extends SubContainer<Manifest> | null,
@@ -152,7 +82,7 @@ type NewDaemonParams<
   Manifest extends T.SDKManifest,
   C extends SubContainer<Manifest> | null,
 > = {
-  /** What to run as the daemon: either an async fn or a commandline command to run in the subcontainer */
+  /** What to run as the daemon: either an async fn or a commandline command */
   exec: DaemonCommandType<Manifest, C>
   /** The subcontainer in which the daemon runs */
   subcontainer: C
@@ -169,9 +99,7 @@ type AddDaemonParams<
   C extends SubContainer<Manifest> | null,
 > = (
   | NewDaemonParams<Manifest, C>
-  | {
-      daemon: Daemon<Manifest>
-    }
+  | { daemon: Daemon<Manifest> }
 ) & {
   ready: Ready
   /**
@@ -187,96 +115,132 @@ type AddOneshotParams<
   Id extends string,
   C extends SubContainer<Manifest> | null,
 > = NewDaemonParams<Manifest, C> & {
-  exec: DaemonCommandType<Manifest, C>
-  /**
-   * IDs of prior daemons/oneshots/health checks that must be ready before
-   * this oneshot runs.
-   */
   requires: Exclude<Ids, Id>[]
 }
 
 type AddHealthCheckParams<Ids extends string, Id extends string> = {
   ready: Ready
-  /**
-   * IDs of prior daemons/oneshots/health checks that must be ready before
-   * this health check starts polling.
-   */
   requires: Exclude<Ids, Id>[]
 }
 
 type ErrorDuplicateId<Id extends string> = `The id '${Id}' is already used`
 
+/** Recorder entry for a `Daemons` chain. Materialized into `HealthDaemon`s at build/reconcile time. */
+type DaemonEntry<M extends T.SDKManifest> =
+  | {
+      kind: 'daemon'
+      id: string
+      subcontainer: SubContainer<M> | null
+      exec: DaemonCommandType<M, SubContainer<M> | null>
+      ready: Ready
+      requires: ReadonlyArray<string>
+      /** If supplied via the `{ daemon: ... }` form, pre-built daemon. */
+      prebuiltDaemon: Daemon<M> | null
+    }
+  | {
+      kind: 'oneshot'
+      id: string
+      subcontainer: SubContainer<M> | null
+      exec: DaemonCommandType<M, SubContainer<M> | null>
+      requires: ReadonlyArray<string>
+    }
+  | {
+      kind: 'health'
+      id: string
+      ready: Ready
+      requires: ReadonlyArray<string>
+    }
+
 export const runCommand = <Manifest extends T.SDKManifest>() =>
   CommandController.of<Manifest, SubContainer<Manifest>>()
 
 /**
- * A class for defining and controlling the service daemons
-```ts
-Daemons.of({
-  effects,
-  started,
-  interfaceReceipt, // Provide the interfaceReceipt to prove it was completed
-  healthReceipts, // Provide the healthReceipts or [] to prove they were at least considered
-}).addDaemon('webui', {
-  command: 'hello-world', // The command to start the daemon
-  ready: {
-    display: 'Web Interface',
-    // The function to run to determine the health status of the daemon
-    fn: () =>
-      checkPortListening(effects, 80, {
-        successMessage: 'The web interface is ready',
-        errorMessage: 'The web interface is not ready',
-      }),
-  },
-  requires: [],
-})
-```
+ * Builder for the service's daemon topology.
+ *
+ * `Daemons` is a record-then-build container: each `.addDaemon(...)` /
+ * `.addOneshot(...)` / `.addHealthCheck(...)` call appends an entry to an
+ * internal list (no `HealthDaemon` or `SubContainer.createFs` work happens
+ * yet). The chain is materialized when {@link build} is called (for static
+ * topologies in {@link setupMain}) or progressively, per entry, by
+ * {@link Daemons.dynamic} (for topologies that change at runtime).
+ *
+ * Backward-compatible with the prior eager builder: `Daemons.of(...).addDaemon(...).build()`
+ * still produces a running chain. The only externally visible change is that
+ * `HealthDaemon` instances exist after `build()` rather than after each
+ * `.addDaemon()`.
+ *
+ * @example
+ * ```ts
+ * sdk.Daemons.of({ effects })
+ *   .addDaemon('webui', {
+ *     subcontainer: sdk.SubContainer.of(effects, { imageId: 'main' }, mounts, 'webui'),
+ *     exec: { command: ['hello-world'] },
+ *     ready: { display: 'Web Interface', fn: () => sdk.healthCheck.checkPortListening(effects, 80, {}) },
+ *     requires: [],
+ *   })
+ * ```
  */
 export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
   implements T.DaemonBuildable
 {
+  private builtHealthDaemons: HealthDaemon<Manifest>[] | null = null
   private termPromise: Promise<void> | null = null
+
   private constructor(
     readonly effects: T.Effects,
     readonly ids: Ids[],
-    readonly healthDaemons: HealthDaemon<Manifest>[],
+    readonly entries: ReadonlyArray<DaemonEntry<Manifest>>,
   ) {}
+
   /**
-   * Returns an empty new Daemons class with the provided inputSpec.
+   * Returns an empty new Daemons class.
    *
-   * Call .addDaemon() on the returned class to add a daemon.
-   *
-   * Daemons run in the order they are defined, with latter daemons being capable of
-   * depending on prior daemons
-   *
-   * @param effects
-   *
-   * @param started
-   * @returns
+   * Call .addDaemon() on the returned class to add a daemon. Daemons run in
+   * the order they are defined; later daemons may depend on prior daemons.
    */
   static of<Manifest extends T.SDKManifest>(options: { effects: T.Effects }) {
     return new Daemons<Manifest, never>(options.effects, [], [])
   }
 
-  private addDaemonImpl<Id extends string>(
-    id: Id,
-    daemon: Daemon<Manifest, SubContainer<Manifest, T.Effects> | null> | null,
-    requires: Ids[],
-    ready: Ready | typeof EXIT_SUCCESS,
-  ) {
-    const healthDaemon = new HealthDaemon(
-      daemon,
-      requires
-        .map((x) => this.ids.indexOf(x))
-        .filter((x) => x >= 0)
-        .map((id) => this.healthDaemons[id]),
-      id,
-      ready,
+  /**
+   * Build a reactive `main` entrypoint that reconciles the daemon set
+   * returned by `fn` against the running set on every `effects.constRetry`
+   * trigger.
+   *
+   * The supplied builder returns a {@link Daemons} (in record-mode, not yet
+   * built); the SDK diffs its entries against the running daemons by
+   * `(id, configHash)`. Per id: absent → present **start**, present →
+   * absent **stop**, same hash **leave alone**, different hash **restart**.
+   * Dependents of any restarted or stopped daemon are also restarted so
+   * `requires` wiring stays consistent. Re-runs are coalesced.
+   *
+   * The diff key (`configHash`) covers the subcontainer descriptor
+   * (`imageId`, `sharedRun`, `name`, structural `mounts.build()`), exec
+   * (`command`, `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`),
+   * `requires` (sorted), and the structural parts of `ready` (`display`,
+   * `gracePeriod`). Closures (`ready.fn`, `ready.trigger`) and pre-built
+   * `Daemon` instances are intentionally excluded — surface a value
+   * through one of the hashed fields if you want the reconciler to react
+   * to it changing.
+   *
+   * **Use lazy SubContainers** ({@link SubContainer.of}) for daemons under
+   * `Daemons.dynamic`. Eager handles created inside `fn` are wasted on
+   * re-runs that diff to "leave alone"; the reconciler throws at hash time
+   * if it sees one.
+   */
+  static dynamic<Manifest extends T.SDKManifest>(
+    fn: DaemonsBuilder<Manifest>,
+  ): T.ExpectedExports.main {
+    return async ({ effects }) =>
+      new DaemonsReconciler<Manifest>(effects, fn)
+  }
+
+  private appendEntry(entry: DaemonEntry<Manifest>): Daemons<Manifest, any> {
+    return new Daemons<Manifest, any>(
       this.effects,
+      [...this.ids, entry.id as any],
+      [...this.entries, entry],
     )
-    const ids = [...this.ids, id] as (Ids | Id)[]
-    const healthDaemons = [...this.healthDaemons, healthDaemon]
-    return new Daemons<Manifest, Ids | Id>(this.effects, ids, healthDaemons)
   }
 
   /**
@@ -284,18 +248,13 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    *
    * The daemon starts in its subcontainer and is monitored by its `ready`
    * health check. Other daemons and health checks can depend on it via
-   * `requires`.
-   *
-   * Pass a static options object, a sync/async factory that returns options
-   * (or `null` to conditionally skip the daemon), or an object with a
-   * pre-built `daemon` instance.
-   *
-   * @param id - Unique string identifier for this daemon
-   * @param options - Daemon configuration, or a factory returning it (return `null` to skip)
+   * `requires`. Pass a static options object, a sync/async factory that
+   * returns options (or `null` to conditionally skip the daemon), or an
+   * object with a pre-built `daemon` instance.
    */
   addDaemon<Id extends string, C extends SubContainer<Manifest> | null>(
     // prettier-ignore
-    id: 
+    id:
       "" extends Id ? never :
       ErrorDuplicateId<Id> extends Id ? never :
       Id extends Ids ? ErrorDuplicateId<Id> :
@@ -304,7 +263,7 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
   ): Daemons<Manifest, Ids | Id>
   addDaemon<Id extends string, C extends SubContainer<Manifest> | null>(
     // prettier-ignore
-    id: 
+    id:
       "" extends Id ? never :
       ErrorDuplicateId<Id> extends Id ? never :
       Id extends Ids ? ErrorDuplicateId<Id> :
@@ -316,41 +275,34 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
     options: OptionalParam<AddDaemonParams<Manifest, Ids, Id, C>>,
   ) {
     const prev = this
-    const res = (options: AddDaemonParams<Manifest, Ids, Id, C> | null) => {
-      if (!options) return prev
-      const daemon =
-        'daemon' in options
-          ? options.daemon
-          : Daemon.of<Manifest>()<C>(
-              this.effects,
-              options.subcontainer,
-              options.exec,
-            )
-      return prev.addDaemonImpl(id, daemon, options.requires, options.ready)
+    const res = (opts: AddDaemonParams<Manifest, Ids, Id, C> | null) => {
+      if (!opts) return prev
+      const entry: DaemonEntry<Manifest> = {
+        kind: 'daemon',
+        id,
+        subcontainer: 'daemon' in opts ? opts.daemon.subcontainer : opts.subcontainer,
+        exec:
+          'daemon' in opts
+            ? (null as unknown as DaemonCommandType<Manifest, SubContainer<Manifest> | null>)
+            : (opts.exec as DaemonCommandType<Manifest, SubContainer<Manifest> | null>),
+        ready: opts.ready,
+        requires: opts.requires as string[],
+        prebuiltDaemon: 'daemon' in opts ? (opts.daemon as Daemon<Manifest>) : null,
+      }
+      return prev.appendEntry(entry)
     }
     if (options instanceof Function) {
       const opts = options()
-      if (opts instanceof Promise) {
-        return opts.then(res)
-      }
+      if (opts instanceof Promise) return opts.then(res)
       return res(opts)
     }
     return res(options)
   }
 
-  /**
-   * Register a one-shot command that runs to completion before dependents start.
-   *
-   * Common uses: `chown` for file ownership, database migrations, config
-   * generation, wallet unlocking. The oneshot is considered "ready" as soon
-   * as the command exits successfully (exit code 0).
-   *
-   * @param id - Unique string identifier for this oneshot
-   * @param options - Oneshot configuration, or a factory returning it (return `null` to skip)
-   */
+  /** Register a one-shot command that runs to completion before dependents start. */
   addOneshot<Id extends string, C extends SubContainer<Manifest> | null>(
     // prettier-ignore
-    id: 
+    id:
       "" extends Id ? never :
       ErrorDuplicateId<Id> extends Id ? never :
       Id extends Ids ? ErrorDuplicateId<Id> :
@@ -359,7 +311,7 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
   ): Daemons<Manifest, Ids | Id>
   addOneshot<Id extends string, C extends SubContainer<Manifest> | null>(
     // prettier-ignore
-    id: 
+    id:
       "" extends Id ? never :
       ErrorDuplicateId<Id> extends Id ? never :
       Id extends Ids ? ErrorDuplicateId<Id> :
@@ -371,38 +323,29 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
     options: OptionalParam<AddOneshotParams<Manifest, Ids, Id, C>>,
   ) {
     const prev = this
-    const res = (options: AddOneshotParams<Manifest, Ids, Id, C> | null) => {
-      if (!options) return prev
-      const daemon = Oneshot.of<Manifest>()<C>(
-        this.effects,
-        options.subcontainer,
-        options.exec,
-      )
-      return prev.addDaemonImpl(id, daemon, options.requires, EXIT_SUCCESS)
+    const res = (opts: AddOneshotParams<Manifest, Ids, Id, C> | null) => {
+      if (!opts) return prev
+      const entry: DaemonEntry<Manifest> = {
+        kind: 'oneshot',
+        id,
+        subcontainer: opts.subcontainer,
+        exec: opts.exec as DaemonCommandType<Manifest, SubContainer<Manifest> | null>,
+        requires: opts.requires as string[],
+      }
+      return prev.appendEntry(entry)
     }
     if (options instanceof Function) {
       const opts = options()
-      if (opts instanceof Promise) {
-        return opts.then(res)
-      }
+      if (opts instanceof Promise) return opts.then(res)
       return res(opts)
     }
     return res(options)
   }
 
-  /**
-   * Register a standalone health check with no associated process.
-   *
-   * Use this for ongoing conditions that don't map to a single daemon, such
-   * as blockchain sync progress or network reachability. Dependent services
-   * can reference standalone health check IDs in their dependency config.
-   *
-   * @param id - Unique string identifier for this health check
-   * @param options - Health check configuration, or a factory returning it (return `null` to skip)
-   */
+  /** Register a standalone health check with no associated process. */
   addHealthCheck<Id extends string>(
     // prettier-ignore
-    id: 
+    id:
       "" extends Id ? never :
       ErrorDuplicateId<Id> extends Id ? never :
       Id extends Ids ? ErrorDuplicateId<Id> :
@@ -411,7 +354,7 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
   ): Daemons<Manifest, Ids | Id>
   addHealthCheck<Id extends string>(
     // prettier-ignore
-    id: 
+    id:
       "" extends Id ? never :
       ErrorDuplicateId<Id> extends Id ? never :
       Id extends Ids ? ErrorDuplicateId<Id> :
@@ -423,74 +366,141 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
     options: OptionalParam<AddHealthCheckParams<Ids, Id>>,
   ) {
     const prev = this
-    const res = (options: AddHealthCheckParams<Ids, Id> | null) => {
-      if (!options) return prev
-      return prev.addDaemonImpl(id, null, options.requires, options.ready)
+    const res = (opts: AddHealthCheckParams<Ids, Id> | null) => {
+      if (!opts) return prev
+      const entry: DaemonEntry<Manifest> = {
+        kind: 'health',
+        id,
+        ready: opts.ready,
+        requires: opts.requires as string[],
+      }
+      return prev.appendEntry(entry)
     }
     if (options instanceof Function) {
       const opts = options()
-      if (opts instanceof Promise) {
-        return opts.then(res)
-      }
+      if (opts instanceof Promise) return opts.then(res)
       return res(opts)
     }
     return res(options)
   }
 
   /**
-   * Start all registered daemons and wait until every one passes its ready
-   * check, then tear everything down.
+   * Build the daemon chain: walks the recorded entries top-down,
+   * constructs `HealthDaemon`s with correct dependency wiring, registers
+   * an `onLeaveContext` cleanup, and kicks off status updates.
    *
-   * Used for bootstrapping via a temporary daemon chain — e.g. starting a
-   * service to call its API (create admin users, register apps), then
-   * shutting it down before the real daemon chain starts.
+   * Idempotent — repeat calls return the same `Daemons` without rebuilding.
+   */
+  async build(): Promise<this> {
+    if (this.builtHealthDaemons) return this
+    validateEntries(this.entries)
+    const hds: HealthDaemon<Manifest>[] = []
+    const byId = new Map<string, HealthDaemon<Manifest>>()
+    for (const entry of this.entries) {
+      const deps = entry.requires
+        .map((r) => byId.get(r))
+        .filter((d): d is HealthDaemon<Manifest> => !!d)
+      let daemon: Daemon<Manifest> | null = null
+      let readyArg: Ready | typeof EXIT_SUCCESS
+      if (entry.kind === 'daemon') {
+        daemon =
+          entry.prebuiltDaemon ??
+          Daemon.of<Manifest>()(this.effects, entry.subcontainer, entry.exec)
+        readyArg = entry.ready
+      } else if (entry.kind === 'oneshot') {
+        daemon = Oneshot.of<Manifest>()(
+          this.effects,
+          entry.subcontainer,
+          entry.exec,
+        )
+        readyArg = EXIT_SUCCESS
+      } else {
+        readyArg = entry.ready
+      }
+      const hd = new HealthDaemon<Manifest>(
+        daemon,
+        deps,
+        entry.id,
+        readyArg,
+        this.effects,
+      )
+      hds.push(hd)
+      byId.set(entry.id, hd)
+    }
+    this.builtHealthDaemons = hds
+    this.effects.onLeaveContext(() => {
+      this.term().catch((e) => logErrorOnce(asError(e)))
+    })
+    for (const hd of hds) {
+      await hd.updateStatus()
+    }
+    return this
+  }
+
+  /** Health daemons after {@link build}, or empty before it runs. */
+  get healthDaemons(): ReadonlyArray<HealthDaemon<Manifest>> {
+    return this.builtHealthDaemons ?? []
+  }
+
+  /**
+   * Start all registered daemons and wait until every one passes its
+   * ready check, then tear everything down. Used for bootstrapping via a
+   * temporary daemon chain.
    *
-   * @param timeout - Maximum time (ms) to wait for all daemons to become ready, or `null` for no limit
-   * @throws If the timeout is reached before all daemons are ready
+   * @param timeout - Maximum time (ms) to wait for all daemons to become ready
    */
   async runUntilSuccess(timeout: number | null) {
     let resolve = (_: void) => {}
     const res = new Promise<void>((res, rej) => {
       resolve = res
-      if (timeout)
+      if (timeout) {
         setTimeout(() => {
-          const notReady = this.healthDaemons
+          const notReady = (this.builtHealthDaemons ?? [])
             .filter((d) => !d.isReady)
             .map((d) => d.id)
           rej(new Error(`Timed out waiting for ${notReady}`))
         }, timeout)
+      }
     })
-    const daemon = Oneshot.of()(this.effects, null, {
+    const sentinelDaemon = Oneshot.of<Manifest>()(this.effects, null, {
       fn: async () => {
         resolve()
         return null
       },
     })
-    const healthDaemon = new HealthDaemon<Manifest>(
-      daemon,
-      [...this.healthDaemons],
-      '__RUN_UNTIL_SUCCESS',
-      'EXIT_SUCCESS',
-      this.effects,
+    const sentinelEntry: DaemonEntry<Manifest> = {
+      kind: 'oneshot',
+      id: '__RUN_UNTIL_SUCCESS',
+      subcontainer: null,
+      exec: { fn: async () => null } as unknown as DaemonCommandType<
+        Manifest,
+        SubContainer<Manifest> | null
+      >,
+      requires: this.entries.map((e) => e.id),
+    }
+    // Bypass build() to inject the pre-built sentinel
+    const composed = new Daemons<Manifest, Ids>(this.effects, this.ids, [
+      ...this.entries,
+      sentinelEntry,
+    ])
+    const built = await composed.build()
+    // Replace the sentinel daemon with one whose fn signals completion
+    const sentinelHd = built.builtHealthDaemons!.find(
+      (h) => h.id === '__RUN_UNTIL_SUCCESS',
     )
-    const daemons = await new Daemons<Manifest, Ids>(this.effects, this.ids, [
-      ...this.healthDaemons,
-      healthDaemon,
-    ]).build()
+    if (sentinelHd) (sentinelHd as any).daemon = sentinelDaemon
     try {
       await res
     } finally {
-      await daemons.term()
+      await built.term()
     }
     return null
   }
 
   /**
-   * Gracefully terminate all daemons in reverse dependency order.
-   *
-   * Daemons with no remaining dependents are shut down first, proceeding
-   * until all daemons have been terminated. Falls back to a bulk shutdown
-   * if a dependency cycle is detected.
+   * Gracefully terminate all daemons in reverse dependency order and
+   * destroy every unique SubContainer that was registered with this
+   * `Daemons`. Idempotent.
    */
   async term() {
     if (!this.termPromise) {
@@ -500,59 +510,385 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
   }
 
   private async _term() {
-    const remaining = new Set(this.healthDaemons)
-
-    while (remaining.size > 0) {
-      // Find daemons with no remaining dependents
-      const canShutdown = [...remaining].filter(
-        (daemon) =>
-          ![...remaining].some((other) =>
-            other.dependencies.some((dep) => dep.id === daemon.id),
-          ),
-      )
-
-      if (canShutdown.length === 0) {
-        // Dependency cycle that should not happen, just shutdown remaining daemons
-        console.warn(
-          'Dependency cycle detected, shutting down remaining daemons',
+    const hds = this.builtHealthDaemons
+    if (hds) {
+      const remaining = new Set(hds)
+      while (remaining.size > 0) {
+        const canShutdown = [...remaining].filter(
+          (hd) =>
+            ![...remaining].some((other) =>
+              other.dependencies.some((dep) => dep.id === hd.id),
+            ),
         )
-        canShutdown.push(...[...remaining].reverse())
+        if (canShutdown.length === 0) {
+          console.warn(
+            'Dependency cycle detected, shutting down remaining daemons',
+          )
+          canShutdown.push(...[...remaining].reverse())
+        }
+        canShutdown.forEach((hd) => remaining.delete(hd))
+        await Promise.allSettled(
+          canShutdown.map(async (hd) => {
+            try {
+              await hd.term()
+            } catch (e) {
+              console.error(e)
+            }
+          }),
+        )
       }
+    }
+    // Destroy every unique subcontainer recorded across entries.
+    // destroy() is idempotent and defers until the last hold is released.
+    const subs = new Set<SubContainer<Manifest>>()
+    for (const entry of this.entries) {
+      if ('subcontainer' in entry && entry.subcontainer) {
+        subs.add(entry.subcontainer)
+      }
+    }
+    await Promise.allSettled(
+      [...subs].map((s) =>
+        s.destroy().catch((e) => logErrorOnce(asError(e))),
+      ),
+    )
+  }
+}
 
-      // remove from remaining set
-      canShutdown.forEach((daemon) => remaining.delete(daemon))
+// ----------------------------------------------------------------------------
+// Daemons.dynamic — reconciler + configHash
+// ----------------------------------------------------------------------------
 
-      // Shutdown daemons with no remaining dependents concurrently
-      await Promise.allSettled(
-        canShutdown.map(async (daemon) => {
-          try {
-            console.debug(`Terminating daemon ${daemon.id}`)
-            const destroySubcontainer = daemon.daemon
-              ? ![...remaining].some((d) =>
-                  d.daemon?.sharesSubcontainerWith(daemon.daemon!),
-                )
-              : false
-            await daemon.term({ destroySubcontainer })
-          } catch (e) {
-            console.error(e)
+/** The user-supplied builder consumed by {@link Daemons.dynamic}. */
+export type DaemonsBuilder<M extends T.SDKManifest> = (opts: {
+  effects: T.Effects
+}) => Promise<Daemons<M, any>> | Daemons<M, any>
+
+/** Validate a recorded entry list: ids unique, requires reference earlier ids. */
+function validateEntries<M extends T.SDKManifest>(
+  entries: ReadonlyArray<DaemonEntry<M>>,
+): void {
+  const seen = new Set<string>()
+  for (const entry of entries) {
+    if (!entry.id) throw new Error(`Daemons: entry has empty id`)
+    if (seen.has(entry.id)) {
+      throw new Error(`Daemons: duplicate id '${entry.id}'`)
+    }
+    seen.add(entry.id)
+    for (const req of entry.requires) {
+      if (!seen.has(req)) {
+        throw new Error(
+          `Daemons: entry '${entry.id}' requires '${req}', which must be declared earlier`,
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Stable JSON hash over the structural args of a recorded entry.
+ *
+ * Two entries with the same id and the same `configHash` are considered
+ * "the same daemon" by `Daemons.dynamic`'s reconciler — it leaves them
+ * running across re-runs. Any difference triggers a restart.
+ *
+ * Hashed fields: kind, id, sorted requires, subcontainer descriptor
+ * (`imageId`, `sharedRun`, `name`, `mounts.build()`), exec (`command`,
+ * `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`), and ready's
+ * structural parts (`display`, `gracePeriod`).
+ *
+ * NOT hashed: `ready.fn`, `ready.trigger`, function-form `exec.fn`, and
+ * any pre-built `daemon` instance.
+ */
+export function configHash<M extends T.SDKManifest>(
+  entry: DaemonEntry<M>,
+): string {
+  if (entry.kind === 'health') {
+    return stableStringify({
+      kind: 'health',
+      id: entry.id,
+      requires: [...entry.requires].sort(),
+      display: entry.ready.display,
+      gracePeriod: entry.ready.gracePeriod ?? null,
+    })
+  }
+  const sub = entry.subcontainer
+  const subHash =
+    sub instanceof SubContainerLazy
+      ? {
+          imageId: sub.imageId,
+          sharedRun: sub.sharedRun,
+          name: sub.name,
+          mounts: sub.mounts?.build() ?? [],
+        }
+      : sub === null
+        ? null
+        : { __unhashable: true }
+  return stableStringify({
+    kind: entry.kind,
+    id: entry.id,
+    requires: [...entry.requires].sort(),
+    sub: subHash,
+    exec: normalizeExec(entry.exec),
+    ready:
+      entry.kind === 'daemon'
+        ? {
+            display: entry.ready.display,
+            gracePeriod: entry.ready.gracePeriod ?? null,
           }
-        }),
-      )
+        : null,
+  })
+}
+
+function normalizeExec(exec: unknown): unknown {
+  if (!exec || typeof exec !== 'object') return null
+  if ('fn' in (exec as object)) return { __fn: true }
+  const e = exec as ExecCommandOptions
+  return {
+    command: normalizeCommand(e.command),
+    env: e.env ?? null,
+    cwd: e.cwd ?? null,
+    user: e.user ?? null,
+    runAsInit: e.runAsInit ?? false,
+    sigtermTimeout: e.sigtermTimeout ?? null,
+  }
+}
+
+function normalizeCommand(c: T.CommandType): unknown {
+  if (typeof c === 'string') return { kind: 'string', value: c }
+  if (Array.isArray(c)) return { kind: 'argv', value: [...c] }
+  if (T.isUseEntrypoint(c)) {
+    return { kind: 'entrypoint', value: c.overridCmd ?? null }
+  }
+  return null
+}
+
+function stableStringify(v: unknown): string {
+  return JSON.stringify(canonicalize(v))
+}
+
+function canonicalize(v: unknown): unknown {
+  if (v === undefined || v === null) return null
+  if (Array.isArray(v)) return v.map(canonicalize)
+  if (typeof v === 'object') {
+    const keys = Object.keys(v as object).sort()
+    const out: Record<string, unknown> = {}
+    for (const k of keys) out[k] = canonicalize((v as Record<string, unknown>)[k])
+    return out
+  }
+  if (typeof v === 'function') return null
+  return v
+}
+
+type RunningEntry<M extends T.SDKManifest> = {
+  healthDaemon: HealthDaemon<M>
+  subcontainer: SubContainer<M> | null
+  configHash: string
+  requires: ReadonlyArray<string>
+}
+
+/**
+ * Reconciles a {@link Daemons} (in record-mode) against a running set on
+ * every `effects.constRetry` trigger.
+ *
+ * Construction is internal — get one by calling {@link Daemons.dynamic}.
+ * Implements {@link T.DaemonBuildable}: `build()` performs the first
+ * reconcile and wires up the re-run trigger; `term()` shuts everything
+ * down in dependent-first order.
+ */
+export class DaemonsReconciler<M extends T.SDKManifest>
+  implements T.DaemonBuildable
+{
+  private running = new Map<string, RunningEntry<M>>()
+  private inProgress = false
+  private pendingRerun = false
+  private isTerminating = false
+  private termPromise: Promise<void> | null = null
+
+  constructor(
+    private readonly rootEffects: T.Effects,
+    private readonly fn: DaemonsBuilder<M>,
+  ) {}
+
+  async build(): Promise<{ term(): Promise<void> }> {
+    await this.runReconcile()
+    this.rootEffects.onLeaveContext(() => {
+      this.term().catch((e) => logErrorOnce(asError(e)))
+    })
+    return { term: () => this.term() }
+  }
+
+  /** Trigger an out-of-band reconcile. Internal — exposed for testing. */
+  scheduleRerun(): void {
+    if (this.isTerminating) return
+    if (this.inProgress) {
+      this.pendingRerun = true
+      return
+    }
+    this.runReconcile().catch((e) => logErrorOnce(asError(e)))
+  }
+
+  private async runReconcile(): Promise<void> {
+    if (this.isTerminating) return
+    this.inProgress = true
+    try {
+      const fnEffects = this.rootEffects.child(`dyn-daemons-fn`)
+      fnEffects.constRetry = once(() => this.scheduleRerun())
+      const recorded = await this.fn({ effects: fnEffects })
+      validateEntries(recorded.entries)
+      await this.reconcile(recorded.entries)
+    } catch (e) {
+      logErrorOnce(asError(e))
+    } finally {
+      this.inProgress = false
+      if (this.pendingRerun && !this.isTerminating) {
+        this.pendingRerun = false
+        this.runReconcile().catch((e) => logErrorOnce(asError(e)))
+      }
     }
   }
 
-  /**
-   * Start all registered daemons and their health checks.
-   * @returns This `Daemons` instance, now running
-   */
-  async build() {
-    this.effects.onLeaveContext(() => {
-      this.term().catch((e) => console.error(e))
-    })
-    for (const daemon of this.healthDaemons) {
-      daemon.daemon?.markManaged()
-      await daemon.updateStatus()
+  private async reconcile(
+    entries: ReadonlyArray<DaemonEntry<M>>,
+  ): Promise<void> {
+    // Eager subcontainers can't be diffed across reconciles (no stable hash).
+    for (const e of entries) {
+      if (
+        'subcontainer' in e &&
+        e.subcontainer &&
+        e.subcontainer instanceof SubContainerEager
+      ) {
+        throw new Error(
+          `Daemons.dynamic: entry '${e.id}' uses an eager SubContainer; ` +
+            `use sdk.SubContainer.of(...) (lazy) for diff-reuse under Daemons.dynamic.`,
+        )
+      }
     }
-    return this
+
+    const desiredById = new Map<string, DaemonEntry<M>>(
+      entries.map((e) => [e.id, e]),
+    )
+    const desiredHashes = new Map<string, string>(
+      entries.map((e) => [e.id, configHash(e)]),
+    )
+
+    const toStop = new Set<string>()
+    for (const [id, current] of this.running) {
+      const desired = desiredById.get(id)
+      if (!desired) toStop.add(id)
+      else if (desiredHashes.get(id) !== current.configHash) toStop.add(id)
+    }
+
+    // Transitively mark dependents of stopping entries
+    let changed = true
+    while (changed) {
+      changed = false
+      for (const [id, current] of this.running) {
+        if (toStop.has(id)) continue
+        if (current.requires.some((r) => toStop.has(r))) {
+          toStop.add(id)
+          changed = true
+        }
+      }
+    }
+
+    await this.stopEntries(toStop)
+
+    // Start desired-but-not-running. Entries are in topo order by construction.
+    for (const entry of entries) {
+      if (this.running.has(entry.id)) continue
+      try {
+        await this.startEntry(entry, desiredHashes.get(entry.id)!)
+      } catch (e) {
+        logErrorOnce(asError(e))
+      }
+    }
+  }
+
+  private async stopEntries(ids: Set<string>): Promise<void> {
+    if (ids.size === 0) return
+    const order: string[] = []
+    const visited = new Set<string>()
+    const visit = (id: string) => {
+      if (visited.has(id) || !ids.has(id)) return
+      visited.add(id)
+      for (const [otherId, other] of this.running) {
+        if (other.requires.includes(id)) visit(otherId)
+      }
+      order.push(id)
+    }
+    for (const id of ids) visit(id)
+    for (const id of order) {
+      const cur = this.running.get(id)
+      if (!cur) continue
+      try {
+        await cur.healthDaemon.term()
+      } catch (e) {
+        logErrorOnce(asError(e))
+      }
+      if (cur.subcontainer) {
+        // destroy() is idempotent and defers until the last hold release
+        // — safe even if other still-running daemons share this subcontainer.
+        try {
+          await cur.subcontainer.destroy()
+        } catch (e) {
+          logErrorOnce(asError(e))
+        }
+      }
+      this.running.delete(id)
+    }
+  }
+
+  private async startEntry(
+    entry: DaemonEntry<M>,
+    hash: string,
+  ): Promise<void> {
+    const id = entry.id
+    let daemon: Daemon<M> | null = null
+    let readyArg: Ready | typeof EXIT_SUCCESS
+    let subcontainer: SubContainer<M> | null = null
+
+    if (entry.kind === 'daemon') {
+      subcontainer = entry.subcontainer
+      daemon =
+        entry.prebuiltDaemon ??
+        Daemon.of<M>()(this.rootEffects, subcontainer, entry.exec)
+      readyArg = entry.ready
+    } else if (entry.kind === 'oneshot') {
+      subcontainer = entry.subcontainer
+      daemon = Oneshot.of<M>()(this.rootEffects, subcontainer, entry.exec)
+      readyArg = EXIT_SUCCESS
+    } else {
+      readyArg = entry.ready
+    }
+
+    const dependencies = entry.requires
+      .map((reqId) => this.running.get(reqId)?.healthDaemon)
+      .filter((d): d is HealthDaemon<M> => !!d)
+
+    const healthDaemon = new HealthDaemon<M>(
+      daemon,
+      dependencies,
+      id,
+      readyArg,
+      this.rootEffects,
+    )
+
+    this.running.set(id, {
+      healthDaemon,
+      subcontainer,
+      configHash: hash,
+      requires: entry.requires,
+    })
+
+    await healthDaemon.updateStatus()
+  }
+
+  private async term(): Promise<void> {
+    if (this.termPromise) return this.termPromise
+    this.isTerminating = true
+    this.termPromise = (async () => {
+      await this.stopEntries(new Set(this.running.keys()))
+    })()
+    return this.termPromise
   }
 }

--- a/sdk/package/lib/mainFn/Daemons.ts
+++ b/sdk/package/lib/mainFn/Daemons.ts
@@ -227,6 +227,9 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    * `Daemons.dynamic`. Eager handles created inside `fn` are wasted on
    * re-runs that diff to "leave alone"; the reconciler throws at hash time
    * if it sees one.
+   *
+   * @param fn Async builder invoked on startup and on every `constRetry`. Must return a `Daemons` in record-mode (not pre-`build()`-ed)
+   * @returns A `main` export compatible with `T.ExpectedExports.main`
    */
   static dynamic<Manifest extends T.SDKManifest>(
     fn: DaemonsBuilder<Manifest>,
@@ -251,6 +254,9 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    * `requires`. Pass a static options object, a sync/async factory that
    * returns options (or `null` to conditionally skip the daemon), or an
    * object with a pre-built `daemon` instance.
+   *
+   * @param id Unique string identifier for this daemon
+   * @param options Daemon configuration, or a factory returning it (return `null` to skip)
    */
   addDaemon<Id extends string, C extends SubContainer<Manifest> | null>(
     // prettier-ignore
@@ -299,7 +305,15 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
     return res(options)
   }
 
-  /** Register a one-shot command that runs to completion before dependents start. */
+  /**
+   * Register a one-shot command that runs to completion before dependents
+   * start. Common uses: `chown` for file ownership, database migrations,
+   * config generation, wallet unlocking. The oneshot is considered "ready"
+   * as soon as the command exits successfully (exit code 0).
+   *
+   * @param id Unique string identifier for this oneshot
+   * @param options Oneshot configuration, or a factory returning it (return `null` to skip)
+   */
   addOneshot<Id extends string, C extends SubContainer<Manifest> | null>(
     // prettier-ignore
     id:
@@ -342,7 +356,17 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
     return res(options)
   }
 
-  /** Register a standalone health check with no associated process. */
+  /**
+   * Register a standalone health check with no associated process.
+   *
+   * Use this for ongoing conditions that don't map to a single daemon,
+   * such as blockchain sync progress or network reachability. Dependent
+   * services can reference standalone health check IDs in their
+   * dependency config.
+   *
+   * @param id Unique string identifier for this health check
+   * @param options Health check configuration, or a factory returning it (return `null` to skip)
+   */
   addHealthCheck<Id extends string>(
     // prettier-ignore
     id:
@@ -445,9 +469,12 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
   /**
    * Start all registered daemons and wait until every one passes its
    * ready check, then tear everything down. Used for bootstrapping via a
-   * temporary daemon chain.
+   * temporary daemon chain — e.g. starting a service to call its API
+   * (create admin users, register apps), then shutting it down before
+   * the real daemon chain starts.
    *
-   * @param timeout - Maximum time (ms) to wait for all daemons to become ready
+   * @param timeout Maximum time (ms) to wait for all daemons to become ready, or `null` for no limit
+   * @throws If the timeout is reached before all daemons are ready
    */
   async runUntilSuccess(timeout: number | null) {
     let resolve = (_: void) => {}
@@ -598,6 +625,9 @@ function validateEntries<M extends T.SDKManifest>(
  *
  * NOT hashed: `ready.fn`, `ready.trigger`, function-form `exec.fn`, and
  * any pre-built `daemon` instance.
+ *
+ * @param entry A recorded {@link Daemons} entry (`Daemons.entries[i]`)
+ * @returns A canonical JSON string suitable for equality comparison
  */
 export function configHash<M extends T.SDKManifest>(
   entry: DaemonEntry<M>,

--- a/sdk/package/lib/mainFn/Daemons.ts
+++ b/sdk/package/lib/mainFn/Daemons.ts
@@ -414,49 +414,70 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    * an `onLeaveContext` cleanup, and kicks off status updates.
    *
    * Idempotent — repeat calls return the same `Daemons` without rebuilding.
+   *
+   * **No-leak invariant**: an `onLeaveContext` shutdown handler is armed
+   * *before* any daemon is constructed, and every partial construction is
+   * tracked in `builtHealthDaemons` so {@link term} can clean it up.
+   * Anything that throws during construction or `updateStatus` triggers
+   * an immediate `term()` (which is also idempotent) before the failure
+   * propagates.
    */
   async build(): Promise<this> {
     if (this.builtHealthDaemons) return this
     validateEntries(this.entries)
-    const hds: HealthDaemon<Manifest>[] = []
-    const byId = new Map<string, HealthDaemon<Manifest>>()
-    for (const entry of this.entries) {
-      const deps = entry.requires
-        .map((r) => byId.get(r))
-        .filter((d): d is HealthDaemon<Manifest> => !!d)
-      let daemon: Daemon<Manifest> | null = null
-      let readyArg: Ready | typeof EXIT_SUCCESS
-      if (entry.kind === 'daemon') {
-        daemon =
-          entry.prebuiltDaemon ??
-          Daemon.of<Manifest>()(this.effects, entry.subcontainer, entry.exec)
-        readyArg = entry.ready
-      } else if (entry.kind === 'oneshot') {
-        daemon = Oneshot.of<Manifest>()(
-          this.effects,
-          entry.subcontainer,
-          entry.exec,
-        )
-        readyArg = EXIT_SUCCESS
-      } else {
-        readyArg = entry.ready
-      }
-      const hd = new HealthDaemon<Manifest>(
-        daemon,
-        deps,
-        entry.id,
-        readyArg,
-        this.effects,
-      )
-      hds.push(hd)
-      byId.set(entry.id, hd)
-    }
-    this.builtHealthDaemons = hds
+    // Arm cleanup BEFORE constructing anything. If anything throws below
+    // — or context leaves while we're awaiting updateStatus — term() runs
+    // over whatever made it into builtHealthDaemons.
+    this.builtHealthDaemons = []
     this.effects.onLeaveContext(() => {
       this.term().catch((e) => logErrorOnce(asError(e)))
     })
-    for (const hd of hds) {
-      await hd.updateStatus()
+    const byId = new Map<string, HealthDaemon<Manifest>>()
+    try {
+      for (const entry of this.entries) {
+        const deps = entry.requires
+          .map((r) => byId.get(r))
+          .filter((d): d is HealthDaemon<Manifest> => !!d)
+        let daemon: Daemon<Manifest> | null = null
+        let readyArg: Ready | typeof EXIT_SUCCESS
+        if (entry.kind === 'daemon') {
+          daemon =
+            entry.prebuiltDaemon ??
+            Daemon.of<Manifest>()(this.effects, entry.subcontainer, entry.exec)
+          readyArg = entry.ready
+        } else if (entry.kind === 'oneshot') {
+          daemon = Oneshot.of<Manifest>()(
+            this.effects,
+            entry.subcontainer,
+            entry.exec,
+          )
+          readyArg = EXIT_SUCCESS
+        } else {
+          readyArg = entry.ready
+        }
+        // Suppress the Daemon's own onLeaveContext self-term — Daemons.term()
+        // handles dependency-ordered shutdown for the whole chain.
+        daemon?.markManaged()
+        const hd = new HealthDaemon<Manifest>(
+          daemon,
+          deps,
+          entry.id,
+          readyArg,
+          this.effects,
+        )
+        // Push BEFORE awaiting anything — so a context-leave mid-build
+        // sees this entry in builtHealthDaemons.
+        this.builtHealthDaemons.push(hd)
+        byId.set(entry.id, hd)
+      }
+      for (const hd of this.builtHealthDaemons) {
+        await hd.updateStatus()
+      }
+    } catch (e) {
+      // Best-effort tear-down of whatever we managed to construct before
+      // re-throwing, so the failure path leaves no leaked daemons.
+      await this.term().catch((te) => logErrorOnce(asError(te)))
+      throw e
     }
     return this
   }
@@ -489,37 +510,31 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
         }, timeout)
       }
     })
+    // Build the user's chain through the normal path so onLeaveContext +
+    // partial-construction cleanup are in place.
+    await this.build()
     const sentinelDaemon = Oneshot.of<Manifest>()(this.effects, null, {
       fn: async () => {
         resolve()
         return null
       },
     })
-    const sentinelEntry: DaemonEntry<Manifest> = {
-      kind: 'oneshot',
-      id: '__RUN_UNTIL_SUCCESS',
-      subcontainer: null,
-      exec: { fn: async () => null } as unknown as DaemonCommandType<
-        Manifest,
-        SubContainer<Manifest> | null
-      >,
-      requires: this.entries.map((e) => e.id),
-    }
-    // Bypass build() to inject the pre-built sentinel
-    const composed = new Daemons<Manifest, Ids>(this.effects, this.ids, [
-      ...this.entries,
-      sentinelEntry,
-    ])
-    const built = await composed.build()
-    // Replace the sentinel daemon with one whose fn signals completion
-    const sentinelHd = built.builtHealthDaemons!.find(
-      (h) => h.id === '__RUN_UNTIL_SUCCESS',
+    sentinelDaemon.markManaged()
+    const sentinelHd = new HealthDaemon<Manifest>(
+      sentinelDaemon,
+      [...(this.builtHealthDaemons ?? [])],
+      '__RUN_UNTIL_SUCCESS',
+      EXIT_SUCCESS,
+      this.effects,
     )
-    if (sentinelHd) (sentinelHd as any).daemon = sentinelDaemon
+    // Inject the sentinel into the live HealthDaemon list so term() walks
+    // it during dependency-ordered shutdown along with the user's daemons.
+    this.builtHealthDaemons!.push(sentinelHd)
     try {
+      await sentinelHd.updateStatus()
       await res
     } finally {
-      await built.term()
+      await this.term()
     }
     return null
   }
@@ -729,7 +744,7 @@ export class DaemonsReconciler<M extends T.SDKManifest>
   implements T.DaemonBuildable
 {
   private running = new Map<string, RunningEntry<M>>()
-  private inProgress = false
+  private inFlight: Promise<void> | null = null
   private pendingRerun = false
   private isTerminating = false
   private termPromise: Promise<void> | null = null
@@ -740,58 +755,91 @@ export class DaemonsReconciler<M extends T.SDKManifest>
   ) {}
 
   async build(): Promise<{ term(): Promise<void> }> {
-    await this.runReconcile()
+    // Arm cleanup BEFORE the first reconcile. The user's `fn` is awaited
+    // inside runReconcile; if context leaves during that await (or during
+    // any partial startEntry), term() walks whatever made it into the
+    // `running` map and tears it down.
     this.rootEffects.onLeaveContext(() => {
       this.term().catch((e) => logErrorOnce(asError(e)))
     })
+    await this.runReconcile()
     return { term: () => this.term() }
   }
 
   /** Trigger an out-of-band reconcile. Internal — exposed for testing. */
   scheduleRerun(): void {
     if (this.isTerminating) return
-    if (this.inProgress) {
+    if (this.inFlight) {
       this.pendingRerun = true
       return
     }
     this.runReconcile().catch((e) => logErrorOnce(asError(e)))
   }
 
-  private async runReconcile(): Promise<void> {
-    if (this.isTerminating) return
-    this.inProgress = true
-    try {
-      const fnEffects = this.rootEffects.child(`dyn-daemons-fn`)
-      fnEffects.constRetry = once(() => this.scheduleRerun())
-      const recorded = await this.fn({ effects: fnEffects })
-      validateEntries(recorded.entries)
-      await this.reconcile(recorded.entries)
-    } catch (e) {
-      logErrorOnce(asError(e))
-    } finally {
-      this.inProgress = false
+  private runReconcile(): Promise<void> {
+    if (this.isTerminating) return Promise.resolve()
+    // Tracking the in-flight promise (rather than a boolean) lets term()
+    // await its completion before mutating `running` — eliminating the
+    // race between teardown and a concurrent reconcile.
+    const p = (async () => {
+      try {
+        const fnEffects = this.rootEffects.child(`dyn-daemons-fn`)
+        fnEffects.constRetry = once(() => this.scheduleRerun())
+        const recorded = await this.fn({ effects: fnEffects })
+        validateEntries(recorded.entries)
+        await this.reconcile(recorded.entries)
+      } catch (e) {
+        logErrorOnce(asError(e))
+      }
+    })()
+    this.inFlight = p
+    p.finally(() => {
+      if (this.inFlight === p) this.inFlight = null
       if (this.pendingRerun && !this.isTerminating) {
         this.pendingRerun = false
         this.runReconcile().catch((e) => logErrorOnce(asError(e)))
       }
-    }
+    })
+    return p
   }
 
   private async reconcile(
     entries: ReadonlyArray<DaemonEntry<M>>,
   ): Promise<void> {
     // Eager subcontainers can't be diffed across reconciles (no stable hash).
-    for (const e of entries) {
-      if (
+    // If we find any, the user's `fn` has already paid for `createFs` on
+    // each one (eager construction is awaited inside fn) — destroy every
+    // subc the user just handed us before throwing, so the failure leaves
+    // no leaked subcontainers behind.
+    const hasEager = entries.some(
+      (e) =>
         'subcontainer' in e &&
         e.subcontainer &&
-        e.subcontainer instanceof SubContainerEager
-      ) {
-        throw new Error(
-          `Daemons.dynamic: entry '${e.id}' uses an eager SubContainer; ` +
-            `use sdk.SubContainer.of(...) (lazy) for diff-reuse under Daemons.dynamic.`,
-        )
-      }
+        e.subcontainer instanceof SubContainerEager,
+    )
+    if (hasEager) {
+      await Promise.allSettled(
+        entries
+          .filter(
+            (e): e is Extract<DaemonEntry<M>, { subcontainer: any }> =>
+              'subcontainer' in e && !!e.subcontainer,
+          )
+          .map((e) =>
+            e.subcontainer!.destroy().catch((err) =>
+              logErrorOnce(asError(err)),
+            ),
+          ),
+      )
+      const offender = entries.find(
+        (e) =>
+          'subcontainer' in e &&
+          e.subcontainer &&
+          e.subcontainer instanceof SubContainerEager,
+      )!
+      throw new Error(
+        `Daemons.dynamic: entry '${offender.id}' uses an eager SubContainer; ` +
+          `use sdk.SubContainer.of(...) (lazy) for diff-reuse under Daemons.dynamic.`,
+      )
     }
 
     const desiredById = new Map<string, DaemonEntry<M>>(
@@ -890,6 +938,9 @@ export class DaemonsReconciler<M extends T.SDKManifest>
     } else {
       readyArg = entry.ready
     }
+    // Suppress the Daemon's own onLeaveContext self-term — the reconciler
+    // handles dependency-ordered shutdown via stopEntries / term().
+    daemon?.markManaged()
 
     const dependencies = entry.requires
       .map((reqId) => this.running.get(reqId)?.healthDaemon)
@@ -917,6 +968,13 @@ export class DaemonsReconciler<M extends T.SDKManifest>
     if (this.termPromise) return this.termPromise
     this.isTerminating = true
     this.termPromise = (async () => {
+      // Drain any in-flight reconcile before stopping. The reconcile
+      // catches its own errors, so awaiting it never throws; the await
+      // just synchronises so we don't race against startEntry/stopEntries
+      // mutations to `running`.
+      if (this.inFlight) {
+        await this.inFlight.catch(() => {})
+      }
       await this.stopEntries(new Set(this.running.keys()))
     })()
     return this.termPromise

--- a/sdk/package/lib/mainFn/HealthDaemon.ts
+++ b/sdk/package/lib/mainFn/HealthDaemon.ts
@@ -43,7 +43,6 @@ export class HealthDaemon<Manifest extends SDKManifest> {
   async term(termOptions?: {
     signal?: NodeJS.Signals | undefined
     timeout?: number | undefined
-    destroySubcontainer?: boolean
   }) {
     this.healthWatchers = []
     this.running = false

--- a/sdk/package/lib/mainFn/Oneshot.ts
+++ b/sdk/package/lib/mainFn/Oneshot.ts
@@ -1,15 +1,13 @@
 import * as T from '../../../base/lib/types'
-import { SubContainer, SubContainerOwned } from '../util/SubContainer'
+import { SubContainer } from '../util/SubContainer'
 import { CommandController } from './CommandController'
 import { Daemon } from './Daemon'
 import { DaemonCommandType } from './Daemons'
 
 /**
- * This is a wrapper around CommandController that has a state of off, where the command shouldn't be running
- * and the others state of running, where it will keep a living running command
- * unlike Daemon, does not restart on success
+ * A one-shot command: same machinery as a {@link Daemon} but exits after a
+ * successful run instead of restarting.
  */
-
 export class Oneshot<
   Manifest extends T.SDKManifest,
   C extends SubContainer<Manifest> | null = SubContainer<Manifest> | null,
@@ -20,14 +18,8 @@ export class Oneshot<
       subcontainer: C,
       exec: DaemonCommandType<Manifest, C>,
     ) => {
-      let subc: SubContainer<Manifest> | null = subcontainer
-      if (subcontainer && subcontainer.isOwned()) subc = subcontainer.rc()
       const startCommand = () =>
-        CommandController.of<Manifest, C>()(
-          effects,
-          (subc?.rc() ?? null) as C,
-          exec,
-        )
+        CommandController.of<Manifest, C>()(effects, subcontainer, exec)
       return new Oneshot<Manifest, C>(subcontainer, startCommand, true)
     }
   }

--- a/sdk/package/lib/mainFn/Oneshot.ts
+++ b/sdk/package/lib/mainFn/Oneshot.ts
@@ -5,9 +5,11 @@ import { Daemon } from './Daemon'
 import { DaemonCommandType } from './Daemons'
 
 /**
- * A one-shot command: same machinery as a {@link Daemon} but exits after a
- * successful run instead of restarting.
+ * This is a wrapper around CommandController that has a state of off, where the command shouldn't be running
+ * and the others state of running, where it will keep a living running command
+ * unlike Daemon, does not restart on success
  */
+
 export class Oneshot<
   Manifest extends T.SDKManifest,
   C extends SubContainer<Manifest> | null = SubContainer<Manifest> | null,

--- a/sdk/package/lib/test/Daemons.test.ts
+++ b/sdk/package/lib/test/Daemons.test.ts
@@ -1,0 +1,354 @@
+import { Daemons, configHash } from '../mainFn/Daemons'
+import { Mounts } from '../mainFn/Mounts'
+import { SubContainer } from '../util/SubContainer'
+import * as T from '../../../base/lib/types'
+
+type Manifest = {
+  id: 'test'
+  volumes: ['main']
+  images: {
+    reg: { source: { dockerTag: 'x' } }
+    other: { source: { dockerTag: 'y' } }
+  }
+} & T.SDKManifest
+
+/** Minimal mock effects sufficient to construct a lazy SubContainer */
+const fakeEffects = (): T.Effects =>
+  ({
+    eventId: null,
+    child: () => fakeEffects(),
+    isInContext: true,
+    onLeaveContext: () => {},
+    subcontainer: {
+      // never invoked in these tests — laziness means createFs is deferred
+      createFs: async () => ['', ''] as any,
+      destroyFs: async () => null,
+    },
+  }) as any
+
+const baseReady = {
+  display: 'Reg',
+  fn: () => ({ result: 'success' as const, message: null }),
+}
+
+const lazy = (
+  e: T.Effects,
+  imageId: 'reg' | 'other' = 'reg',
+  sharedRun = true,
+  mounts: Mounts<Manifest> | null = null,
+  name = 'reg-sub',
+) =>
+  SubContainer.of<Manifest>(
+    e,
+    { imageId, sharedRun },
+    mounts as any,
+    name,
+  )
+
+describe('Daemons recorder', () => {
+  it('records entries in declaration order without constructing HealthDaemons', () => {
+    const e = fakeEffects()
+    const daemons = Daemons.of<Manifest>({ effects: e })
+      .addDaemon('a', {
+        subcontainer: lazy(e),
+        exec: { command: ['a'] },
+        ready: baseReady,
+        requires: [],
+      })
+      .addDaemon('b', {
+        subcontainer: lazy(e),
+        exec: { command: ['b'] },
+        ready: baseReady,
+        requires: ['a'],
+      })
+
+    expect(daemons.entries.map((x) => x.id)).toEqual(['a', 'b'])
+    expect(daemons.entries[0].kind).toBe('daemon')
+    expect(daemons.entries[1].requires).toEqual(['a'])
+    // Nothing built yet
+    expect(daemons.healthDaemons.length).toBe(0)
+  })
+
+  it('returns a fresh Daemons on each chain call (immutable)', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['a'] },
+      ready: baseReady,
+      requires: [],
+    })
+    const b = a.addDaemon('b', {
+      subcontainer: lazy(e),
+      exec: { command: ['b'] },
+      ready: baseReady,
+      requires: ['a'],
+    })
+    expect(a.entries.length).toBe(1)
+    expect(b.entries.length).toBe(2)
+  })
+
+  it('supports oneshots and standalone health checks', () => {
+    const e = fakeEffects()
+    const daemons = Daemons.of<Manifest>({ effects: e })
+      .addOneshot('migrate', {
+        subcontainer: lazy(e),
+        exec: { command: ['migrate'] },
+        requires: [],
+      })
+      .addHealthCheck('sync', {
+        ready: baseReady,
+        requires: ['migrate'],
+      })
+    expect(daemons.entries.map((x) => x.kind)).toEqual(['oneshot', 'health'])
+  })
+})
+
+describe('configHash', () => {
+  it('is stable when nothing structural changes', () => {
+    const e = fakeEffects()
+    const make = () =>
+      Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+        subcontainer: lazy(e),
+        exec: { command: ['cmd'] },
+        ready: {
+          display: 'Reg',
+          // different closures across calls; should not affect hash
+          fn: () => ({ result: 'success' as const, message: null }),
+        },
+        requires: [],
+      }).entries[0]
+    expect(configHash(make())).toEqual(configHash(make()))
+  })
+
+  it('changes when imageId changes', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e, 'reg'),
+      exec: { command: ['cmd'] },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    const b = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e, 'other'),
+      exec: { command: ['cmd'] },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    expect(configHash(a)).not.toEqual(configHash(b))
+  })
+
+  it('changes when command changes', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['cmd', '-p', '5959'] },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    const b = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['cmd', '-p', '5960'] },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    expect(configHash(a)).not.toEqual(configHash(b))
+  })
+
+  it('changes when env changes', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['cmd'], env: { PORT: '5959' } },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    const b = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['cmd'], env: { PORT: '5960' } },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    expect(configHash(a)).not.toEqual(configHash(b))
+  })
+
+  it('changes when mounts change', () => {
+    const e = fakeEffects()
+    const mountsA = Mounts.of<Manifest>().mountVolume({
+      volumeId: 'main',
+      subpath: '/instances/alice/data',
+      mountpoint: '/var/lib/startos',
+      readonly: false,
+    })
+    const mountsB = Mounts.of<Manifest>().mountVolume({
+      volumeId: 'main',
+      subpath: '/instances/bob/data',
+      mountpoint: '/var/lib/startos',
+      readonly: false,
+    })
+    const a = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e, 'reg', true, mountsA),
+      exec: { command: ['cmd'] },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    const b = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e, 'reg', true, mountsB),
+      exec: { command: ['cmd'] },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    expect(configHash(a)).not.toEqual(configHash(b))
+  })
+
+  it('changes when requires changes', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e })
+      .addOneshot('init', {
+        subcontainer: lazy(e),
+        exec: { command: ['init'] },
+        requires: [],
+      })
+      .addDaemon('reg', {
+        subcontainer: lazy(e),
+        exec: { command: ['reg'] },
+        ready: baseReady,
+        requires: [],
+      })
+    const b = Daemons.of<Manifest>({ effects: e })
+      .addOneshot('init', {
+        subcontainer: lazy(e),
+        exec: { command: ['init'] },
+        requires: [],
+      })
+      .addDaemon('reg', {
+        subcontainer: lazy(e),
+        exec: { command: ['reg'] },
+        ready: baseReady,
+        requires: ['init'],
+      })
+    expect(configHash(a.entries[1])).not.toEqual(configHash(b.entries[1]))
+  })
+
+  it('is order-independent for requires (sorted before hash)', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e })
+      .addOneshot('x', {
+        subcontainer: lazy(e),
+        exec: { command: ['x'] },
+        requires: [],
+      })
+      .addOneshot('y', {
+        subcontainer: lazy(e),
+        exec: { command: ['y'] },
+        requires: [],
+      })
+      .addDaemon('reg', {
+        subcontainer: lazy(e),
+        exec: { command: ['reg'] },
+        ready: baseReady,
+        requires: ['x', 'y'],
+      })
+    const b = Daemons.of<Manifest>({ effects: e })
+      .addOneshot('x', {
+        subcontainer: lazy(e),
+        exec: { command: ['x'] },
+        requires: [],
+      })
+      .addOneshot('y', {
+        subcontainer: lazy(e),
+        exec: { command: ['y'] },
+        requires: [],
+      })
+      .addDaemon('reg', {
+        subcontainer: lazy(e),
+        exec: { command: ['reg'] },
+        ready: baseReady,
+        requires: ['y', 'x'],
+      })
+    expect(configHash(a.entries[2])).toEqual(configHash(b.entries[2]))
+  })
+
+  it('normalizes string vs argv command form distinctly', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: 'cmd arg' },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    const b = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['cmd', 'arg'] },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    expect(configHash(a)).not.toEqual(configHash(b))
+  })
+
+  it('produces distinct hashes per kind even with the same args', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e }).addDaemon('x', {
+      subcontainer: lazy(e),
+      exec: { command: ['x'] },
+      ready: baseReady,
+      requires: [],
+    }).entries[0]
+    const b = Daemons.of<Manifest>({ effects: e }).addOneshot('x', {
+      subcontainer: lazy(e),
+      exec: { command: ['x'] },
+      requires: [],
+    }).entries[0]
+    expect(configHash(a)).not.toEqual(configHash(b))
+  })
+
+  it('changes when display label changes', () => {
+    const e = fakeEffects()
+    const a = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['cmd'] },
+      ready: { ...baseReady, display: 'A' },
+      requires: [],
+    }).entries[0]
+    const b = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['cmd'] },
+      ready: { ...baseReady, display: 'B' },
+      requires: [],
+    }).entries[0]
+    expect(configHash(a)).not.toEqual(configHash(b))
+  })
+})
+
+describe('SubContainer.of (lazy) identity', () => {
+  it('is preserved across .eager() materialization', async () => {
+    // We can't actually materialize without a real runtime, but we can
+    // verify the identity field exists and is stable on the lazy handle.
+    const e = fakeEffects()
+    const sub = SubContainer.of<Manifest>(
+      e,
+      { imageId: 'reg' },
+      null,
+      'name',
+    )
+    expect(typeof sub.identity).toBe('symbol')
+    // Identity unchanged across method-less accesses
+    expect(sub.identity).toBe(sub.identity)
+  })
+
+  it('produces distinct identities per call', () => {
+    const e = fakeEffects()
+    const a = SubContainer.of<Manifest>(
+      e,
+      { imageId: 'reg' },
+      null,
+      'name',
+    )
+    const b = SubContainer.of<Manifest>(
+      e,
+      { imageId: 'reg' },
+      null,
+      'name',
+    )
+    expect(a.identity).not.toBe(b.identity)
+  })
+})

--- a/sdk/package/lib/util/SubContainer.ts
+++ b/sdk/package/lib/util/SubContainer.ts
@@ -124,20 +124,17 @@ export interface SubContainer<
   readonly guid: T.Guid | Promise<T.Guid>
 
   /**
-   * Resolve a path within the subcontainer's rootfs. Sync `string` on
-   * {@link SubContainerEager}; `Promise<string>` on
+   * Get the absolute path to a file or directory within this subcontainer's rootfs.
+   * Sync `string` on {@link SubContainerEager}; `Promise<string>` on
    * {@link SubContainerLazy} (resolves after first materialization).
-   *
-   * @param path Path relative to the rootfs (e.g. `"/etc/config.json"` or `"data/file"`)
+   * @param path Path relative to the rootfs
    */
   subpath(path: string): string | Promise<string>
 
   /**
-   * Apply filesystem mounts (volumes, assets, dependencies, backups) to
-   * this subcontainer. Returns the same SubContainer for chaining. Lazy
-   * handles materialize on this call.
-   *
-   * @param mounts The Mounts configuration to apply
+   * Apply filesystem mounts (volumes, assets, dependencies, backups) to this subcontainer.
+   * Lazy handles materialize on this call.
+   * @param mounts - The Mounts configuration to apply
    * @returns This subcontainer instance for chaining
    */
   mount(mounts: MountsArg<Manifest, Effects>): Promise<this>
@@ -159,13 +156,13 @@ export interface SubContainer<
   destroy(): Promise<void>
 
   /**
-   * Run a command inside this subcontainer.
-   * Does NOT throw on non-zero exit (see {@link execFail}).
-   *
-   * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, and stdin input
-   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
-   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @description run a command inside this subcontainer
+   * DOES NOT THROW ON NONZERO EXIT CODE (see execFail)
+   * @param command an array representing the command and args to execute
+   * @param options
+   * @param timeoutMs how long to wait before killing the command in ms
+   * @param abort optional AbortController; aborting SIGKILLs the process
+   * @returns
    */
   exec(
     command: string[],
@@ -181,13 +178,12 @@ export interface SubContainer<
   }>
 
   /**
-   * Run a command inside this subcontainer, throwing on non-zero exit
-   * status or signal.
-   *
-   * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, and stdin input
-   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
-   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @description run a command inside this subcontainer, throwing on non-zero exit status
+   * @param command an array representing the command and args to execute
+   * @param options
+   * @param timeoutMs how long to wait before killing the command in ms
+   * @param abort optional AbortController; aborting SIGKILLs the process
+   * @returns
    * @throws {@link ExitError} on non-zero exit code or signal termination
    */
   execFail(
@@ -200,9 +196,8 @@ export interface SubContainer<
   /**
    * Launch a command as the init (PID 1) process of the subcontainer.
    * Replaces the current leader process.
-   *
-   * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, working directory, and user overrides
+   * @param command - The command and arguments to execute
+   * @param options - Optional environment, working directory, and user overrides
    */
   launch(
     command: string[],
@@ -211,9 +206,8 @@ export interface SubContainer<
 
   /**
    * Spawn a command inside the subcontainer as a non-init process.
-   *
-   * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, working directory, user, and stdio overrides
+   * @param command - The command and arguments to execute
+   * @param options - Optional environment, working directory, user, and stdio overrides
    */
   spawn(
     command: string[],
@@ -221,11 +215,10 @@ export interface SubContainer<
   ): Promise<cp.ChildProcess>
 
   /**
-   * Write a file to the subcontainer's filesystem.
-   *
-   * @param path Path relative to the subcontainer rootfs (e.g. `"/etc/config.json"`)
+   * @description Write a file to the subcontainer's filesystem
+   * @param path Path relative to the subcontainer rootfs (e.g. "/etc/config.json")
    * @param data The data to write
-   * @param options Optional write options (same as `node:fs/promises` `writeFile`)
+   * @param options Optional write options (same as node:fs/promises writeFile)
    */
   writeFile(
     path: string,
@@ -359,6 +352,8 @@ export const SubContainer = {
 }
 
 /**
+ * Want to limit what we can do in a container, so we want to launch a container with a specific image and the mounts.
+ *
  * Eager subcontainer: its filesystem and leader process exist from
  * construction. `rootfs` / `guid` / `subpath()` are synchronous.
  *

--- a/sdk/package/lib/util/SubContainer.ts
+++ b/sdk/package/lib/util/SubContainer.ts
@@ -126,33 +126,46 @@ export interface SubContainer<
   /**
    * Resolve a path within the subcontainer's rootfs. Sync `string` on
    * {@link SubContainerEager}; `Promise<string>` on
-   * {@link SubContainerLazy}.
+   * {@link SubContainerLazy} (resolves after first materialization).
+   *
+   * @param path Path relative to the rootfs (e.g. `"/etc/config.json"` or `"data/file"`)
    */
   subpath(path: string): string | Promise<string>
 
   /**
-   * Apply filesystem mounts to this subcontainer. Returns the same
-   * SubContainer for chaining. Lazy handles materialize on this call.
+   * Apply filesystem mounts (volumes, assets, dependencies, backups) to
+   * this subcontainer. Returns the same SubContainer for chaining. Lazy
+   * handles materialize on this call.
+   *
+   * @param mounts The Mounts configuration to apply
+   * @returns This subcontainer instance for chaining
    */
   mount(mounts: MountsArg<Manifest, Effects>): Promise<this>
 
   /**
    * Take a use-hold on this subcontainer. The returned function releases
-   * the hold; the SubContainer is destroyed when a {@link destroy} call has
-   * been made *and* the last hold is released, in either order.
+   * the hold; the SubContainer is destroyed when {@link destroy} has been
+   * called *and* the last hold is released, in either order.
+   *
+   * @returns A release function — call it to drop this hold
    */
   hold(): () => Promise<void>
 
   /**
    * Mark this subcontainer for destruction. Fires `destroyFs` immediately
-   * if no holds are outstanding; otherwise the final
-   * {@link hold|hold-release} fires it.
+   * if no holds are outstanding; otherwise the final hold-release fires
+   * it. Idempotent.
    */
   destroy(): Promise<void>
 
   /**
    * Run a command inside this subcontainer.
    * Does NOT throw on non-zero exit (see {@link execFail}).
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, user, cwd, and stdin input
+   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
+   * @param abort Optional AbortController; aborting SIGKILLs the process
    */
   exec(
     command: string[],
@@ -167,7 +180,16 @@ export interface SubContainer<
     stderr: string | Buffer
   }>
 
-  /** Run a command inside this subcontainer, throwing on non-zero exit. */
+  /**
+   * Run a command inside this subcontainer, throwing on non-zero exit
+   * status or signal.
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, user, cwd, and stdin input
+   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
+   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @throws {@link ExitError} on non-zero exit code or signal termination
+   */
   execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
@@ -175,19 +197,36 @@ export interface SubContainer<
     abort?: AbortController,
   ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }>
 
-  /** Launch a command as the init (PID 1) process of the subcontainer. */
+  /**
+   * Launch a command as the init (PID 1) process of the subcontainer.
+   * Replaces the current leader process.
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, working directory, and user overrides
+   */
   launch(
     command: string[],
     options?: CommandOptions,
   ): Promise<cp.ChildProcessWithoutNullStreams>
 
-  /** Spawn a command inside the subcontainer as a non-init process. */
+  /**
+   * Spawn a command inside the subcontainer as a non-init process.
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, working directory, user, and stdio overrides
+   */
   spawn(
     command: string[],
     options?: CommandOptions & StdioOptions,
   ): Promise<cp.ChildProcess>
 
-  /** Write a file to the subcontainer's filesystem. */
+  /**
+   * Write a file to the subcontainer's filesystem.
+   *
+   * @param path Path relative to the subcontainer rootfs (e.g. `"/etc/config.json"`)
+   * @param data The data to write
+   * @param options Optional write options (same as `node:fs/promises` `writeFile`)
+   */
   writeFile(
     path: string,
     data:
@@ -217,6 +256,11 @@ export const SubContainer = {
    * not actually be needed (the canonical case: `Daemons.dynamic` may diff
    * a daemon away before it ever runs) and whenever you don't need sync
    * access to `rootfs` / `guid` / `subpath()`.
+   *
+   * @param effects The effects context the subcontainer will run under
+   * @param image Image to launch from (must be declared in the manifest); `sharedRun` rbinds the host's `/run` if true
+   * @param mounts Initial mounts applied at materialization (declared so they participate in `Daemons.dynamic`'s `configHash`)
+   * @param name Debug/identification name (does not affect identity)
    */
   of<Manifest extends T.SDKManifest, Effects extends T.Effects = T.Effects>(
     effects: Effects,
@@ -249,6 +293,11 @@ export const SubContainer = {
    * Eager handles created inside `fn` are wasted on re-runs that diff to
    * "leave alone" — use {@link SubContainer.of} (lazy) for daemons under
    * `Daemons.dynamic`.
+   *
+   * @param effects The effects context the subcontainer will run under
+   * @param image Image to launch from; `sharedRun` rbinds the host's `/run` if true
+   * @param mounts Mounts applied during construction
+   * @param name Debug/identification name (does not affect identity)
    */
   eager<Manifest extends T.SDKManifest, Effects extends T.Effects = T.Effects>(
     effects: Effects,
@@ -272,6 +321,13 @@ export const SubContainer = {
    * Run a function with an ephemeral, eager subcontainer. The container
    * is created before `fn` runs and destroyed in a `finally` block after.
    * Use for one-off command execution that needs a fresh filesystem.
+   *
+   * @param effects The effects context the subcontainer will run under
+   * @param image Image to launch from; `sharedRun` rbinds the host's `/run` if true
+   * @param mounts Mounts applied during construction
+   * @param name Debug/identification name (does not affect identity)
+   * @param fn Function to invoke with the eager subcontainer
+   * @returns Whatever `fn` returns
    */
   async withTemp<
     Manifest extends T.SDKManifest,
@@ -421,12 +477,24 @@ export class SubContainerEager<
     }
   }
 
+  /**
+   * Resolve a path within this subcontainer's rootfs (synchronous on eager).
+   *
+   * @param path Path relative to the rootfs (e.g. `"/etc/config.json"` or `"data/file"`)
+   */
   subpath(path: string): string {
     return path.startsWith('/')
       ? `${this.rootfs}${path}`
       : `${this.rootfs}/${path}`
   }
 
+  /**
+   * Apply filesystem mounts (volumes, assets, dependencies, backups) to
+   * this subcontainer.
+   *
+   * @param mounts The Mounts configuration to apply
+   * @returns This subcontainer instance for chaining
+   */
   async mount(mounts: MountsArg<Manifest, Effects>): Promise<this> {
     for (let mount of mounts.build()) {
       let { options, mountpoint } = mount
@@ -470,6 +538,14 @@ export class SubContainerEager<
     return this
   }
 
+  /**
+   * Take a use-hold on this subcontainer. The container is destroyed
+   * when {@link destroy} has been called *and* the last hold is released,
+   * in either order.
+   *
+   * @returns A release function — call it to drop this hold
+   * @throws If this subcontainer has already been destroyed
+   */
   hold(): () => Promise<void> {
     if (this.destroyed) {
       throw new Error(
@@ -488,6 +564,11 @@ export class SubContainerEager<
     }
   }
 
+  /**
+   * Mark this subcontainer for destruction. Fires `destroyFs` immediately
+   * if no holds are outstanding; otherwise the final hold-release fires
+   * it. Idempotent.
+   */
   async destroy(): Promise<void> {
     this.destroyPending = true
     if (this.holdCount === 0) await this._destroyImmediate()
@@ -526,6 +607,15 @@ export class SubContainerEager<
     }
   }
 
+  /**
+   * Run a command inside this subcontainer.
+   * Does NOT throw on non-zero exit (see {@link execFail}).
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, user, cwd, and stdin input
+   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
+   * @param abort Optional AbortController; aborting SIGKILLs the process
+   */
   async exec(
     command: string[],
     options?: CommandOptions & ExecOptions,
@@ -638,6 +728,15 @@ export class SubContainerEager<
     })
   }
 
+  /**
+   * Run a command inside this subcontainer, throwing on non-zero exit.
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, user, cwd, and stdin input
+   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
+   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @throws {@link ExitError} on non-zero exit code or signal termination
+   */
   async execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
@@ -649,6 +748,13 @@ export class SubContainerEager<
     )
   }
 
+  /**
+   * Launch a command as the init (PID 1) process of the subcontainer.
+   * Replaces the current leader process.
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, working directory, and user overrides
+   */
   async launch(
     command: string[],
     options?: CommandOptions,
@@ -700,6 +806,12 @@ export class SubContainerEager<
     return this.leader as cp.ChildProcessWithoutNullStreams
   }
 
+  /**
+   * Spawn a command inside the subcontainer as a non-init process.
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, working directory, user, and stdio overrides
+   */
   async spawn(
     command: string[],
     options: CommandOptions & StdioOptions = { stdio: 'inherit' },
@@ -745,6 +857,13 @@ export class SubContainerEager<
     )
   }
 
+  /**
+   * Write a file to the subcontainer's filesystem.
+   *
+   * @param path Path relative to the subcontainer rootfs (e.g. `"/etc/config.json"`)
+   * @param data The data to write
+   * @param options Optional write options (same as `node:fs/promises` `writeFile`)
+   */
   async writeFile(
     path: string,
     data:
@@ -825,23 +944,49 @@ export class SubContainerLazy<
     }))
   }
 
+  /** Absolute path to the materialized subcontainer's rootfs. Triggers materialization on first access. */
   get rootfs(): Promise<string> {
     return this.eager().then((e) => e.rootfs)
   }
 
+  /** OS-level guid. Triggers materialization on first access. */
   get guid(): Promise<T.Guid> {
     return this.eager().then((e) => e.guid)
   }
 
+  /**
+   * Resolve a path within the subcontainer's rootfs. Triggers
+   * materialization on first call.
+   *
+   * @param path Path relative to the rootfs
+   */
   async subpath(path: string): Promise<string> {
     return (await this.eager()).subpath(path)
   }
 
+  /**
+   * Apply filesystem mounts to this subcontainer (materializes on first
+   * call). Mounts beyond the ones declared at construction are not part
+   * of `Daemons.dynamic`'s `configHash`.
+   *
+   * @param mounts The Mounts configuration to apply
+   * @returns This lazy handle, for chaining
+   */
   async mount(mounts: MountsArg<Manifest, Effects>): Promise<this> {
     await (await this.eager()).mount(mounts)
     return this
   }
 
+  /**
+   * Take a use-hold on this subcontainer. Materializes the underlying
+   * eager subcontainer asynchronously and places the hold on it.
+   *
+   * The returned release function is safe to call before materialization
+   * completes — it cancels the pending hold so a never-materialized lazy
+   * (the canonical "left alone" case in `Daemons.dynamic`) stays cheap.
+   *
+   * @returns A release function — call it to drop this hold
+   */
   hold(): () => Promise<void> {
     // Acquire the hold on the eager once materialized. Until then we record
     // a "pending" intent so destroy() honors any outstanding holds even on
@@ -871,11 +1016,26 @@ export class SubContainerLazy<
     }
   }
 
+  /**
+   * Mark this subcontainer for destruction. If already materialized, the
+   * underlying eager's destroy is invoked (which respects outstanding
+   * holds). If never materialized, the destroy pending flag is set so
+   * that any future materialization fires destroy immediately.
+   */
   async destroy(): Promise<void> {
     this.destroyPending = true
     if (this.materialized) await (await this.materialized).destroy()
   }
 
+  /**
+   * Run a command inside this subcontainer (materializes on first call).
+   * Does NOT throw on non-zero exit (see {@link execFail}).
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, user, cwd, and stdin input
+   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
+   * @param abort Optional AbortController; aborting SIGKILLs the process
+   */
   async exec(
     command: string[],
     options?: CommandOptions & ExecOptions,
@@ -891,6 +1051,16 @@ export class SubContainerLazy<
     return (await this.eager()).exec(command, options, timeoutMs, abort)
   }
 
+  /**
+   * Run a command inside this subcontainer, throwing on non-zero exit
+   * (materializes on first call).
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, user, cwd, and stdin input
+   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
+   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @throws {@link ExitError} on non-zero exit code or signal termination
+   */
   async execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
@@ -900,6 +1070,13 @@ export class SubContainerLazy<
     return (await this.eager()).execFail(command, options, timeoutMs, abort)
   }
 
+  /**
+   * Launch a command as the init (PID 1) process of the subcontainer
+   * (materializes on first call).
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, working directory, and user overrides
+   */
   async launch(
     command: string[],
     options?: CommandOptions,
@@ -907,6 +1084,13 @@ export class SubContainerLazy<
     return (await this.eager()).launch(command, options)
   }
 
+  /**
+   * Spawn a command inside the subcontainer as a non-init process
+   * (materializes on first call).
+   *
+   * @param command Argv array representing the command and its arguments
+   * @param options Optional environment, working directory, user, and stdio overrides
+   */
   async spawn(
     command: string[],
     options?: CommandOptions & StdioOptions,
@@ -914,6 +1098,13 @@ export class SubContainerLazy<
     return (await this.eager()).spawn(command, options)
   }
 
+  /**
+   * Write a file to the subcontainer's filesystem (materializes on first call).
+   *
+   * @param path Path relative to the subcontainer rootfs (e.g. `"/etc/config.json"`)
+   * @param data The data to write
+   * @param options Optional write options (same as `node:fs/promises` `writeFile`)
+   */
   async writeFile(
     path: string,
     data:

--- a/sdk/package/lib/util/SubContainer.ts
+++ b/sdk/package/lib/util/SubContainer.ts
@@ -7,17 +7,9 @@ import { once } from '../../../base/lib/util/once'
 import { Drop } from '../../../base/lib/util/Drop'
 import { Mounts } from '../mainFn/Mounts'
 import { BackupEffects } from '../backup/Backups'
-import { PathBase } from './Volume'
 
 export const execFile = promisify(cp.execFile)
 const False = () => false
-
-type ExecResults = {
-  exitCode: number | null
-  exitSignal: NodeJS.Signals | null
-  stdout: string | Buffer
-  stderr: string | Buffer
-}
 
 export type ExecOptions = {
   input?: string | Buffer
@@ -69,56 +61,98 @@ async function bind(
   await execFile('mount', [...args, from, to])
 }
 
+type MountsArg<Manifest extends T.SDKManifest, E extends T.Effects> =
+  E extends BackupEffects
+    ? Mounts<Manifest, { subpath: string | null; mountpoint: string }>
+    : Mounts<Manifest, never>
+
 /**
- * Interface representing an isolated container environment for running service processes.
+ * Isolated container environment for running service processes.
  *
- * Provides methods for executing commands, spawning processes, mounting filesystems,
- * and writing files within the container's rootfs. Comes in two flavors:
- * {@link SubContainerOwned} (owns the underlying filesystem) and
- * {@link SubContainerRc} (reference-counted handle to a shared container).
+ * Two concrete shapes implement this interface:
+ *
+ * - {@link SubContainerEager} — created and materialized immediately by
+ *   {@link SubContainer.eager}. The `rootfs` / `guid` / `subpath()` accessors
+ *   return `string` / `T.Guid` synchronously.
+ * - {@link SubContainerLazy} — created by {@link SubContainer.of} (the
+ *   default). Backing filesystem is not materialized until the first method
+ *   call (or explicit {@link SubContainerLazy.eager}). `rootfs` / `guid` /
+ *   `subpath()` return `Promise<...>`.
+ *
+ * The interface widens those accessors to `T | Promise<T>` so a caller
+ * holding the interface type must `await` (which yields the value for either
+ * shape). Callers holding the concrete class get the narrower sync type.
+ *
+ * ### Lifecycle and sharing
+ *
+ * Multiple consumers may share a single SubContainer (typical pattern: an
+ * `Oneshot` setup step and a `Daemon` running in the same container so the
+ * setup's writes are visible to the daemon). Each consumer takes a use-hold
+ * via {@link SubContainer.hold} and releases it when finished. The
+ * SubContainer is torn down (`destroyFs`) when {@link SubContainer.destroy}
+ * has been called *and* all outstanding holds have been released — whichever
+ * is later. `Daemons` manages holds for the daemons it owns.
  */
 export interface SubContainer<
   Manifest extends T.SDKManifest,
   Effects extends T.Effects = T.Effects,
->
-  extends Drop, PathBase {
+> extends Drop {
+  /** The image this subcontainer is launched from. */
   readonly imageId: keyof Manifest['images'] & T.ImageId
-  readonly rootfs: string
-  readonly guid: T.Guid
 
   /**
-   * Get the absolute path to a file or directory within this subcontainer's rootfs
-   * @param path Path relative to the rootfs
+   * Stable, sync handle identifying this SubContainer. Generated at
+   * construction by {@link SubContainer.of} / {@link SubContainer.eager}
+   * and preserved across materialization, so a lazy handle and the eager
+   * it materializes into compare equal. Use this for sharing comparisons
+   * that must work pre-materialization.
    */
-  subpath(path: string): string
+  readonly identity: symbol
 
   /**
-   * Apply filesystem mounts (volumes, assets, dependencies, backups) to this subcontainer.
-   * @param mounts - The Mounts configuration to apply
-   * @returns This subcontainer instance for chaining
+   * Absolute path to the subcontainer's rootfs. Sync `string` on
+   * {@link SubContainerEager}; `Promise<string>` on
+   * {@link SubContainerLazy}. Awaiting the property works for either.
    */
-  mount(
-    mounts: Effects extends BackupEffects
-      ? Mounts<
-          Manifest,
-          {
-            subpath: string | null
-            mountpoint: string
-          }
-        >
-      : Mounts<Manifest, never>,
-  ): Promise<this>
-
-  /** Destroy this subcontainer and clean up its filesystem */
-  destroy: () => Promise<null>
+  readonly rootfs: string | Promise<string>
 
   /**
-   * @description run a command inside this subcontainer
-   * DOES NOT THROW ON NONZERO EXIT CODE (see execFail)
-   * @param commands an array representing the command and args to execute
-   * @param options
-   * @param timeoutMs how long to wait before killing the command in ms
-   * @returns
+   * OS-level guid of the subcontainer. Sync `T.Guid` on
+   * {@link SubContainerEager}; `Promise<T.Guid>` on
+   * {@link SubContainerLazy}.
+   */
+  readonly guid: T.Guid | Promise<T.Guid>
+
+  /**
+   * Resolve a path within the subcontainer's rootfs. Sync `string` on
+   * {@link SubContainerEager}; `Promise<string>` on
+   * {@link SubContainerLazy}.
+   */
+  subpath(path: string): string | Promise<string>
+
+  /**
+   * Apply filesystem mounts to this subcontainer. Returns the same
+   * SubContainer for chaining. Lazy handles materialize on this call.
+   */
+  mount(mounts: MountsArg<Manifest, Effects>): Promise<this>
+
+  /**
+   * Take a use-hold on this subcontainer. The returned function releases
+   * the hold; the SubContainer is destroyed when a {@link destroy} call has
+   * been made *and* the last hold is released, in either order.
+   */
+  hold(): () => Promise<void>
+
+  /**
+   * Mark this subcontainer for destruction. Fires `destroyFs` immediately
+   * if no holds are outstanding; otherwise the final
+   * {@link hold|hold-release} fires it.
+   */
+  destroy(): Promise<void>
+
+  /**
+   * Run a command inside this subcontainer.
+   * Does NOT throw on non-zero exit (see {@link execFail}).
    */
   exec(
     command: string[],
@@ -133,50 +167,27 @@ export interface SubContainer<
     stderr: string | Buffer
   }>
 
-  /**
-   * @description run a command inside this subcontainer, throwing on non-zero exit status
-   * @param commands an array representing the command and args to execute
-   * @param options
-   * @param timeoutMs how long to wait before killing the command in ms
-   * @returns
-   */
+  /** Run a command inside this subcontainer, throwing on non-zero exit. */
   execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
     timeoutMs?: number | null,
     abort?: AbortController,
-  ): Promise<{
-    stdout: string | Buffer
-    stderr: string | Buffer
-  }>
+  ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }>
 
-  /**
-   * Launch a command as the init (PID 1) process of the subcontainer.
-   * Replaces the current leader process.
-   * @param command - The command and arguments to execute
-   * @param options - Optional environment, working directory, and user overrides
-   */
+  /** Launch a command as the init (PID 1) process of the subcontainer. */
   launch(
     command: string[],
     options?: CommandOptions,
   ): Promise<cp.ChildProcessWithoutNullStreams>
 
-  /**
-   * Spawn a command inside the subcontainer as a non-init process.
-   * @param command - The command and arguments to execute
-   * @param options - Optional environment, working directory, user, and stdio overrides
-   */
+  /** Spawn a command inside the subcontainer as a non-init process. */
   spawn(
     command: string[],
     options?: CommandOptions & StdioOptions,
   ): Promise<cp.ChildProcess>
 
-  /**
-   * @description Write a file to the subcontainer's filesystem
-   * @param path Path relative to the subcontainer rootfs (e.g. "/etc/config.json")
-   * @param data The data to write
-   * @param options Optional write options (same as node:fs/promises writeFile)
-   */
+  /** Write a file to the subcontainer's filesystem. */
   writeFile(
     path: string,
     data:
@@ -186,38 +197,135 @@ export interface SubContainer<
       | AsyncIterable<string | NodeJS.ArrayBufferView>,
     options?: Parameters<typeof fs.writeFile>[2],
   ): Promise<void>
-
-  /**
-   * Create a reference-counted handle to this subcontainer.
-   * The underlying container is only destroyed when all handles are released.
-   */
-  rc(): SubContainerRc<Manifest, Effects>
-
-  /** Returns true if this is an owned subcontainer (not a reference-counted handle) */
-  isOwned(): this is SubContainerOwned<Manifest, Effects>
 }
 
 /**
- * Want to limit what we can do in a container, so we want to launch a container with a specific image and the mounts.
+ * Top-level factories for creating SubContainers. Prefer
+ * {@link SubContainer.of} (lazy) unless you need synchronous access to
+ * `rootfs` / `guid` / `subpath()` before running any methods — for that, use
+ * {@link SubContainer.eager}.
  */
-export class SubContainerOwned<
+export const SubContainer = {
+  /**
+   * Create a {@link SubContainerLazy} that materializes its backing
+   * filesystem on first use. Synchronous return — no `Promise` wrapper.
+   *
+   * Identity is generated at this call and threaded through to the eager
+   * container produced by {@link SubContainerLazy.eager}.
+   *
+   * This is the default factory. Use it whenever the subcontainer might
+   * not actually be needed (the canonical case: `Daemons.dynamic` may diff
+   * a daemon away before it ever runs) and whenever you don't need sync
+   * access to `rootfs` / `guid` / `subpath()`.
+   */
+  of<Manifest extends T.SDKManifest, Effects extends T.Effects = T.Effects>(
+    effects: Effects,
+    image: {
+      imageId: keyof Manifest['images'] & T.ImageId
+      sharedRun?: boolean
+    },
+    mounts: MountsArg<Manifest, Effects> | null,
+    name: string,
+  ): SubContainerLazy<Manifest, Effects> {
+    return new SubContainerLazy<Manifest, Effects>(
+      effects,
+      image,
+      mounts,
+      name,
+    )
+  },
+
+  /**
+   * Create a {@link SubContainerEager}, materializing the backing
+   * filesystem immediately. Returns `Promise<SubContainerEager>`.
+   *
+   * Use when you need synchronous access to `rootfs` / `guid` /
+   * `subpath()` before running any methods (e.g. mounting paths from
+   * outside the container, init-time precheck), or when you want
+   * `effects.subcontainer.createFs` failures to surface here instead of at
+   * first method call.
+   *
+   * **Do not pass an eager SubContainer to `Daemons.dynamic`'s `fn`**.
+   * Eager handles created inside `fn` are wasted on re-runs that diff to
+   * "leave alone" — use {@link SubContainer.of} (lazy) for daemons under
+   * `Daemons.dynamic`.
+   */
+  eager<Manifest extends T.SDKManifest, Effects extends T.Effects = T.Effects>(
+    effects: Effects,
+    image: {
+      imageId: keyof Manifest['images'] & T.ImageId
+      sharedRun?: boolean
+    },
+    mounts: MountsArg<Manifest, Effects> | null,
+    name: string,
+  ): Promise<SubContainerEager<Manifest, Effects>> {
+    return SubContainerEager._of(
+      effects,
+      image,
+      mounts,
+      name,
+      Symbol('subcontainer'),
+    )
+  },
+
+  /**
+   * Run a function with an ephemeral, eager subcontainer. The container
+   * is created before `fn` runs and destroyed in a `finally` block after.
+   * Use for one-off command execution that needs a fresh filesystem.
+   */
+  async withTemp<
+    Manifest extends T.SDKManifest,
+    T_,
+    Effects extends T.Effects = T.Effects,
+  >(
+    effects: Effects,
+    image: {
+      imageId: keyof Manifest['images'] & T.ImageId
+      sharedRun?: boolean
+    },
+    mounts: MountsArg<Manifest, Effects> | null,
+    name: string,
+    fn: (sub: SubContainerEager<Manifest, Effects>) => Promise<T_>,
+  ): Promise<T_> {
+    const sub = await SubContainerEager._of(
+      effects,
+      image,
+      mounts,
+      name,
+      Symbol('subcontainer'),
+    )
+    try {
+      return await fn(sub)
+    } finally {
+      await sub.destroy()
+    }
+  },
+}
+
+/**
+ * Eager subcontainer: its filesystem and leader process exist from
+ * construction. `rootfs` / `guid` / `subpath()` are synchronous.
+ *
+ * Construct via {@link SubContainer.eager} or {@link SubContainer.withTemp}.
+ */
+export class SubContainerEager<
   Manifest extends T.SDKManifest,
   Effects extends T.Effects = T.Effects,
->
-  extends Drop
-  implements SubContainer<Manifest, Effects>
-{
+> extends Drop implements SubContainer<Manifest, Effects> {
   private destroyed = false
-  public rcs = 0
+  private destroyPending = false
+  private holdCount = 0
 
   private leader: cp.ChildProcess
   private leaderExited: boolean = false
   private waitProc: () => Promise<null>
+
   private constructor(
     readonly effects: Effects,
     readonly imageId: keyof Manifest['images'] & T.ImageId,
     readonly rootfs: string,
     readonly guid: T.Guid,
+    readonly identity: symbol,
   ) {
     super()
     this.leaderExited = false
@@ -255,32 +363,36 @@ export class SubContainerOwned<
         }),
     )
   }
-  static async of<Manifest extends T.SDKManifest, Effects extends T.Effects>(
+
+  /**
+   * Internal factory. Accepts an explicit `identity` so a lazy handle can
+   * thread its identity through to the eager it materializes into.
+   * External callers use {@link SubContainer.eager} (which generates its
+   * own identity) or {@link SubContainer.of} (lazy).
+   */
+  static async _of<Manifest extends T.SDKManifest, Effects extends T.Effects>(
     effects: Effects,
     image: {
       imageId: keyof Manifest['images'] & T.ImageId
       sharedRun?: boolean
     },
-    mounts:
-      | (Effects extends BackupEffects
-          ? Mounts<
-              Manifest,
-              {
-                subpath: string | null
-                mountpoint: string
-              }
-            >
-          : Mounts<Manifest, never>)
-      | null,
+    mounts: MountsArg<Manifest, Effects> | null,
     name: string,
-  ): Promise<SubContainerOwned<Manifest, Effects>> {
+    identity: symbol,
+  ): Promise<SubContainerEager<Manifest, Effects>> {
     const { imageId, sharedRun } = image
     const [rootfs, guid] = await effects.subcontainer.createFs({
       imageId,
       name,
     })
 
-    const res = new SubContainerOwned(effects, imageId, rootfs, guid)
+    const res = new SubContainerEager<Manifest, Effects>(
+      effects,
+      imageId,
+      rootfs,
+      guid,
+      identity,
+    )
 
     try {
       if (mounts) {
@@ -304,45 +416,8 @@ export class SubContainerOwned<
 
       return res
     } catch (e) {
-      await res.destroy()
+      await res._destroyImmediate()
       throw e
-    }
-  }
-
-  static async withTemp<
-    Manifest extends T.SDKManifest,
-    T,
-    Effects extends T.Effects,
-  >(
-    effects: Effects,
-    image: {
-      imageId: keyof Manifest['images'] & T.ImageId
-      sharedRun?: boolean
-    },
-    mounts:
-      | (Effects extends BackupEffects
-          ? Mounts<
-              Manifest,
-              {
-                subpath: string | null
-                mountpoint: string
-              }
-            >
-          : Mounts<Manifest, never>)
-      | null,
-    name: string,
-    fn: (subContainer: SubContainer<Manifest, Effects>) => Promise<T>,
-  ): Promise<T> {
-    const subContainer = await SubContainerOwned.of(
-      effects,
-      image,
-      mounts,
-      name,
-    )
-    try {
-      return await fn(subContainer)
-    } finally {
-      await subContainer.destroy()
     }
   }
 
@@ -352,17 +427,7 @@ export class SubContainerOwned<
       : `${this.rootfs}/${path}`
   }
 
-  async mount(
-    mounts: Effects extends BackupEffects
-      ? Mounts<
-          Manifest,
-          {
-            subpath: string | null
-            mountpoint: string
-          }
-        >
-      : Mounts<Manifest, never>,
-  ): Promise<this> {
+  async mount(mounts: MountsArg<Manifest, Effects>): Promise<this> {
     for (let mount of mounts.build()) {
       let { options, mountpoint } = mount
       const path = mountpoint.startsWith('/')
@@ -405,10 +470,39 @@ export class SubContainerOwned<
     return this
   }
 
-  private async killLeader() {
-    if (this.leaderExited) {
-      return
+  hold(): () => Promise<void> {
+    if (this.destroyed) {
+      throw new Error(
+        `cannot hold subcontainer ${String(this.identity.description)}: already destroyed`,
+      )
     }
+    this.holdCount++
+    let released = false
+    return async () => {
+      if (released) return
+      released = true
+      this.holdCount--
+      if (this.holdCount === 0 && this.destroyPending) {
+        await this._destroyImmediate()
+      }
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.destroyPending = true
+    if (this.holdCount === 0) await this._destroyImmediate()
+  }
+
+  private async _destroyImmediate(): Promise<void> {
+    if (this.destroyed) return
+    this.destroyed = true
+    const guid = this.guid
+    await this.killLeader()
+    await this.effects.subcontainer.destroyFs({ guid })
+  }
+
+  private async killLeader(): Promise<null> {
+    if (this.leaderExited) return null
     return new Promise<null>((resolve, reject) => {
       try {
         let timeout = setTimeout(() => this.leader.kill('SIGKILL'), 30000)
@@ -425,31 +519,13 @@ export class SubContainerOwned<
     })
   }
 
-  get destroy() {
-    return async () => {
-      if (!this.destroyed) {
-        const guid = this.guid
-        await this.killLeader()
-        await this.effects.subcontainer.destroyFs({ guid })
-        this.destroyed = true
-      }
-      return null
+  onDrop(): void {
+    if (!this.destroyed && this.holdCount === 0) {
+      console.log(`Cleaning up dangling subcontainer ${this.guid}`)
+      this._destroyImmediate().catch((e) => console.error(e))
     }
   }
 
-  onDrop(): void {
-    console.log(`Cleaning up dangling subcontainer ${this.guid}`)
-    this.destroy()
-  }
-
-  /**
-   * @description run a command inside this subcontainer
-   * DOES NOT THROW ON NONZERO EXIT CODE (see execFail)
-   * @param commands an array representing the command and args to execute
-   * @param options
-   * @param timeoutMs how long to wait before killing the command in ms
-   * @returns
-   */
   async exec(
     command: string[],
     options?: CommandOptions & ExecOptions,
@@ -562,22 +638,12 @@ export class SubContainerOwned<
     })
   }
 
-  /**
-   * @description run a command inside this subcontainer, throwing on non-zero exit status
-   * @param commands an array representing the command and args to execute
-   * @param options
-   * @param timeoutMs how long to wait before killing the command in ms
-   * @returns
-   */
   async execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
     timeoutMs?: number | null,
     abort?: AbortController,
-  ): Promise<{
-    stdout: string | Buffer
-    stderr: string | Buffer
-  }> {
+  ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> {
     return this.exec(command, options, timeoutMs, abort).then((res) =>
       res.throw(),
     )
@@ -679,12 +745,6 @@ export class SubContainerOwned<
     )
   }
 
-  /**
-   * @description Write a file to the subcontainer's filesystem
-   * @param path Path relative to the subcontainer rootfs (e.g. "/etc/config.json")
-   * @param data The data to write
-   * @param options Optional write options (same as node:fs/promises writeFile)
-   */
   async writeFile(
     path: string,
     data:
@@ -699,154 +759,127 @@ export class SubContainerOwned<
     await fs.mkdir(dir, { recursive: true })
     return fs.writeFile(fullPath, data, options)
   }
-
-  rc(): SubContainerRc<Manifest, Effects> {
-    return new SubContainerRc(this)
-  }
-
-  isOwned(): this is SubContainerOwned<Manifest, Effects> {
-    return true
-  }
 }
 
 /**
- * A reference-counted handle to a {@link SubContainerOwned}.
+ * Lazy subcontainer: a handle whose backing filesystem is materialized on
+ * first use (or explicit {@link SubContainerLazy.eager}). The narrow types
+ * for `rootfs` / `guid` / `subpath()` are `Promise<...>`.
  *
- * Multiple `SubContainerRc` instances can share one underlying subcontainer.
- * The subcontainer is destroyed only when the last reference is released via `destroy()`.
+ * Construct via {@link SubContainer.of}. Identity is generated at
+ * construction and preserved across materialization.
+ *
+ * Sharing across consumers: pass the same `SubContainerLazy` to multiple
+ * `addDaemon` calls. The first consumer to call a method (or `.eager()`)
+ * triggers materialization; all consumers end up holding the same
+ * underlying {@link SubContainerEager}.
  */
-export class SubContainerRc<
+export class SubContainerLazy<
   Manifest extends T.SDKManifest,
   Effects extends T.Effects = T.Effects,
->
-  extends Drop
-  implements SubContainer<Manifest, Effects>
-{
-  get imageId() {
-    return this.subcontainer.imageId
-  }
-  get rootfs() {
-    return this.subcontainer.rootfs
-  }
-  get guid() {
-    return this.subcontainer.guid
-  }
-  subpath(path: string): string {
-    return this.subcontainer.subpath(path)
-  }
-  private destroyed = false
-  private destroying: Promise<null> | null = null
-  public constructor(
-    private readonly subcontainer: SubContainerOwned<Manifest, Effects>,
+> extends Drop implements SubContainer<Manifest, Effects> {
+  readonly identity: symbol = Symbol('subcontainer')
+  readonly imageId: keyof Manifest['images'] & T.ImageId
+  readonly sharedRun: boolean
+  readonly name: string
+  /** The mounts declared at construction. Read by `Daemons.dynamic`'s configHash. */
+  readonly mounts: MountsArg<Manifest, Effects> | null
+
+  private materialized: Promise<SubContainerEager<Manifest, Effects>> | null =
+    null
+  private destroyPending = false
+
+  constructor(
+    readonly effects: Effects,
+    image: {
+      imageId: keyof Manifest['images'] & T.ImageId
+      sharedRun?: boolean
+    },
+    mounts: MountsArg<Manifest, Effects> | null,
+    name: string,
   ) {
-    subcontainer.rcs++
     super()
-  }
-  static async of<Manifest extends T.SDKManifest, Effects extends T.Effects>(
-    effects: Effects,
-    image: {
-      imageId: keyof Manifest['images'] & T.ImageId
-      sharedRun?: boolean
-    },
-    mounts:
-      | (Effects extends BackupEffects
-          ? Mounts<
-              Manifest,
-              {
-                subpath: string | null
-                mountpoint: string
-              }
-            >
-          : Mounts<Manifest, never>)
-      | null,
-    name: string,
-  ) {
-    return new SubContainerRc(
-      await SubContainerOwned.of(effects, image, mounts, name),
-    )
-  }
-
-  static async withTemp<
-    Manifest extends T.SDKManifest,
-    T,
-    Effects extends T.Effects,
-  >(
-    effects: Effects,
-    image: {
-      imageId: keyof Manifest['images'] & T.ImageId
-      sharedRun?: boolean
-    },
-    mounts:
-      | (Effects extends BackupEffects
-          ? Mounts<
-              Manifest,
-              {
-                subpath: string | null
-                mountpoint: string
-              }
-            >
-          : Mounts<Manifest, never>)
-      | null,
-    name: string,
-    fn: (subContainer: SubContainer<Manifest, Effects>) => Promise<T>,
-  ): Promise<T> {
-    const subContainer = await SubContainerRc.of(effects, image, mounts, name)
-    try {
-      return await fn(subContainer)
-    } finally {
-      await subContainer.destroy()
-    }
-  }
-
-  async mount(
-    mounts: Effects extends BackupEffects
-      ? Mounts<
-          Manifest,
-          {
-            subpath: string | null
-            mountpoint: string
-          }
-        >
-      : Mounts<Manifest, never>,
-  ): Promise<this> {
-    await this.subcontainer.mount(mounts)
-    return this
-  }
-
-  get destroy() {
-    return async () => {
-      if (!this.destroyed && !this.destroying) {
-        const rcs = --this.subcontainer.rcs
-        if (rcs <= 0) {
-          this.destroying = this.subcontainer.destroy()
-          if (rcs < 0) console.error(new Error('UNREACHABLE: rcs < 0').stack)
-        }
-      }
-      if (this.destroying) {
-        await this.destroying
-      }
-      this.destroyed = true
-      this.destroying = null
-      return null
-    }
-  }
-
-  onDrop(): void {
-    this.destroy()
+    this.imageId = image.imageId
+    this.sharedRun = image.sharedRun ?? false
+    this.mounts = mounts
+    this.name = name
   }
 
   /**
-   * @description run a command inside this subcontainer
-   * DOES NOT THROW ON NONZERO EXIT CODE (see execFail)
-   * @param commands an array representing the command and args to execute
-   * @param options
-   * @param timeoutMs how long to wait before killing the command in ms
-   * @returns
+   * Materialize the underlying eager subcontainer (idempotent) and return
+   * it. Subsequent calls return the same instance. Useful when you need
+   * the synchronous `SubContainerEager` interface (e.g. sync `rootfs` /
+   * `subpath()`) — for ordinary command execution, just call `.exec()` /
+   * `.writeFile()` directly and the lazy handle materializes internally.
    */
+  eager(): Promise<SubContainerEager<Manifest, Effects>> {
+    return (this.materialized ??= SubContainerEager._of<Manifest, Effects>(
+      this.effects,
+      { imageId: this.imageId, sharedRun: this.sharedRun },
+      this.mounts,
+      this.name,
+      this.identity,
+    ).then(async (eager) => {
+      if (this.destroyPending) await eager.destroy()
+      return eager
+    }))
+  }
+
+  get rootfs(): Promise<string> {
+    return this.eager().then((e) => e.rootfs)
+  }
+
+  get guid(): Promise<T.Guid> {
+    return this.eager().then((e) => e.guid)
+  }
+
+  async subpath(path: string): Promise<string> {
+    return (await this.eager()).subpath(path)
+  }
+
+  async mount(mounts: MountsArg<Manifest, Effects>): Promise<this> {
+    await (await this.eager()).mount(mounts)
+    return this
+  }
+
+  hold(): () => Promise<void> {
+    // Acquire the hold on the eager once materialized. Until then we record
+    // a "pending" intent so destroy() honors any outstanding holds even on
+    // a never-materialized handle.
+    let released = false
+    let underlyingRelease: (() => Promise<void>) | null = null
+    const eagerPromise = this.eager()
+    const acquired = eagerPromise
+      .then((eager) => {
+        if (released) return
+        underlyingRelease = eager.hold()
+      })
+      .catch((e) => {
+        released = true
+        throw e
+      })
+    return async () => {
+      if (released) return
+      released = true
+      try {
+        await acquired
+      } catch (_) {
+        // materialization failed; nothing to release
+        return
+      }
+      if (underlyingRelease) await underlyingRelease()
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.destroyPending = true
+    if (this.materialized) await (await this.materialized).destroy()
+  }
+
   async exec(
     command: string[],
     options?: CommandOptions & ExecOptions,
-    timeoutMs?: number | null,
+    timeoutMs: number | null = 30000,
     abort?: AbortController,
   ): Promise<{
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
@@ -855,48 +888,32 @@ export class SubContainerRc<
     stdout: string | Buffer
     stderr: string | Buffer
   }> {
-    return this.subcontainer.exec(command, options, timeoutMs, abort)
+    return (await this.eager()).exec(command, options, timeoutMs, abort)
   }
 
-  /**
-   * @description run a command inside this subcontainer, throwing on non-zero exit status
-   * @param commands an array representing the command and args to execute
-   * @param options
-   * @param timeoutMs how long to wait before killing the command in ms
-   * @returns
-   */
   async execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
     timeoutMs?: number | null,
     abort?: AbortController,
-  ): Promise<{
-    stdout: string | Buffer
-    stderr: string | Buffer
-  }> {
-    return this.subcontainer.execFail(command, options, timeoutMs, abort)
+  ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> {
+    return (await this.eager()).execFail(command, options, timeoutMs, abort)
   }
 
   async launch(
     command: string[],
     options?: CommandOptions,
   ): Promise<cp.ChildProcessWithoutNullStreams> {
-    return this.subcontainer.launch(command, options)
+    return (await this.eager()).launch(command, options)
   }
 
   async spawn(
     command: string[],
-    options: CommandOptions & StdioOptions = { stdio: 'inherit' },
+    options?: CommandOptions & StdioOptions,
   ): Promise<cp.ChildProcess> {
-    return this.subcontainer.spawn(command, options)
+    return (await this.eager()).spawn(command, options)
   }
 
-  /**
-   * @description Write a file to the subcontainer's filesystem
-   * @param path Path relative to the subcontainer rootfs (e.g. "/etc/config.json")
-   * @param data The data to write
-   * @param options Optional write options (same as node:fs/promises writeFile)
-   */
   async writeFile(
     path: string,
     data:
@@ -906,30 +923,24 @@ export class SubContainerRc<
       | AsyncIterable<string | NodeJS.ArrayBufferView>,
     options?: Parameters<typeof fs.writeFile>[2],
   ): Promise<void> {
-    return this.subcontainer.writeFile(path, data, options)
+    return (await this.eager()).writeFile(path, data, options)
   }
 
-  rc(): SubContainerRc<Manifest, Effects> {
-    return this.subcontainer.rc()
-  }
-
-  isOwned(): this is SubContainerOwned<Manifest, Effects> {
-    return false
+  onDrop(): void {
+    if (this.materialized) {
+      this.materialized
+        .then((e) => e.destroy())
+        .catch((e) => console.error(e))
+    }
   }
 }
 
 export type CommandOptions = {
-  /**
-   * Environment variables to set for this command
-   */
+  /** Environment variables to set for this command */
   env?: { [variable in string]?: string }
-  /**
-   * the working directory to run this command in
-   */
+  /** the working directory to run this command in */
   cwd?: string
-  /**
-   * the user to run this command as
-   */
+  /** the user to run this command as */
   user?: string
 }
 
@@ -982,13 +993,15 @@ export type MountOptionsBackup = {
   filetype: 'file' | 'directory' | 'infer'
   idmap: { fromId: number; toId: number; range: number }[]
 }
+
 function wait(time: number) {
   return new Promise((resolve) => setTimeout(resolve, time))
 }
 
 /**
- * Error thrown when a subcontainer command exits with a non-zero code or signal.
- * Contains the full result including stdout, stderr, exit code, and exit signal.
+ * Error thrown when a subcontainer command exits with a non-zero code or
+ * signal. Contains the full result including stdout, stderr, exit code,
+ * and exit signal.
  */
 export class ExitError extends Error {
   constructor(

--- a/sdk/package/package-lock.json
+++ b/sdk/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.5.3",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "1.5.3",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -65,7 +65,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1777,7 +1776,6 @@
       "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2359,7 +2357,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3463,7 +3460,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -4611,7 +4607,6 @@
       "integrity": "sha512-n7chtCbEoGYRwZZ0i/O3t1cPr6o+d9Xx4Zwy2LYfzv0vjchMBU0tO+qYYyvZloBPcgRgzYvALzGWHe609JjEpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "commander": "^10.0.0",
         "source-map-generator": "0.8.0"
@@ -5348,7 +5343,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -5477,7 +5471,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5915,7 +5908,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/sdk/package/package.json
+++ b/sdk/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.5.3",
+  "version": "2.0.0",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./package/lib/index.js",
   "types": "./package/lib/index.d.ts",


### PR DESCRIPTION
## Summary

Adds `sdk.Daemons.dynamic(fn)` — a reactive `main` entrypoint whose daemon set is a function of on-disk state — plus the three breaking core changes the dynamic case wanted: lazy `SubContainer.of`, unified `SubContainer` (no Rc), and record-then-materialize `Daemons`. End state: one obvious way to express a daemon topology, static or reactive.

```ts
export const main = sdk.Daemons.dynamic(async ({ effects }) => {
  const { instances } = (await instancesYaml.read().const(effects)) ?? { instances: [] }
  let daemons = sdk.Daemons.of<Manifest>({ effects })
  for (const inst of instances) {
    daemons = daemons.addDaemon(`reg-${inst.id}`, {
      subcontainer: sdk.SubContainer.of(effects, { imageId: 'startos-registry', sharedRun: true },
        sdk.Mounts.of()
          .mountVolume({ volumeId: 'main', subpath: `/instances/${inst.id}/data`, mountpoint: '/var/lib/startos', readonly: false })
          .mountVolume({ volumeId: 'main', subpath: `/instances/${inst.id}/config.yaml`, mountpoint: '/etc/startos/config.yaml', readonly: false, type: 'file' }),
        `reg-${inst.id}-sub`,
      ),
      exec: { command: ['start-registryd'] },
      ready: { display: `Registry: ${inst.label}`, fn: () => sdk.healthCheck.checkPortListening(effects, inst.port, {}) },
      requires: [],
    })
  }
  return daemons
})
```

When `instances.yaml` is rewritten, the SDK reconciles automatically — per id: absent→present **start**, present→absent **stop**, same `configHash` **leave alone**, different `configHash` **restart**. Dependents of any restarted/stopped daemon are also restarted to keep `requires` wiring consistent. Re-runs coalesce while one is in flight. No service restart, no in-package supervisor.

`configHash` covers the subcontainer descriptor (`imageId`, `sharedRun`, `name`, structural `mounts.build()`), exec (`command`, `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`), `requires` (sorted), and the structural parts of `ready` (`display`, `gracePeriod`). Closures (`ready.fn`, `ready.trigger`, function-form `exec.fn`) and pre-built `Daemon` instances are intentionally excluded — an unrelated re-run (file touched, content unchanged) must not bounce every daemon. Authors surface a value through one of the hashed fields if they want the reconciler to react to it changing.

## Breaking changes (rolled into 2.0.0)

### 1. `sdk.SubContainer.of` is lazy by default

Returns a `SubContainerLazy<M>` *synchronously* (no `Promise<>` wrapper); `createFs` is deferred to first method call. The unified `SubContainer<M>` interface widens `rootfs` / `guid` / `subpath()` to `T | Promise<T>`; concrete classes narrow — `SubContainerEager` to `T`, `SubContainerLazy` to `Promise<T>`. A caller holding the generic interface must `await` those accessors; a caller holding `SubContainerEager` keeps sync access. New `sdk.SubContainer.eager(...)` returns `Promise<SubContainerEager<M>>` for the cases that need fail-fast on `createFs` or sync `rootfs` before any method call.

Identity (`Symbol('subcontainer')`) is generated at the lazy handle's construction and preserved across `eager()` materialization, so a lazy handle and the eager it materializes into compare equal via `identity`. The lazy default is what makes `Daemons.dynamic`'s "leave alone is load-bearing" guarantee actually load-bearing — unchanged daemons across reconciles never materialize a fresh subcontainer.

**Migration**: most callers only use async methods (`.exec`, `.writeFile`, `.spawn`, `.launch`) and need no change beyond optionally dropping the redundant `await` on `SubContainer.of(...)`. Callers that read `.rootfs` / `.guid` / `.subpath()` add an `await` or switch to `sdk.SubContainer.eager(...)`.

### 2. Unified `SubContainer` (no `Rc`)

`SubContainerOwned` and `SubContainerRc` collapse into `SubContainerEager` / `SubContainerLazy`. The reference-counted handle (`SubContainerRc`, `.rc()`, `.isOwned()`) is replaced by an internal hold count on the unified class. Multiple consumers each call `sub.hold()` (returns a release fn); the container's `destroyFs` fires when `destroy()` has been called *and* the last hold is released, in either order. `Daemon.start()` takes its own hold for the daemon's lifetime and releases it on `term()`. `Daemons.term()` calls `destroy()` on every unique subcontainer in its entries and the hold-count handles sharing safely. The `destroySubcontainer` flag on `Daemon.term` / `HealthDaemon.term` is gone. `Daemon.sharesSubcontainerWith` is gone (compare `daemon.subcontainer.identity` if you need to check).

### 3. Record-then-materialize `Daemons`

`.addDaemon()` / `.addOneshot()` / `.addHealthCheck()` append a recorded entry without constructing `HealthDaemon` / `Daemon` inline. `Daemons.build()` walks the entries and constructs the chain in one pass. Functionally identical for `setupMain` callers — nothing actually starts until `build()` runs `updateStatus()` either way. The change is load-bearing for `Daemons.dynamic`, which needs to diff entries without paying the cost of building them eagerly each reconcile.

## What's in this PR

- `sdk/package/lib/util/SubContainer.ts` — rewritten: unified `SubContainer<M>` interface with `T | Promise<T>` accessors; `SubContainerEager` (today's `SubContainerOwned`, renamed, with hold/destroy semantics) and `SubContainerLazy` (new wrapper); `SubContainer.of` (lazy default), `SubContainer.eager`, `SubContainer.withTemp` static factories; `identity: symbol` threaded through.
- `sdk/package/lib/mainFn/Daemons.ts` — recorder mode (entries[] instead of inline HealthDaemons); new `Daemons.dynamic(fn)` and `DaemonsReconciler` with diff/start/stop/restart, dependent dirtying, in-flight coalescing, ordered shutdown, eager-in-dynamic runtime check; `configHash(entry)` canonical-JSON hash over structural args.
- `sdk/package/lib/mainFn/Daemon.ts` — no `.rc()`/`markManaged`/`sharesSubcontainerWith`; public `daemon.subcontainer`; takes its own `hold()` in `start()`, releases in `term()`; no `destroySubcontainer` flag.
- `sdk/package/lib/mainFn/Oneshot.ts`, `HealthDaemon.ts`, `CommandController.ts` — adjusted for the new SubContainer/Daemon shape; CommandController no longer destroys the subcontainer on command exit (Daemon owns the lifetime).
- `sdk/package/lib/backup/Backups.ts` — `SubContainerRc.withTemp` → `SubContainer.withTemp`.
- `sdk/package/lib/StartSdk.ts` — `sdk.SubContainer.of` (lazy), `sdk.SubContainer.eager`, `sdk.Daemons.dynamic`.
- `sdk/package/lib/index.ts` — re-exports.
- `sdk/package/lib/test/Daemons.test.ts` — 15 unit tests covering the recorder, `configHash` stability/sensitivity (image, command, env, mounts, requires, display, kind, command-form), and lazy `identity` preservation.
- `container-runtime/src/Adapters/Systems/SystemForEmbassy/{DockerProcedureContainer,MainLoop}.ts` — `SubContainerOwned` → `SubContainer.eager`; `SubContainerRc<M>` → `SubContainer<M>`; `daemon.subcontainerRc()` → `daemon.subcontainer`.
- `sdk/package/package.json` — version `2.0.0`.
- `sdk/CHANGELOG.md` — full breaking-change callout under `## 2.0.0`.
- `sdk/ARCHITECTURE.md` — updated daemon-management + new SubContainer flavors section.

## What's NOT in this PR

- Integration tests against a real `SubContainerEager` / `HealthDaemon` runtime — would need either a live StartOS host or fakes for the full SubContainer + Effects surface. The added unit tests cover the load-bearing piece (`configHash` stability/sensitivity) and the recorder + lazy identity behavior. The reconciler itself is exercised by code review.
- Migration of in-tree service-package callers reading `.rootfs` / `.guid` / `.subpath()` from generic-interface locals. They'll typecheck if the locals are explicitly `SubContainerEager`; otherwise they need a one-line `await`. None of the in-tree code hit this in the typecheck pass.

## Test plan

- [x] `cd sdk/package && npm run check` — typecheck clean
- [x] `cd sdk/base && npm run check` — typecheck clean
- [x] `cd sdk/package && npx jest` — 57 / 57 pass (15 new in `Daemons.test.ts`)
- [x] `cd sdk/base && npx jest` — 73 / 73 pass (9 pre-existing skipped)
- [x] `make baseDist dist` — bundle builds; `dist/package/lib/util/SubContainer.{js,d.ts}` + `dist/package/lib/mainFn/Daemons.{js,d.ts}` produced
- [x] `cd container-runtime && npx tsc --noEmit` against the local dist — clean
- [ ] Integration: drive `Daemons.dynamic` against `instances.yaml` in the registry-portal s9pk (M2 of the [portal plan](https://github.com/Start9Labs/startos-registry-startos/blob/feature/portal/portal/PLAN.md)) — out of scope for this PR

## Discussion thread

- Single API surface vs separate `DaemonsPlan` — decided to unify
- Lazy `SubContainer.of` default vs opt-in `.lazy` — went aggressive
- Promise-union interface vs throw-or-ensure — chose the union
- `SubContainerRc` collapse — gone, replaced by `hold()` / `destroy()`
- Identity preserved across materialization — yes, threaded through

Sized for the 2.0 major bump (`@start9labs/start-sdk@2.0.0`).