### PR TITLE
feat(s9pk): add init-workspace and init-package commands

### DIFF
--- a/core/locales/i18n.yaml
+++ b/core/locales/i18n.yaml
@@ -140,6 +140,70 @@ bins.tunnel.error-updating-webserver-bind:
   fr_FR: "erreur lors de la mise à jour de la liaison du serveur web : %{error}"
   pl_PL: "błąd podczas aktualizacji powiązania serwera WWW: %{error}"
 
+# s9pk/init.rs
+s9pk.init.cloning-start-docs:
+  en_US: "Cloning the packaging guide (start-docs)…"
+  de_DE: "Paketierungsleitfaden (start-docs) wird geklont…"
+  es_ES: "Clonando la guía de empaquetado (start-docs)…"
+  fr_FR: "Clonage du guide d'empaquetage (start-docs)…"
+  pl_PL: "Klonowanie przewodnika pakowania (start-docs)…"
+
+s9pk.init.installing-deps:
+  en_US: "Installing dependencies (npm install)…"
+  de_DE: "Abhängigkeiten werden installiert (npm install)…"
+  es_ES: "Instalando dependencias (npm install)…"
+  fr_FR: "Installation des dépendances (npm install)…"
+  pl_PL: "Instalowanie zależności (npm install)…"
+
+s9pk.init.invalid-package-name:
+  en_US: "Cannot derive a valid package ID from \"%{name}\". Use a name containing letters or digits."
+  de_DE: "Aus „%{name}“ lässt sich keine gültige Paket-ID ableiten. Verwende einen Namen mit Buchstaben oder Ziffern."
+  es_ES: "No se puede derivar un ID de paquete válido de «%{name}». Usa un nombre que contenga letras o dígitos."
+  fr_FR: "Impossible de dériver un ID de paquet valide à partir de « %{name} ». Utilisez un nom contenant des lettres ou des chiffres."
+  pl_PL: "Nie można utworzyć prawidłowego identyfikatora pakietu z „%{name}”. Użyj nazwy zawierającej litery lub cyfry."
+
+s9pk.init.nested-workspace:
+  en_US: "Cannot create a workspace inside an existing one (found %{path})."
+  de_DE: "Ein Arbeitsbereich kann nicht innerhalb eines bestehenden erstellt werden (gefunden: %{path})."
+  es_ES: "No se puede crear un espacio de trabajo dentro de uno existente (se encontró %{path})."
+  fr_FR: "Impossible de créer un espace de travail à l'intérieur d'un autre (trouvé : %{path})."
+  pl_PL: "Nie można utworzyć obszaru roboczego wewnątrz istniejącego (znaleziono %{path})."
+
+s9pk.init.not-in-workspace:
+  en_US: "Not inside a packaging workspace. Run `start-cli s9pk init-workspace` first."
+  de_DE: "Nicht innerhalb eines Paketierungs-Arbeitsbereichs. Führe zuerst `start-cli s9pk init-workspace` aus."
+  es_ES: "No estás dentro de un espacio de trabajo de empaquetado. Ejecuta primero `start-cli s9pk init-workspace`."
+  fr_FR: "Vous n'êtes pas dans un espace de travail d'empaquetage. Exécutez d'abord `start-cli s9pk init-workspace`."
+  pl_PL: "Nie jesteś w obszarze roboczym pakowania. Najpierw uruchom `start-cli s9pk init-workspace`."
+
+s9pk.init.package-created:
+  en_US: "Created %{id} at %{path}. Next: work the checklist in TODO.md."
+  de_DE: "%{id} wurde unter %{path} erstellt. Nächster Schritt: Arbeite die Checkliste in TODO.md ab."
+  es_ES: "Se creó %{id} en %{path}. Siguiente: completa la lista de tareas en TODO.md."
+  fr_FR: "%{id} créé dans %{path}. Étape suivante : suivez la liste de tâches dans TODO.md."
+  pl_PL: "Utworzono %{id} w %{path}. Następnie: wykonaj listę zadań w TODO.md."
+
+s9pk.init.package-exists:
+  en_US: "%{path} already exists; choose a different name or remove it."
+  de_DE: "%{path} existiert bereits; wähle einen anderen Namen oder entferne es."
+  es_ES: "%{path} ya existe; elige otro nombre o elimínalo."
+  fr_FR: "%{path} existe déjà ; choisissez un autre nom ou supprimez-le."
+  pl_PL: "%{path} już istnieje; wybierz inną nazwę lub usuń je."
+
+s9pk.init.template-missing:
+  en_US: "Package template not found at %{path}. Re-run `start-cli s9pk init-workspace` to restore start-docs."
+  de_DE: "Paketvorlage unter %{path} nicht gefunden. Führe `start-cli s9pk init-workspace` erneut aus, um start-docs wiederherzustellen."
+  es_ES: "No se encontró la plantilla de paquete en %{path}. Vuelve a ejecutar `start-cli s9pk init-workspace` para restaurar start-docs."
+  fr_FR: "Modèle de paquet introuvable à %{path}. Relancez `start-cli s9pk init-workspace` pour restaurer start-docs."
+  pl_PL: "Nie znaleziono szablonu pakietu w %{path}. Uruchom ponownie `start-cli s9pk init-workspace`, aby przywrócić start-docs."
+
+s9pk.init.workspace-ready:
+  en_US: "Packaging workspace ready at %{path}. Next: start-cli s9pk init-package \"<Name>\"."
+  de_DE: "Paketierungs-Arbeitsbereich bereit unter %{path}. Nächster Schritt: start-cli s9pk init-package \"<Name>\"."
+  es_ES: "Espacio de trabajo de empaquetado listo en %{path}. Siguiente: start-cli s9pk init-package \"<Nombre>\"."
+  fr_FR: "Espace de travail d'empaquetage prêt à %{path}. Étape suivante : start-cli s9pk init-package \"<Nom>\"."
+  pl_PL: "Obszar roboczy pakowania gotowy w %{path}. Następnie: start-cli s9pk init-package \"<Nazwa>\"."
+
 # setup.rs
 setup.opening-data-drive:
   en_US: "Opening data drive"
