### PR TITLE
fix(sdk): stop mysqld with a zombie-aware wait, not `tail --pid` (1.5.3)

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.3 — StartOS 0.4.0-beta.9 (2026-05-20)
+
+### Fixed
+
+- `Backups.withMysqlDump` no longer wedges the entire backup (and the StartOS host) on the database-shutdown step. After the dump it stopped mysqld with `kill $PID && tail --pid=$PID -f /dev/null`, but the daemonized (mysql) / backgrounded (mariadb) mysqld is never reaped in the dump subcontainer, so it lingers as a zombie that keeps its PID and `tail --pid` waited on it forever. The subcontainer was then never torn down and the backup hung until the box was rebooted — often surfacing afterward as a misleading `ENOTCONN … mkdir` notification as mounts were unwound under the stuck operation. Shutdown now waits for mysqld to reach the zombie (`Z`) state or vanish (treating either as "exited"), with a bounded SIGKILL fallback so it can never deadlock again. Applies to both backup and restore. `withPgDump` was unaffected (it uses `pg_ctl stop -w`, which reaps cleanly). The `withMysqlDump` packages (ghost, mempool) should rebuild against this SDK
+
 ## 1.5.2 — StartOS 0.4.0-beta.9 (2026-05-15)
 
 ### Fixed

--- a/sdk/package/lib/backup/Backups.ts
+++ b/sdk/package/lib/backup/Backups.ts
@@ -270,10 +270,9 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             // Stage the dump off the FUSE before pg_restore reads it — see
             // the comment on `tmpDumpFile` above.
             await sub.execFail(['cp', dumpFile, tmpDumpFile], { user: 'root' })
-            await sub.execFail(
-              ['chown', 'postgres:postgres', tmpDumpFile],
-              { user: 'root' },
-            )
+            await sub.execFail(['chown', 'postgres:postgres', tmpDumpFile], {
+              user: 'root',
+            })
             await sub.execFail(
               ['chown', '-R', 'postgres:postgres', mountpoint],
               { user: 'root' },
@@ -411,6 +410,36 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       }
     }
 
+    async function stopMysql(sub: {
+      exec(cmd: string[], opts?: any): Promise<{ exitCode: number | null }>
+      execFail(cmd: string[], opts?: any, timeout?: number | null): Promise<any>
+    }) {
+      // SIGTERM mysqld and wait for it to finish flushing before teardown.
+      // A killed-but-unreaped mysqld lingers as a zombie that keeps its PID,
+      // so `tail --pid`/`kill -0` would block here forever — treat the zombie
+      // ('Z') state, or a vanished PID, as "fully exited". Bounded SIGKILL
+      // fallback guarantees we can never deadlock the backup.
+      await sub.execFail(
+        [
+          'sh',
+          '-c',
+          [
+            'PID="$(cat /var/run/mysqld/mysqld.pid)"',
+            'kill "$PID" 2>/dev/null || exit 0',
+            'i=0',
+            'while [ -e "/proc/$PID" ]; do',
+            '  case "$(cut -d" " -f3 "/proc/$PID/stat" 2>/dev/null)" in Z|"") break ;; esac',
+            '  i=$((i + 1))',
+            '  [ "$i" -ge 600 ] && { kill -9 "$PID" 2>/dev/null; break; }',
+            '  sleep 0.2',
+            'done',
+          ].join('\n'),
+        ],
+        { user: 'root' },
+        null,
+      )
+    }
+
     return new Backups<M>()
       .setPreBackup(async (effects) => {
         const pw = await resolvePassword(password)
@@ -456,16 +485,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
               null,
             )
             await sub.execFail(['cp', tmpDumpFile, dumpFile], { user: 'root' })
-            // Graceful shutdown via SIGTERM; wait for exit
-            await sub.execFail(
-              [
-                'sh',
-                '-c',
-                'PID=$(cat /var/run/mysqld/mysqld.pid) && kill $PID && tail --pid=$PID -f /dev/null',
-              ],
-              { user: 'root' },
-              null,
-            )
+            await stopMysql(sub)
           },
         )
       })
@@ -531,16 +551,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
               { user: 'root' },
               null,
             )
-            // Graceful shutdown via SIGTERM; wait for exit
-            await sub.execFail(
-              [
-                'sh',
-                '-c',
-                'PID=$(cat /var/run/mysqld/mysqld.pid) && kill $PID && tail --pid=$PID -f /dev/null',
-              ],
-              { user: 'root' },
-              null,
-            )
+            await stopMysql(sub)
           },
         )
       })

--- a/sdk/package/package-lock.json
+++ b/sdk/package/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",

--- a/sdk/package/package.json
+++ b/sdk/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./package/lib/index.js",
   "types": "./package/lib/index.d.ts",


### PR DESCRIPTION
## Summary

`Backups.withMysqlDump` could hang the entire backup — and the StartOS host — at the database-shutdown step, requiring a reboot to recover.

After dumping, it stopped mysqld with `kill $PID && tail --pid=$PID -f /dev/null`. The daemonized (mysql) / backgrounded (mariadb) mysqld is never reaped inside the dump subcontainer, so it lingers as a **zombie** that keeps its PID — and `tail --pid` waits forever for a PID that never disappears. The dump subcontainer is then never torn down and the backup wedges indefinitely, often surfacing afterward as a misleading `ENOTCONN … mkdir '/media/startos/backup/...'` notification as mounts are unwound under the stuck operation on reboot.

Deterministic and independent of network/disk/DB size — reproduced backing up a fresh, near-empty Ghost to a local USB disk.

## Fix

Replace the `kill`+`tail --pid` shutdown with a wait that treats the zombie (`Z`) state — or a vanished PID — as "exited", with a bounded SIGKILL fallback so it can never deadlock again. Applied to both backup and restore via a shared `stopMysql` helper.

`withPgDump` was unaffected (it uses `pg_ctl stop -w`, which reaps cleanly).

Ships as start-sdk **1.5.3** (already published to npm); the affected packages (ghost, mempool) have been rebuilt against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)