@@ -2364,6 +2428,13 @@ context.cli.cannot-set-url-scheme:
   fr_FR: "Impossible de définir le schéma d'URL"
   pl_PL: "Nie można ustawić schematu URL"
 
+context.cli.unknown-profile-or-url:
+  en_US: "'%{value}' is not a known profile or a valid URL"
+  de_DE: "„%{value}“ ist kein bekanntes Profil und keine gültige URL"
+  es_ES: "«%{value}» no es un perfil conocido ni una URL válida"
+  fr_FR: "« %{value} » n'est pas un profil connu ni une URL valide"
+  pl_PL: "„%{value}” nie jest znanym profilem ani prawidłowym adresem URL"
+
 # context/rpc.rs
 context.rpc.rpc-context-dropped:
   en_US: "RpcContext is dropped"
@@ -3655,6 +3726,13 @@ help.arg.workdir-path:
   fr_FR: "Chemin du répertoire de travail"
   pl_PL: "Ścieżka katalogu roboczego"
 
+help.arg.workspace-path:
+  en_US: "Workspace directory to create or initialize (default: current directory)"
+  de_DE: "Zu erstellendes oder zu initialisierendes Arbeitsbereichsverzeichnis (Standard: aktuelles Verzeichnis)"
+  es_ES: "Directorio del espacio de trabajo a crear o inicializar (predeterminado: directorio actual)"
+  fr_FR: "Répertoire de l'espace de travail à créer ou initialiser (par défaut : répertoire courant)"
+  pl_PL: "Katalog obszaru roboczego do utworzenia lub zainicjowania (domyślnie: bieżący katalog)"
+
 help.arg.action-id:
   en_US: "Action identifier"
   de_DE: "Aktions-Kennung"
@@ -3969,6 +4047,13 @@ help.arg.os-drive-path:
   es_ES: "Ruta a la unidad del sistema operativo"
   fr_FR: "Chemin vers le disque du système d'exploitation"
   pl_PL: "Ścieżka do dysku systemu operacyjnego"
+
+help.arg.package-display-name:
+  en_US: "Human-readable package name (e.g. \"Hello World\")"
+  de_DE: "Menschenlesbarer Paketname (z. B. „Hello World“)"
+  es_ES: "Nombre de paquete legible (p. ej. «Hello World»)"
+  fr_FR: "Nom de paquet lisible (par ex. « Hello World »)"
+  pl_PL: "Czytelna nazwa pakietu (np. „Hello World”)"
 
 help.arg.package-id:
   en_US: "Package identifier"
@@ -5175,6 +5260,13 @@ about.indicate-gateway-inbound-access-from-wan:
   fr_FR: "Indiquer l'accès entrant de la passerelle depuis le WAN"
   pl_PL: "Wskaż dostęp przychodzący bramy z WAN"
 
+about.initialize-a-packaging-workspace:
+  en_US: "Initialize a StartOS packaging workspace"
+  de_DE: "Einen StartOS-Paketierungs-Arbeitsbereich initialisieren"
+  es_ES: "Inicializar un espacio de trabajo de empaquetado de StartOS"
+  fr_FR: "Initialiser un espace de travail d'empaquetage StartOS"
+  pl_PL: "Zainicjuj obszar roboczy pakowania StartOS"
+
 about.initialize-webserver:
   en_US: "Initialize the webserver"
   de_DE: "Webserver initialisieren"
@@ -5776,6 +5868,13 @@ about.run-service-action:
   es_ES: "Ejecutar una acción de servicio"
   fr_FR: "Exécuter une action de service"
   pl_PL: "Uruchom akcję usługi"
+
+about.scaffold-a-new-package-from-template:
+  en_US: "Scaffold a new package from the workspace template"
+  de_DE: "Ein neues Paket aus der Arbeitsbereichsvorlage erzeugen"
+  es_ES: "Generar un nuevo paquete a partir de la plantilla del espacio de trabajo"
+  fr_FR: "Générer un nouveau paquet à partir du modèle de l'espace de travail"
+  pl_PL: "Utwórz nowy pakiet z szablonu obszaru roboczego"
 
 about.set-address-enabled-for-binding:
   en_US: "Set a gateway address enabled for a binding"

--- a/core/src/context/cli.rs
+++ b/core/src/context/cli.rs
@@ -84,7 +84,7 @@ impl CliContext {
     pub fn init(config: ClientConfig) -> Result<Self, Error> {
         // Resolve -H/-r (profile name or URL) against the workspace config, falling
         // back to a literal URL, then to localhost / no registry when unset.
-        let workspace = WorkspaceConfig::find();
+        let workspace = WorkspaceConfig::find()?;
         let mut url =
             match resolve_target(config.host.as_deref(), workspace.as_ref().map(|w| &w.host))? {
                 Some(url) => url,
@@ -210,7 +210,9 @@ impl CliContext {
         let mut dir = std::env::current_dir().with_kind(ErrorKind::Filesystem)?;
         loop {
             let candidate = dir.join(STARTOS_DIR).join(BUILD_KEY_FILE);
-            if candidate.exists() {
+            // `try_exists` (unlike `exists`) surfaces EACCES on an inaccessible
+            // ancestor as an error instead of reporting `false` and walking past it.
+            if candidate.try_exists()? {
                 return load_signing_key(candidate);
             }
             if !dir.pop() {

--- a/core/src/context/cli.rs
+++ b/core/src/context/cli.rs
@@ -210,18 +210,23 @@ impl CliContext {
         let mut dir = std::env::current_dir().with_kind(ErrorKind::Filesystem)?;
         loop {
             let candidate = dir.join(STARTOS_DIR).join(BUILD_KEY_FILE);
-            // `try_exists` (unlike `exists`) surfaces EACCES on an inaccessible
-            // ancestor as an error instead of reporting `false` and walking past it.
-            if candidate.try_exists()? {
-                return load_signing_key(candidate);
+            // EACCES on an inaccessible ancestor (or any other IO error) is treated
+            // as "no accessible workspace here" — stop walking rather than either
+            // silently stepping past it (`exists()`) or surfacing the error
+            // (`try_exists()?`).
+            match candidate.try_exists() {
+                Ok(true) => return load_signing_key(candidate),
+                Ok(false) => {}
+                Err(_) => break,
             }
             if !dir.pop() {
-                return Err(Error::new(
-                    eyre!("{}", t!("s9pk.init.not-in-workspace")),
-                    ErrorKind::Uninitialized,
-                ));
+                break;
             }
         }
+        Err(Error::new(
+            eyre!("{}", t!("s9pk.init.not-in-workspace")),
+            ErrorKind::Uninitialized,
+        ))
     }
 
     pub async fn ws_continuation(

--- a/core/src/context/cli.rs
+++ b/core/src/context/cli.rs
@@ -22,12 +22,13 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 use tracing::instrument;
 
 use super::setup::CURRENT_SECRET;
-use crate::context::config::{ClientConfig, local_config_path};
+use crate::context::config::{ClientConfig, WorkspaceConfig, local_config_path, resolve_target};
 use crate::context::{DiagnosticContext, InitContext, RpcContext, SetupContext};
-use crate::developer::{OS_DEVELOPER_KEY_PATH, default_developer_key_path};
+use crate::developer::{OS_DEVELOPER_KEY_PATH, default_developer_key_path, load_signing_key};
 use crate::middleware::auth::local::LocalAuthContext;
 use crate::prelude::*;
 use crate::rpc_continuations::Guid;
+use crate::s9pk::init::{BUILD_KEY_FILE, STARTOS_DIR};
 use crate::util::io::read_file_to_string;
 
 #[derive(Debug)]
@@ -81,13 +82,19 @@ impl CliContext {
     /// BLOCKING
     #[instrument(skip_all)]
     pub fn init(config: ClientConfig) -> Result<Self, Error> {
-        let mut url = if let Some(host) = config.host {
-            host
-        } else {
-            "http://localhost".parse()?
-        };
+        // Resolve -H/-r (profile name or URL) against the workspace config, falling
+        // back to a literal URL, then to localhost / no registry when unset.
+        let workspace = WorkspaceConfig::find();
+        let mut url =
+            match resolve_target(config.host.as_deref(), workspace.as_ref().map(|w| &w.host))? {
+                Some(url) => url,
+                None => "http://localhost".parse()?,
+            };
 
-        let registry = config.registry.clone();
+        let registry = resolve_target(
+            config.registry.as_deref(),
+            workspace.as_ref().map(|w| &w.registry),
+        )?;
 
         let cookie_path = config.cookie_path.unwrap_or_else(|| {
             local_config_path()
@@ -193,6 +200,26 @@ impl CliContext {
                 crate::ErrorKind::Uninitialized,
             ))
         })
+    }
+
+    /// The workspace's s9pk signing key. Walks up from cwd for `.startos/build-key`
+    /// (created by `s9pk init-workspace`) and errors if there's no workspace, since
+    /// s9pk signing is workspace-scoped. Distinct from [`Self::developer_key`], which
+    /// stays the global identity for registry/server auth.
+    pub fn build_key(&self) -> Result<ed25519_dalek::SigningKey, Error> {
+        let mut dir = std::env::current_dir().with_kind(ErrorKind::Filesystem)?;
+        loop {
+            let candidate = dir.join(STARTOS_DIR).join(BUILD_KEY_FILE);
+            if candidate.exists() {
+                return load_signing_key(candidate);
+            }
+            if !dir.pop() {
+                return Err(Error::new(
+                    eyre!("{}", t!("s9pk.init.not-in-workspace")),
+                    ErrorKind::Uninitialized,
+                ));
+            }
+        }
     }
 
     pub async fn ws_continuation(

--- a/core/src/context/config.rs
+++ b/core/src/context/config.rs
@@ -151,8 +151,8 @@ impl WorkspaceConfig {
     /// Walk up from cwd for the nearest `.startos/config.yaml` that parses as a
     /// workspace config. A flat config (no `schema`) fails to parse and is skipped,
     /// so the walk continues — preserving the global fallback when there's none.
-    /// An EACCES (or other non-NotFound) error on a candidate is surfaced rather
-    /// than swallowed, so an unreadable workspace can't masquerade as absent.
+    /// EACCES (or any other IO error) on a candidate stops the walk and reports
+    /// no workspace; an inaccessible ancestor isn't surfaced as an error.
     pub fn find() -> Result<Option<Self>, Error> {
         let mut dir = std::env::current_dir()?;
         loop {
@@ -166,7 +166,7 @@ impl WorkspaceConfig {
                     // config) — keep walking up.
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => return Err(e.into()),
+                Err(_) => return Ok(None),
             }
             if !dir.pop() {
                 return Ok(None);

--- a/core/src/context/config.rs
+++ b/core/src/context/config.rs
@@ -151,17 +151,25 @@ impl WorkspaceConfig {
     /// Walk up from cwd for the nearest `.startos/config.yaml` that parses as a
     /// workspace config. A flat config (no `schema`) fails to parse and is skipped,
     /// so the walk continues — preserving the global fallback when there's none.
-    pub fn find() -> Option<Self> {
-        let mut dir = std::env::current_dir().ok()?;
+    /// An EACCES (or other non-NotFound) error on a candidate is surfaced rather
+    /// than swallowed, so an unreadable workspace can't masquerade as absent.
+    pub fn find() -> Result<Option<Self>, Error> {
+        let mut dir = std::env::current_dir()?;
         loop {
             let candidate = dir.join(".startos").join("config.yaml");
-            if let Ok(file) = File::open(&candidate) {
-                if let Ok(config) = IoFormat::Yaml.from_reader::<_, Self>(file) {
-                    return Some(config);
+            match File::open(&candidate) {
+                Ok(file) => {
+                    if let Ok(config) = IoFormat::Yaml.from_reader::<_, Self>(file) {
+                        return Ok(Some(config));
+                    }
+                    // Present but not a workspace config (e.g. the legacy flat
+                    // config) — keep walking up.
                 }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
             }
             if !dir.pop() {
-                return None;
+                return Ok(None);
             }
         }
     }

--- a/core/src/context/config.rs
+++ b/core/src/context/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -60,10 +61,12 @@ pub trait ContextConfig: DeserializeOwned + Default {
 pub struct ClientConfig {
     #[arg(short = 'c', long, help = "help.arg.config-file-path")]
     pub config: Option<PathBuf>,
+    /// A `host` profile name from the workspace `.startos/config.yaml`, or a URL.
     #[arg(short = 'H', long, help = "help.arg.host-url")]
-    pub host: Option<Url>,
+    pub host: Option<String>,
+    /// A `registry` profile name from the workspace `.startos/config.yaml`, or a URL.
     #[arg(short = 'r', long, help = "help.arg.registry-url")]
-    pub registry: Option<Url>,
+    pub registry: Option<String>,
     #[arg(long, help = "help.arg.registry-hostname")]
     pub registry_hostname: Option<Vec<InternedString>>,
     #[arg(skip)]
@@ -127,6 +130,67 @@ impl ClientConfig {
         self.load_path_rec(local_config_path())?;
         self.load_path_rec(Some(CONFIG_PATH))?;
         Ok(self)
+    }
+}
+
+/// Per-workspace config (`.startos/config.yaml`), discovered by walking up from
+/// cwd. Unlike the flat global config it carries named `host`/`registry` profiles.
+/// The required `schema` field is what distinguishes it from the legacy flat
+/// `~/.startos/config.yaml` (which has no `schema`, so it's skipped here and still
+/// loaded the old way).
+#[derive(Debug, Default, Deserialize)]
+pub struct WorkspaceConfig {
+    #[allow(dead_code)]
+    pub schema: u64,
+    #[serde(default)]
+    pub host: BTreeMap<String, Url>,
+    #[serde(default)]
+    pub registry: BTreeMap<String, Url>,
+}
+impl WorkspaceConfig {
+    /// Walk up from cwd for the nearest `.startos/config.yaml` that parses as a
+    /// workspace config. A flat config (no `schema`) fails to parse and is skipped,
+    /// so the walk continues — preserving the global fallback when there's none.
+    pub fn find() -> Option<Self> {
+        let mut dir = std::env::current_dir().ok()?;
+        loop {
+            let candidate = dir.join(".startos").join("config.yaml");
+            if let Ok(file) = File::open(&candidate) {
+                if let Ok(config) = IoFormat::Yaml.from_reader::<_, Self>(file) {
+                    return Some(config);
+                }
+            }
+            if !dir.pop() {
+                return None;
+            }
+        }
+    }
+}
+
+/// Resolve a `-H`/`-r` value against a profile map: a profile-name match first,
+/// then a literal URL, else an error. A missing value falls back to the `default`
+/// profile, or `None` when there's no workspace config (keeping the global fallback).
+pub fn resolve_target(
+    value: Option<&str>,
+    profiles: Option<&BTreeMap<String, Url>>,
+) -> Result<Option<Url>, Error> {
+    match value {
+        Some(value) => {
+            if let Some(url) = profiles.and_then(|p| p.get(value)) {
+                Ok(Some(url.clone()))
+            } else if let Ok(url) = Url::parse(value) {
+                Ok(Some(url))
+            } else {
+                Err(Error::new(
+                    eyre!(
+                        "{}",
+                        t!("context.cli.unknown-profile-or-url", value = value)
+                    ),
+                    ErrorKind::InvalidRequest,
+                ))
+            }
+        }
+        None => Ok(profiles.and_then(|p| p.get("default")).cloned()),
     }
 }
 

--- a/core/src/developer/mod.rs
+++ b/core/src/developer/mod.rs
@@ -43,6 +43,23 @@ pub async fn write_developer_key(
     Ok(())
 }
 
+/// Read counterpart to [`write_developer_key`]: load a PKCS#8 PEM ed25519 key
+/// (e.g. a workspace `.startos/build-key`) into a `SigningKey`.
+pub fn load_signing_key(path: impl AsRef<Path>) -> Result<SigningKey, Error> {
+    let path = path.as_ref();
+    let pair = <ed25519::KeypairBytes as ed25519::pkcs8::DecodePrivateKey>::from_pkcs8_pem(
+        &std::fs::read_to_string(path).with_ctx(|_| (ErrorKind::Filesystem, path.display()))?,
+    )
+    .with_kind(ErrorKind::Pem)?;
+    let secret = ed25519_dalek::SecretKey::try_from(&pair.secret_key[..]).map_err(|_| {
+        Error::new(
+            eyre!("{}", t!("context.cli.pkcs8-key-incorrect-length")),
+            ErrorKind::OpenSsl,
+        )
+    })?;
+    Ok(secret.into())
+}
+
 #[instrument(skip_all)]
 pub async fn init(ctx: CliContext) -> Result<(), Error> {
     if tokio::fs::metadata(OS_DEVELOPER_KEY_PATH).await.is_ok() {

--- a/core/src/s9pk/init.rs
+++ b/core/src/s9pk/init.rs
@@ -251,9 +251,9 @@ fn find_workspace_root(start: &Path) -> Result<Option<PathBuf>, Error> {
             // Present but not a directory — not a marker; keep walking up.
             Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-            // EACCES (or other non-NotFound) on an ancestor: surface it rather
-            // than reporting "no workspace" and silently walking past it.
-            Err(e) => return Err(e.into()),
+            // EACCES (or any other IO error) on an ancestor — treat as "no
+            // accessible workspace here" and stop walking.
+            Err(_) => return Ok(None),
         }
         if !dir.pop() {
             return Ok(None);

--- a/core/src/s9pk/init.rs
+++ b/core/src/s9pk/init.rs
@@ -90,7 +90,7 @@ pub async fn init_workspace(
 
     // Refuse nesting: a marker strictly above `root` would put a workspace inside a
     // workspace. A marker at `root` itself is just a re-run, which is allowed.
-    if let Some(outer) = root.parent().and_then(find_workspace_root) {
+    if let Some(outer) = root.parent().map(find_workspace_root).transpose()?.flatten() {
         return Err(Error::new(
             eyre!(
                 "{}",
@@ -174,7 +174,7 @@ pub async fn init_package(
     InitPackageParams { name }: InitPackageParams,
 ) -> Result<(), Error> {
     let cwd = std::env::current_dir().with_kind(ErrorKind::Filesystem)?;
-    let root = find_workspace_root(&cwd).ok_or_else(|| {
+    let root = find_workspace_root(&cwd)?.ok_or_else(|| {
         Error::new(
             eyre!("{}", t!("s9pk.init.not-in-workspace")),
             ErrorKind::InvalidRequest,
@@ -243,14 +243,20 @@ pub async fn init_package(
 /// Walk up from `start` (inclusive) for the nearest workspace — a directory
 /// containing a `.startos` dir. (start-cli's own config/key discovery walks up
 /// the same way; the outermost match may be the global `~/.startos`.)
-fn find_workspace_root(start: &Path) -> Option<PathBuf> {
+fn find_workspace_root(start: &Path) -> Result<Option<PathBuf>, Error> {
     let mut dir = start.to_path_buf();
     loop {
-        if dir.join(STARTOS_DIR).is_dir() {
-            return Some(dir);
+        match std::fs::metadata(dir.join(STARTOS_DIR)) {
+            Ok(meta) if meta.is_dir() => return Ok(Some(dir)),
+            // Present but not a directory — not a marker; keep walking up.
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            // EACCES (or other non-NotFound) on an ancestor: surface it rather
+            // than reporting "no workspace" and silently walking past it.
+            Err(e) => return Err(e.into()),
         }
         if !dir.pop() {
-            return None;
+            return Ok(None);
         }
     }
 }

--- a/core/src/s9pk/init.rs
+++ b/core/src/s9pk/init.rs
@@ -1,0 +1,352 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use clap::Parser;
+use ed25519_dalek::SigningKey;
+use futures::future::{BoxFuture, FutureExt};
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+use crate::PackageId;
+use crate::context::CliContext;
+use crate::developer::write_developer_key;
+use crate::prelude::*;
+use crate::util::Invoke;
+
+/// Per-workspace state directory, created at the workspace root. Its presence is
+/// the marker that both `init-package` and start-cli walk up from cwd to find;
+/// `schema` (in config.yaml) lets a future change migrate the contract.
+pub const STARTOS_DIR: &str = ".startos";
+/// Workspace-scoped ed25519 signing key (PKCS#8 PEM). Generated once and never
+/// overwritten — it signs the packages built in this workspace.
+pub const BUILD_KEY_FILE: &str = "build-key";
+/// Workspace config: named host and registry targets the packager switches
+/// between. Scaffolded with defaults; the `host` entries are placeholders to
+/// point at your own StartOS boxes.
+const CONFIG_FILE: &str = "config.yaml";
+const WORKSPACE_CONFIG_CONTENTS: &str = r#"schema: 1
+host:
+  default: https://dev-vm.local
+  prod: https://prodbox.local
+registry:
+  default: https://alpha-registry-x.start9.com
+  beta: https://beta-registry.start9.com
+  prod: https://registry.start9.com
+"#;
+
+/// Default source for the packaging guide (which also carries the package
+/// template). Re-point the `start-docs` remote afterward to track a fork; the
+/// session-start sync follows whatever remote is configured.
+const START_DOCS_URL: &str = "https://github.com/Start9Labs/start-docs.git";
+/// Workspace-relative path to the cloned guide.
+const START_DOCS_DIR: &str = "start-docs";
+/// Symlink target for the workspace `AGENTS.md` — the guide's canonical copy, so
+/// a sync keeps the workspace context current with no extra step.
+const AGENTS_SYMLINK_TARGET: &str = "start-docs/packaging/AGENTS.md";
+/// Path to the package template inside the cloned guide.
+const TEMPLATE_SUBPATH: &str = "packaging/package-template";
+
+/// Claude Code does not auto-read `AGENTS.md`, so the workspace `CLAUDE.md`
+/// imports both it and the user's local prefs.
+const CLAUDE_MD_CONTENTS: &str = "@AGENTS.md\n@AGENTS.local.md\n";
+
+/// Created once and never overwritten by a sync — the user's own context.
+const AGENTS_LOCAL_STUB: &str = r#"# AGENTS.local.md — your workspace preferences
+
+<!--
+Notes and preferences for AI assistants working in this workspace. This file is yours;
+syncing start-docs never overwrites it. Put anything you want always in scope here — the
+registry you publish to, the packages you're focused on, local conventions, and so on.
+-->
+"#;
+
+#[derive(Deserialize, Serialize, Parser)]
+#[group(skip)]
+pub struct InitWorkspaceParams {
+    #[arg(help = "help.arg.workspace-path")]
+    path: Option<PathBuf>,
+}
+
+/// Prepare a directory so any AI assistant working in it has the latest packaging
+/// context in scope. Clones the guide, links the context files, and provisions
+/// `.startos/` (a workspace signing key + target config). Idempotent: a re-run only
+/// fills in what's missing; updates to the guide happen via the session-start sync
+/// documented in `AGENTS.md`.
+pub async fn init_workspace(
+    _: CliContext,
+    InitWorkspaceParams { path }: InitWorkspaceParams,
+) -> Result<(), Error> {
+    let root = if let Some(path) = path {
+        path
+    } else {
+        std::env::current_dir().with_kind(ErrorKind::Filesystem)?
+    };
+    tokio::fs::create_dir_all(&root)
+        .await
+        .with_ctx(|_| (ErrorKind::Filesystem, root.display().to_string()))?;
+    let root = tokio::fs::canonicalize(&root)
+        .await
+        .with_ctx(|_| (ErrorKind::Filesystem, root.display().to_string()))?;
+
+    // Refuse nesting: a marker strictly above `root` would put a workspace inside a
+    // workspace. A marker at `root` itself is just a re-run, which is allowed.
+    if let Some(outer) = root.parent().and_then(find_workspace_root) {
+        return Err(Error::new(
+            eyre!(
+                "{}",
+                t!(
+                    "s9pk.init.nested-workspace",
+                    path = outer.display().to_string()
+                )
+            ),
+            ErrorKind::InvalidRequest,
+        ));
+    }
+
+    // Provision the guide. Clone only when absent — refreshing is the session-start
+    // sync's job, not this command's, so an existing checkout is left untouched.
+    let docs = root.join(START_DOCS_DIR);
+    if !docs.exists() {
+        eprintln!("{}", t!("s9pk.init.cloning-start-docs"));
+        Command::new("git")
+            .arg("clone")
+            .arg("--depth")
+            .arg("1")
+            .arg("--branch")
+            .arg("master")
+            .arg(START_DOCS_URL)
+            .arg(&docs)
+            .capture(false)
+            .invoke(ErrorKind::Git)
+            .await?;
+    }
+
+    // Symlink (not a copy) so a guide sync keeps the workspace AGENTS.md current.
+    // symlink_metadata treats a broken link as present, so a re-run never clobbers.
+    let agents = root.join("AGENTS.md");
+    if tokio::fs::symlink_metadata(&agents).await.is_err() {
+        tokio::fs::symlink(AGENTS_SYMLINK_TARGET, &agents)
+            .await
+            .with_ctx(|_| (ErrorKind::Filesystem, agents.display().to_string()))?;
+    }
+    write_if_absent(&root.join("AGENTS.local.md"), AGENTS_LOCAL_STUB).await?;
+    write_if_absent(&root.join("CLAUDE.md"), CLAUDE_MD_CONTENTS).await?;
+    // .startos/ is the workspace marker (see find_workspace_root) and holds the
+    // signing key + target config. Written last, so only a fully provisioned
+    // directory counts as a workspace. The build-key is generated once and never
+    // regenerated — overwriting it would change the workspace's signing identity.
+    let startos = root.join(STARTOS_DIR);
+    tokio::fs::create_dir_all(&startos)
+        .await
+        .with_ctx(|_| (ErrorKind::Filesystem, startos.display().to_string()))?;
+    write_if_absent(&startos.join(CONFIG_FILE), WORKSPACE_CONFIG_CONTENTS).await?;
+    let build_key = startos.join(BUILD_KEY_FILE);
+    if tokio::fs::symlink_metadata(&build_key).await.is_err() {
+        write_developer_key(
+            &SigningKey::generate(&mut ssh_key::rand_core::OsRng::default()),
+            &build_key,
+        )
+        .await?;
+    }
+
+    println!(
+        "{}",
+        t!(
+            "s9pk.init.workspace-ready",
+            path = root.display().to_string()
+        )
+    );
+    Ok(())
+}
+
+#[derive(Deserialize, Serialize, Parser)]
+#[group(skip)]
+pub struct InitPackageParams {
+    #[arg(help = "help.arg.package-display-name")]
+    name: String,
+}
+
+/// Scaffold a new package from the workspace's bundled template, interpolating the
+/// display name and a normalized ID, then `npm install` the result. Leaves a
+/// `TODO.md` worklist that drives the package from clone to release-ready.
+pub async fn init_package(
+    _: CliContext,
+    InitPackageParams { name }: InitPackageParams,
+) -> Result<(), Error> {
+    let cwd = std::env::current_dir().with_kind(ErrorKind::Filesystem)?;
+    let root = find_workspace_root(&cwd).ok_or_else(|| {
+        Error::new(
+            eyre!("{}", t!("s9pk.init.not-in-workspace")),
+            ErrorKind::InvalidRequest,
+        )
+    })?;
+
+    // Normalize to a candidate ID, then validate it through the manifest's own
+    // rules rather than re-implementing them.
+    let id = normalize_id(&name);
+    PackageId::from_str(&id).map_err(|_| {
+        Error::new(
+            eyre!(
+                "{}",
+                t!("s9pk.init.invalid-package-name", name = name.as_str())
+            ),
+            ErrorKind::InvalidId,
+        )
+    })?;
+
+    let dst = cwd.join(format!("{id}-startos"));
+    if dst.exists() {
+        return Err(Error::new(
+            eyre!(
+                "{}",
+                t!("s9pk.init.package-exists", path = dst.display().to_string())
+            ),
+            ErrorKind::InvalidRequest,
+        ));
+    }
+
+    let template = root.join(START_DOCS_DIR).join(TEMPLATE_SUBPATH);
+    if !template.exists() {
+        return Err(Error::new(
+            eyre!(
+                "{}",
+                t!(
+                    "s9pk.init.template-missing",
+                    path = template.display().to_string()
+                )
+            ),
+            ErrorKind::NotFound,
+        ));
+    }
+
+    copy_template_interpolated(&template, &dst, &id, &name).await?;
+
+    eprintln!("{}", t!("s9pk.init.installing-deps"));
+    Command::new("npm")
+        .arg("install")
+        .current_dir(&dst)
+        .capture(false)
+        .invoke(ErrorKind::Network)
+        .await?;
+
+    println!(
+        "{}",
+        t!(
+            "s9pk.init.package-created",
+            id = id,
+            path = dst.display().to_string()
+        )
+    );
+    Ok(())
+}
+
+/// Walk up from `start` (inclusive) for the nearest workspace — a directory
+/// containing a `.startos` dir. (start-cli's own config/key discovery walks up
+/// the same way; the outermost match may be the global `~/.startos`.)
+fn find_workspace_root(start: &Path) -> Option<PathBuf> {
+    let mut dir = start.to_path_buf();
+    loop {
+        if dir.join(STARTOS_DIR).is_dir() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// Normalize a human display name to a candidate package ID: lowercase ASCII
+/// alphanumerics, runs of whitespace/underscore/hyphen collapsed to a single
+/// hyphen, every other character dropped, no leading or trailing hyphen. Validity
+/// (non-empty, matches the manifest's ID rules) is the caller's check.
+fn normalize_id(name: &str) -> String {
+    let mut out = String::new();
+    let mut pending_sep = false;
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_sep && !out.is_empty() {
+                out.push('-');
+            }
+            pending_sep = false;
+            out.push(ch.to_ascii_lowercase());
+        } else if ch.is_whitespace() || ch == '_' || ch == '-' {
+            pending_sep = true;
+        }
+        // any other character is dropped without forcing a separator
+    }
+    out
+}
+
+/// Recursively copy `src` to `dst`, replacing `{{id}}`/`{{name}}` in text files.
+/// `{{id}}` is already validated as safe; `{{name}}` is escaped for TypeScript
+/// string literals when writing `.ts` files. Non-UTF-8 files are copied verbatim.
+fn copy_template_interpolated<'a>(
+    src: &'a Path,
+    dst: &'a Path,
+    id: &'a str,
+    name: &'a str,
+) -> BoxFuture<'a, Result<(), Error>> {
+    async move {
+        tokio::fs::create_dir_all(dst)
+            .await
+            .with_ctx(|_| (ErrorKind::Filesystem, dst.display().to_string()))?;
+        let mut entries = tokio::fs::read_dir(src)
+            .await
+            .with_ctx(|_| (ErrorKind::Filesystem, src.display().to_string()))?;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .with_kind(ErrorKind::Filesystem)?
+        {
+            let file_name = entry.file_name();
+            // Defensive: never carry build/VCS cruft into the scaffold.
+            if matches!(
+                file_name.to_str(),
+                Some("node_modules") | Some(".git") | Some("javascript")
+            ) {
+                continue;
+            }
+            let from = entry.path();
+            let to = dst.join(&file_name);
+            let file_type = entry.file_type().await.with_kind(ErrorKind::Filesystem)?;
+            if file_type.is_dir() {
+                copy_template_interpolated(&from, &to, id, name).await?;
+            } else if file_type.is_file() {
+                let bytes = tokio::fs::read(&from)
+                    .await
+                    .with_ctx(|_| (ErrorKind::Filesystem, from.display().to_string()))?;
+                let escape_for_ts = from.extension().and_then(|e| e.to_str()) == Some("ts");
+                let rendered = match String::from_utf8(bytes) {
+                    Ok(text) => interpolate(&text, id, name, escape_for_ts).into_bytes(),
+                    Err(e) => e.into_bytes(),
+                };
+                tokio::fs::write(&to, rendered)
+                    .await
+                    .with_ctx(|_| (ErrorKind::Filesystem, to.display().to_string()))?;
+            }
+            // symlinks (none expected in the template) are skipped
+        }
+        Ok(())
+    }
+    .boxed()
+}
+
+fn interpolate(content: &str, id: &str, name: &str, escape_for_ts: bool) -> String {
+    let name = if escape_for_ts {
+        name.replace('\\', "\\\\").replace('\'', "\\'")
+    } else {
+        name.to_owned()
+    };
+    content.replace("{{id}}", id).replace("{{name}}", &name)
+}
+
+/// Write `contents` to `path` only if nothing is there yet (a broken symlink
+/// counts as present, so a re-run never clobbers).
+async fn write_if_absent(path: &Path, contents: &str) -> Result<(), Error> {
+    if tokio::fs::symlink_metadata(path).await.is_err() {
+        tokio::fs::write(path, contents)
+            .await
+            .with_ctx(|_| (ErrorKind::Filesystem, path.display().to_string()))?;
+    }
+    Ok(())
+}

--- a/core/src/s9pk/mod.rs
+++ b/core/src/s9pk/mod.rs
@@ -1,4 +1,5 @@
 pub mod git_hash;
+pub mod init;
 pub mod merkle_archive;
 pub mod rpc;
 pub mod v1;

--- a/core/src/s9pk/rpc.rs
+++ b/core/src/s9pk/rpc.rs
@@ -53,6 +53,18 @@ pub fn s9pk() -> ParentHandler<CliContext> {
                 .with_about("about.list-paths-of-package-ingredients"),
         )
         .subcommand(
+            "init-workspace",
+            from_fn_async(super::init::init_workspace)
+                .no_display()
+                .with_about("about.initialize-a-packaging-workspace"),
+        )
+        .subcommand(
+            "init-package",
+            from_fn_async(super::init::init_package)
+                .no_display()
+                .with_about("about.scaffold-a-new-package-from-template"),
+        )
+        .subcommand(
             "edit",
             edit().with_about("about.commands-add-image-or-edit-manifest"),
         )
@@ -157,7 +169,7 @@ async fn add_image(
 ) -> Result<(), Error> {
     let mut s9pk = super::load(
         MultiCursorFile::from(open_file(&s9pk_path).await?),
-        || ctx.developer_key().cloned(),
+        || ctx.build_key(),
         None,
     )
     .await?;
@@ -190,7 +202,7 @@ async fn edit_manifest(
 ) -> Result<Manifest, Error> {
     let mut s9pk = super::load(
         MultiCursorFile::from(open_file(&s9pk_path).await?),
-        || ctx.developer_key().cloned(),
+        || ctx.build_key(),
         None,
     )
     .await?;
@@ -201,7 +213,7 @@ async fn edit_manifest(
     let tmp_path = s9pk_path.with_extension("s9pk.tmp");
     let mut tmp_file = create_file(&tmp_path).await?;
     s9pk.as_archive_mut()
-        .set_signer(ctx.developer_key()?.clone(), SIG_CONTEXT);
+        .set_signer(ctx.build_key()?, SIG_CONTEXT);
     s9pk.serialize(&mut tmp_file, true).await?;
     tmp_file.sync_all().await?;
     tokio::fs::rename(&tmp_path, &s9pk_path).await?;
@@ -216,7 +228,7 @@ async fn file_tree(
 ) -> Result<Vec<PathBuf>, Error> {
     let s9pk = super::load(
         MultiCursorFile::from(open_file(&s9pk_path).await?),
-        || ctx.developer_key().cloned(),
+        || ctx.build_key(),
         None,
     )
     .await?;
@@ -240,7 +252,7 @@ async fn cat(
 
     let s9pk = super::load(
         MultiCursorFile::from(open_file(&s9pk_path).await?),
-        || ctx.developer_key().cloned(),
+        || ctx.build_key(),
         None,
     )
     .await?;
@@ -267,7 +279,7 @@ async fn inspect_manifest(
 ) -> Result<Manifest, Error> {
     let s9pk = super::load(
         MultiCursorFile::from(open_file(&s9pk_path).await?),
-        || ctx.developer_key().cloned(),
+        || ctx.build_key(),
         None,
     )
     .await?;
@@ -286,7 +298,7 @@ async fn inspect_commitment(
 async fn convert(ctx: CliContext, S9pkPath { s9pk: s9pk_path }: S9pkPath) -> Result<(), Error> {
     let mut s9pk = super::load(
         MultiCursorFile::from(open_file(&s9pk_path).await?),
-        || ctx.developer_key().cloned(),
+        || ctx.build_key(),
         None,
     )
     .await?;

--- a/core/src/s9pk/v2/pack.rs
+++ b/core/src/s9pk/v2/pack.rs
@@ -707,7 +707,7 @@ pub async fn pack(ctx: CliContext, params: PackParams) -> Result<(), Error> {
     );
 
     let mut s9pk = S9pk::new(
-        MerkleArchive::new(files, ctx.developer_key()?.clone(), SIG_CONTEXT),
+        MerkleArchive::new(files, ctx.build_key()?, SIG_CONTEXT),
         None,
     )
     .await?;


### PR DESCRIPTION
## Summary

Adds two `start-cli s9pk` subcommands for AI-assisted packaging, plus the supporting workspace machinery:

- **`s9pk init-workspace [PATH]`** — provisions a packaging workspace: shallow-clones `start-docs`, links `AGENTS.md` (a symlink into the guide), `AGENTS.local.md`, and a `CLAUDE.md` bridge, and creates `.startos/` holding a generated ed25519 **build-key** and a multi-profile **`config.yaml`** of named `host`/`registry` targets. Idempotent; there is no `--force` — guide updates are a session-start `git -C start-docs pull --ff-only`.
- **`s9pk init-package "<Name>"`** — scaffolds a package from the cloned template (interpolating the name + normalized id), then runs `npm install`. Finds the workspace by walking up from cwd to the `.startos` marker.
- **Signing** — `pack` / `edit` / v1 `convert` now sign with the workspace `.startos/build-key` via a new `CliContext::build_key` (walk-up from cwd), requiring a workspace. Read-only inspection of v2 s9pks still works anywhere. Cookie auth and the registry `developer.key.pem` are untouched.
- **Targets** — `-H/--host` and `-r/--registry` accept a profile name from the workspace `config.yaml` or a literal URL (profile, then URL, else error), with a non-breaking fallback to the existing flat config / `localhost`.

The companion `start-docs` changes (the packaging guide `AGENTS.md`, environment-setup, and the bundled `package-template/`) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)