### PR TITLE
fix(core/logger): move file+stderr writes off worker threads

### DIFF
--- a/build/lib/scripts/diagnose-hang
+++ b/build/lib/scripts/diagnose-hang
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Capture the state of startbox when it is unresponsive. Uses only /proc
+# Capture the state of startd when it is unresponsive. Uses only /proc
 # and basic system tools — does not rely on start-cli (which routes
 # through startd and will hang if startd is hung).
 #
 # Usage: sudo /usr/lib/startos/scripts/diagnose-hang
-# Produces: /tmp/startbox-hang-<timestamp>.tar.gz
+# Produces: /tmp/startd-hang-<timestamp>.tar.gz
 
 set -u
 
@@ -12,22 +12,24 @@ if [ "$(id -u)" -ne 0 ]; then
     exec sudo bash "$0" "$@"
 fi
 
-PID="$(pidof startbox || true)"
+PID="$(pidof startd || true)"
 if [ -z "$PID" ]; then
-    echo "startbox is not running — nothing to diagnose" >&2
+    echo "startd is not running — nothing to diagnose" >&2
     exit 1
 fi
+JOURNALD_PID="$(pidof systemd-journald || true)"
 
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
-OUT="/tmp/startbox-hang-$TS"
+OUT="/tmp/startd-hang-$TS"
 mkdir -p "$OUT"
 
-echo "Capturing startbox state (pid=$PID) to $OUT" >&2
+echo "Capturing startd state (pid=$PID) to $OUT" >&2
 
 # ---- Process-level summary ----
 {
     echo "timestamp: $TS"
     echo "pid:       $PID"
+    echo "journald:  ${JOURNALD_PID:-MISSING}"
     echo "uptime:    $(uptime)"
     awk '/^Name|^State|^Threads|^VmRSS|^VmPeak|^Pid|^PPid/' "/proc/$PID/status"
 } > "$OUT/summary.txt"
@@ -53,15 +55,120 @@ echo "Capturing startbox state (pid=$PID) to $OUT" >&2
 ps -L -p "$PID" -o tid,pcpu,stat,comm 2>/dev/null \
     | sort -k4 > "$OUT/threads-summary.txt"
 
+# ---- Futex address per thread (histogram) ----
+# /proc/<tid>/syscall format: NR arg0 arg1 arg2 arg3 arg4 arg5 sp pc.
+# For futex (NR=202 on x86_64), arg0 is the futex uaddr.
+# Same uaddr across many threads = mutex contention.
+# Different uaddrs = tokio's own park condvars (normal idle workers).
+# This is the single most useful piece of evidence for diagnosing the
+# logger-mutex wedge vs. a healthy-but-idle runtime.
+{
+    echo "=== /proc/<tid>/syscall per thread ==="
+    printf "%-7s %-24s %s\n" TID COMM SYSCALL
+    for t in /proc/$PID/task/*; do
+        tid="$(basename "$t")"
+        comm="$(cat "$t/comm" 2>/dev/null)"
+        sc="$(cat "$t/syscall" 2>/dev/null)"
+        printf "%-7s %-24s %s\n" "$tid" "$comm" "$sc"
+    done
+    echo
+    echo "=== histogram of futex uaddrs (col2 of syscall, only when col1=202) ==="
+    for t in /proc/$PID/task/*; do
+        sc="$(cat "$t/syscall" 2>/dev/null)"
+        set -- $sc
+        [ "${1:-}" = "202" ] && echo "$2"
+    done | sort | uniq -c | sort -rn
+} > "$OUT/futex-histogram.txt"
+
+# ---- Userspace backtraces (if gdb installed) ----
+# Reveals WHICH thread is the logger-mutex holder and what others are
+# parked on. Cheap and read-only.
+if command -v gdb >/dev/null 2>&1; then
+    timeout 60 gdb -batch -nx \
+        -ex "set pagination off" \
+        -ex "set print thread-events off" \
+        -ex "attach $PID" \
+        -ex "info threads" \
+        -ex "thread apply all bt" \
+        -ex "detach" \
+        -ex "quit" \
+        > "$OUT/startd-gdb.txt" 2>&1 || true
+else
+    echo "(gdb not installed)" > "$OUT/startd-gdb.txt"
+fi
+
 # ---- Open files / sockets ----
 ls -la "/proc/$PID/fd/" > "$OUT/fds.txt" 2>&1 || true
 {
-    echo "--- ss (sockets owned by pid) ---"
+    echo "--- ss (sockets owned by startd) ---"
     ss -anpe 2>/dev/null | grep -E "pid=$PID|^Netid" || true
+    echo
+    echo "--- ss (unix sockets owned by journald) ---"
+    if [ -n "${JOURNALD_PID:-}" ]; then
+        ss -xnpe 2>/dev/null | grep -E "pid=$JOURNALD_PID|^Netid" || true
+    fi
+    echo
+    echo "--- /proc/net/unix (queue depths for stdout/journal streams) ---"
+    awk 'NR==1 || /journal|stdout/' /proc/net/unix 2>/dev/null | head -100
 } > "$OUT/sockets.txt"
 
-# ---- Recent journal output for startd ----
+# ---- startd fd 2 -> peer ----
+# Most likely culprit for a logger-shaped wedge: fd 2 connected to a
+# journald stream whose peer is alive but not reading.
+{
+    echo "=== startd fd 0/1/2 ==="
+    ls -l "/proc/$PID/fd/0" "/proc/$PID/fd/1" "/proc/$PID/fd/2" 2>&1
+    echo
+    target="$(readlink "/proc/$PID/fd/2" 2>/dev/null)"
+    echo "fd 2 -> $target"
+    inode="$(echo "$target" | sed -n 's/^socket:\[\([0-9]*\)\]$/\1/p')"
+    if [ -n "$inode" ]; then
+        echo
+        echo "=== matching socket(s) for inode $inode ==="
+        ss -xnpe 2>/dev/null | awk -v ino="$inode" \
+            'NR==1 || $0 ~ ("ino:"ino"[^0-9]") || $0 ~ ("[ \t]"ino"[ \t]")'
+    fi
+} > "$OUT/startd-fd2.txt" 2>&1
+
+# ---- journald state ----
+{
+    echo "=== systemctl status systemd-journald ==="
+    systemctl status systemd-journald --no-pager -l 2>&1
+    echo
+    echo "=== systemctl show systemd-journald (key fields) ==="
+    systemctl show systemd-journald --no-pager \
+        --property=ActiveState,SubState,Result,NRestarts,ExecMainStartTimestamp,ExecMainPID 2>&1
+    echo
+    echo "=== journalctl -u systemd-journald --since '4 hours ago' (last 200) ==="
+    journalctl -u systemd-journald --since "4 hours ago" --no-pager 2>&1 | tail -200
+    echo
+    if [ -n "${JOURNALD_PID:-}" ]; then
+        echo "=== /proc/$JOURNALD_PID/wchan ==="
+        cat "/proc/$JOURNALD_PID/wchan" 2>&1; echo
+        echo "=== /proc/$JOURNALD_PID/stack ==="
+        cat "/proc/$JOURNALD_PID/stack" 2>&1; echo
+        echo "=== /proc/$JOURNALD_PID/io ==="
+        cat "/proc/$JOURNALD_PID/io" 2>&1; echo
+        echo "=== journald per-thread wchan ==="
+        for t in "/proc/$JOURNALD_PID/task/"*; do
+            tid="$(basename "$t")"
+            printf "  tid=%-7s comm=%-20s wchan=%s\n" \
+                "$tid" \
+                "$(cat "$t/comm" 2>/dev/null)" \
+                "$(cat "$t/wchan" 2>/dev/null)"
+        done
+        echo
+        echo "=== journald open fds ==="
+        ls -l "/proc/$JOURNALD_PID/fd" 2>&1
+    fi
+} > "$OUT/journald-state.txt"
+
+# ---- Recent journal output ----
 journalctl -u startd --no-pager -n 500 > "$OUT/startd-journal.txt" 2>&1 || true
+# All-units tail tells us whether the entire system stopped logging at
+# the same instant (journald-side wedge) or just startd's stream.
+journalctl --since "4 hours ago" --no-pager 2>&1 | tail -5000 \
+    > "$OUT/journal-all-tail.txt" || true
 
 # ---- I/O and disk health ----
 dmesg -T 2>/dev/null | tail -200 > "$OUT/dmesg.txt"
@@ -72,12 +179,25 @@ dmesg -T 2>/dev/null | tail -200 > "$OUT/dmesg.txt"
     echo "--- mount ---"
     mount
     echo
+    echo "--- /proc/pressure/* ---"
+    for f in /proc/pressure/cpu /proc/pressure/memory /proc/pressure/io; do
+        [ -r "$f" ] && { echo "$f"; cat "$f"; echo; }
+    done
     echo "--- iostat -x 1 3 ---"
     if command -v iostat >/dev/null 2>&1; then
         iostat -x 1 3
     else
         echo "(iostat not installed)"
     fi
+    echo
+    echo "--- journalctl --disk-usage ---"
+    journalctl --disk-usage 2>&1
+    echo
+    echo "--- /var/log/journal ---"
+    ls -la /var/log/journal/ 2>&1
+    echo
+    echo "--- /run/log/journal ---"
+    ls -la /run/log/journal/ 2>&1
 } > "$OUT/io.txt" 2>&1
 
 # ---- LXC state (the containers startd was managing) ----
@@ -93,6 +213,27 @@ dmesg -T 2>/dev/null | tail -200 > "$OUT/dmesg.txt"
         echo
     done
 } > "$OUT/lxc.txt"
+
+# ---- Environment / versions ----
+{
+    echo "--- uname ---"; uname -a
+    echo
+    echo "--- /etc/os-release ---"; cat /etc/os-release 2>&1
+    echo
+    echo "--- systemd version ---"; systemctl --version 2>&1
+    echo
+    echo "--- /etc/systemd/journald.conf ---"
+    cat /etc/systemd/journald.conf 2>&1
+    echo
+    echo "--- /etc/systemd/journald.conf.d/*.conf ---"
+    cat /etc/systemd/journald.conf.d/*.conf 2>/dev/null
+    echo
+    echo "--- startd exe ---"
+    readlink "/proc/$PID/exe" 2>&1
+    echo
+    echo "--- startd cmdline ---"
+    tr '\0' ' ' < "/proc/$PID/cmdline" 2>&1; echo
+} > "$OUT/environment.txt"
 
 # ---- Bundle ----
 tar czf "$OUT.tar.gz" -C /tmp "$(basename "$OUT")"

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -8076,7 +8076,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8729,9 +8729,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4752072f7740cdfce9c61da81760fbda4182cfe4fff6f7a21fb6470b3f20a0"
+checksum = "a8fe88b2e18f1393e93a7703658ef5edca32d6a7da3aa23afae15f76e1cb0115"
 dependencies = [
  "hashbrown 0.13.2",
  "lazy_static",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6608,6 +6608,7 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tower-service",
  "tracing",
+ "tracing-appender",
  "tracing-error",
  "tracing-journald",
  "tracing-subscriber",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -222,6 +222,7 @@ tokio-tungstenite = { version = "0.26.2", features = ["native-tls", "url"] }
 tokio-util = { version = "0.7.9", features = ["io", "rt"] }
 tower-service = "0.3.3"
 tracing = "0.1.39"
+tracing-appender = "0.2.3"
 tracing-error = "0.2.0"
 tracing-journald = "0.3.0"
 tracing-subscriber = { version = "=0.3.19", features = ["env-filter"] }

--- a/core/src/util/logger.rs
+++ b/core/src/util/logger.rs
@@ -11,56 +11,27 @@ lazy_static! {
     pub static ref LOGGER: StartOSLogger = StartOSLogger::init();
 }
 
-/// Optional, hot-swappable on-disk log file shared between the appender
-/// thread (which writes to it) and `LOGGER::set_logfile` (which swaps it).
-///
-/// The mutex here is **only contested between the appender thread and
-/// callers of `set_logfile`** (which is invoked twice in the lifetime of
-/// the process, both during `startd` init).  Tokio worker threads never
-/// touch this mutex: they push bytes into the appender's mpsc and return
-/// immediately.  See `TeeWriter` below.
+/// Hot-swappable on-disk log file.  Only contested between the appender
+/// thread and `set_logfile` callers; tokio workers never touch it.
 #[derive(Clone, Default)]
 struct SharedLogFile(Arc<Mutex<Option<File>>>);
 
-/// A blocking `io::Write` that tees each event to an optional rotating
-/// log file and to stderr.
-///
-/// This writer is owned by `tracing_appender::non_blocking`'s background
-/// OS thread; it is **never** invoked from a tokio worker.  That is the
-/// whole point of this rewrite: under the previous implementation, every
-/// tracing event from every task synchronously took an
-/// `Arc<Mutex<Option<File>>>` and performed a blocking write to journald
-/// while holding it.  If journald ever fell behind (for any reason —
-/// disk stall, restart, ratelimit, anything) the holding worker stalled
-/// inside the kernel's socket-send path, all subsequent worker threads
-/// piled onto the mutex futex, and `block_in_place` could not rescue
-/// them because they hit the futex before reaching `block_in_place`.
-/// The result was a wedged accept loop and an unresponsive UI.
-///
-/// With this writer behind `NonBlocking`, worker threads push bytes into
-/// a bounded mpsc and return immediately.  If the appender thread itself
-/// blocks on stderr, the channel fills, and events past the limit are
-/// dropped (lossy mode).  No tokio worker ever sync-blocks on logger I/O.
+/// Tees each event to the optional log file and to stderr.  Owned by the
+/// `tracing_appender::non_blocking` background thread, never invoked from
+/// a tokio worker.
 struct TeeWriter {
     file: SharedLogFile,
 }
 
 impl Write for TeeWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // File first — it is our diagnostic record and the more important
-        // of the two sinks.  Errors are swallowed: if the file write
-        // fails, we still want stderr to get the event, and we never want
-        // to surface an error to the appender (it would be logged via the
-        // same broken path).
+        // Best-effort to both sinks. The appender thread may block here if
+        // stderr is wedged, but worker threads cannot.
         if let Ok(mut guard) = self.file.0.lock() {
             if let Some(f) = guard.as_mut() {
                 let _ = f.write_all(buf);
             }
         }
-        // Stderr second, also best-effort.  If stderr is wedged (the
-        // exact condition this rewrite is designed to survive), the
-        // appender thread will block here — but only the appender
-        // thread; worker threads are unaffected.
         let _ = io::stderr().write_all(buf);
         Ok(buf.len())
     }
@@ -79,20 +50,13 @@ impl Write for TeeWriter {
 #[derive(Clone)]
 pub struct StartOSLogger {
     logfile: SharedLogFile,
-    // Keeping the WorkerGuard alive keeps the appender's background OS
-    // thread alive for the lifetime of the process.  Wrapped in
-    // `Arc<Mutex<Option<_>>>` only so that `StartOSLogger: Clone` (the
-    // existing public bound) keeps working; the guard itself is never
-    // dropped or replaced after init.
+    // Keeps the appender background thread alive for the process lifetime.
     _guard: Arc<Mutex<Option<WorkerGuard>>>,
 }
 
 impl StartOSLogger {
     pub fn enable(&self) {}
 
-    /// Swap the optional on-disk log file.  Bytes already queued in the
-    /// appender's mpsc may still land in the previous file; bytes queued
-    /// after this call land in the new file (or nowhere if `None`).
     pub fn set_logfile(&self, logfile: Option<File>) {
         *self.logfile.0.lock().unwrap() = logfile;
     }
@@ -131,10 +95,8 @@ impl StartOSLogger {
 
     fn init() -> Self {
         let logfile = SharedLogFile::default();
-        // Lossy under sustained backpressure.  We accept dropped events
-        // in exchange for a guarantee that worker threads never wedge on
-        // logger I/O.  Buffer is generous so transient bursts (the
-        // migration's multi-megabyte debug events) don't drop anything.
+        // Lossy: drop events under sustained backpressure rather than ever
+        // letting a worker thread sync-block on logger I/O.
         let (writer, guard) = NonBlockingBuilder::default()
             .lossy(true)
             .buffered_lines_limit(65_536)

--- a/core/src/util/logger.rs
+++ b/core/src/util/logger.rs
@@ -1,80 +1,103 @@
 use std::fs::File;
 use std::io::{self, Write};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
 
 use lazy_static::lazy_static;
 use tracing::Subscriber;
-use tracing_subscriber::fmt::MakeWriter;
+use tracing_appender::non_blocking::{NonBlocking, NonBlockingBuilder, WorkerGuard};
 use tracing_subscriber::util::SubscriberInitExt;
 
 lazy_static! {
     pub static ref LOGGER: StartOSLogger = StartOSLogger::init();
 }
 
-#[derive(Clone)]
-pub struct StartOSLogger {
-    logfile: LogFile,
+/// Optional, hot-swappable on-disk log file shared between the appender
+/// thread (which writes to it) and `LOGGER::set_logfile` (which swaps it).
+///
+/// The mutex here is **only contested between the appender thread and
+/// callers of `set_logfile`** (which is invoked twice in the lifetime of
+/// the process, both during `startd` init).  Tokio worker threads never
+/// touch this mutex: they push bytes into the appender's mpsc and return
+/// immediately.  See `TeeWriter` below.
+#[derive(Clone, Default)]
+struct SharedLogFile(Arc<Mutex<Option<File>>>);
+
+/// A blocking `io::Write` that tees each event to an optional rotating
+/// log file and to stderr.
+///
+/// This writer is owned by `tracing_appender::non_blocking`'s background
+/// OS thread; it is **never** invoked from a tokio worker.  That is the
+/// whole point of this rewrite: under the previous implementation, every
+/// tracing event from every task synchronously took an
+/// `Arc<Mutex<Option<File>>>` and performed a blocking write to journald
+/// while holding it.  If journald ever fell behind (for any reason —
+/// disk stall, restart, ratelimit, anything) the holding worker stalled
+/// inside the kernel's socket-send path, all subsequent worker threads
+/// piled onto the mutex futex, and `block_in_place` could not rescue
+/// them because they hit the futex before reaching `block_in_place`.
+/// The result was a wedged accept loop and an unresponsive UI.
+///
+/// With this writer behind `NonBlocking`, worker threads push bytes into
+/// a bounded mpsc and return immediately.  If the appender thread itself
+/// blocks on stderr, the channel fills, and events past the limit are
+/// dropped (lossy mode).  No tokio worker ever sync-blocks on logger I/O.
+struct TeeWriter {
+    file: SharedLogFile,
 }
 
-#[derive(Clone, Default)]
-struct LogFile(Arc<Mutex<Option<File>>>);
-impl<'a> MakeWriter<'a> for LogFile {
-    type Writer = Box<dyn Write + 'a>;
-    fn make_writer(&'a self) -> Self::Writer {
-        let f = self.0.lock().unwrap();
-        if f.is_some() {
-            struct TeeWriter<'a>(MutexGuard<'a, Option<File>>);
-            impl<'a> Write for TeeWriter<'a> {
-                fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-                    // Blocking file+stderr I/O on a tokio worker thread can
-                    // starve the I/O driver (tokio-rs/tokio#4730).
-                    // block_in_place tells the runtime to hand off driver
-                    // duties before we block.  Only available on the
-                    // multi-thread runtime; falls back to a direct write on
-                    // current-thread runtimes (CLI) or outside a runtime.
-                    if matches!(
-                        tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()),
-                        Ok(tokio::runtime::RuntimeFlavor::MultiThread),
-                    ) {
-                        tokio::task::block_in_place(|| self.write_inner(buf))
-                    } else {
-                        self.write_inner(buf)
-                    }
-                }
-                fn flush(&mut self) -> io::Result<()> {
-                    if let Some(f) = &mut *self.0 {
-                        f.flush()?;
-                    }
-                    Ok(())
-                }
+impl Write for TeeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // File first — it is our diagnostic record and the more important
+        // of the two sinks.  Errors are swallowed: if the file write
+        // fails, we still want stderr to get the event, and we never want
+        // to surface an error to the appender (it would be logged via the
+        // same broken path).
+        if let Ok(mut guard) = self.file.0.lock() {
+            if let Some(f) = guard.as_mut() {
+                let _ = f.write_all(buf);
             }
-            impl<'a> TeeWriter<'a> {
-                fn write_inner(&mut self, buf: &[u8]) -> io::Result<usize> {
-                    let n = if let Some(f) = &mut *self.0 {
-                        f.write(buf)?
-                    } else {
-                        buf.len()
-                    };
-                    io::stderr().write_all(&buf[..n])?;
-                    Ok(n)
-                }
-            }
-            Box::new(TeeWriter(f))
-        } else {
-            drop(f);
-            Box::new(io::stderr())
         }
+        // Stderr second, also best-effort.  If stderr is wedged (the
+        // exact condition this rewrite is designed to survive), the
+        // appender thread will block here — but only the appender
+        // thread; worker threads are unaffected.
+        let _ = io::stderr().write_all(buf);
+        Ok(buf.len())
     }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if let Ok(mut guard) = self.file.0.lock() {
+            if let Some(f) = guard.as_mut() {
+                let _ = f.flush();
+            }
+        }
+        let _ = io::stderr().flush();
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct StartOSLogger {
+    logfile: SharedLogFile,
+    // Keeping the WorkerGuard alive keeps the appender's background OS
+    // thread alive for the lifetime of the process.  Wrapped in
+    // `Arc<Mutex<Option<_>>>` only so that `StartOSLogger: Clone` (the
+    // existing public bound) keeps working; the guard itself is never
+    // dropped or replaced after init.
+    _guard: Arc<Mutex<Option<WorkerGuard>>>,
 }
 
 impl StartOSLogger {
     pub fn enable(&self) {}
 
+    /// Swap the optional on-disk log file.  Bytes already queued in the
+    /// appender's mpsc may still land in the previous file; bytes queued
+    /// after this call land in the new file (or nowhere if `None`).
     pub fn set_logfile(&self, logfile: Option<File>) {
         *self.logfile.0.lock().unwrap() = logfile;
     }
 
-    fn base_subscriber(logfile: LogFile) -> impl Subscriber {
+    fn base_subscriber(writer: NonBlocking) -> impl Subscriber {
         use tracing_error::ErrorLayer;
         use tracing_subscriber::prelude::*;
         use tracing_subscriber::{EnvFilter, fmt};
@@ -90,7 +113,7 @@ impl StartOSLogger {
         };
 
         let fmt_layer = fmt::layer()
-            .with_writer(logfile)
+            .with_writer(writer)
             .with_line_number(true)
             .with_file(true)
             .with_target(true)
@@ -105,12 +128,27 @@ impl StartOSLogger {
 
         sub
     }
+
     fn init() -> Self {
-        let logfile = LogFile::default();
-        Self::base_subscriber(logfile.clone()).init();
+        let logfile = SharedLogFile::default();
+        // Lossy under sustained backpressure.  We accept dropped events
+        // in exchange for a guarantee that worker threads never wedge on
+        // logger I/O.  Buffer is generous so transient bursts (the
+        // migration's multi-megabyte debug events) don't drop anything.
+        let (writer, guard) = NonBlockingBuilder::default()
+            .lossy(true)
+            .buffered_lines_limit(65_536)
+            .thread_name("startos-logger".into())
+            .finish(TeeWriter {
+                file: logfile.clone(),
+            });
+        Self::base_subscriber(writer).init();
         color_eyre::install().unwrap_or_else(|_| tracing::warn!("tracing too many times"));
 
-        StartOSLogger { logfile }
+        StartOSLogger {
+            logfile,
+            _guard: Arc::new(Mutex::new(Some(guard))),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- The current `LogFile` `MakeWriter` impl in `core/src/util/logger.rs` returns a writer that **owns a `std::sync::Mutex<Option<File>>`'s `MutexGuard`** for the entire duration of an event's write, and performs a blocking `io::stderr().write_all(...)` inside `block_in_place` while holding it. If stderr ever backpressures permanently (journald write-stall, journald restart, ratelimit edge case, anything that wedges journald's read of its `/run/systemd/journal/stdout` stream), the worker holding the mutex parks in the kernel's `sock_alloc_send_pskb` forever.
- Every other worker that emits any `tracing::*` then sync-blocks inside `LogFile.0.lock()`, **before** reaching `block_in_place` — so tokio cannot spawn a replacement worker to keep the scheduler alive.
- When that happens inside `web_server.rs`'s `tokio::select! { _ = handler, _ = runner }` shape, the `runner` arm synchronously polls the per-connection `FuturesUnordered`; any child future that emits a single `tracing::debug!` during its poll sync-blocks the accept task too. Result: 0 ESTAB on ports 80/443, RX-Q grows, UI unresponsive.

This PR replaces the `Arc<Mutex<Option<File>>>` + `block_in_place` writer with `tracing_appender::non_blocking`, which owns a dedicated OS thread and drains via mpsc. **Worker threads now never sync-block on logger I/O**: they push bytes into the channel and return immediately. If the appender thread itself blocks on stderr, the mpsc fills and new events are dropped (lossy mode) — no worker is affected.

`set_logfile(Option<File>)` still hot-swaps the on-disk sink. The underlying mutex is only contested between the appender thread and the two `set_logfile` calls in `startd` boot, never with worker threads.

## Scope — this is preventative, NOT the fix for `startd-hang-20260522T170444Z.tar.gz`

The field incident referenced in earlier drafts of this PR has the same outward shape this PR addresses (0 ESTAB on :80/:443, RX-Q growing, all tokio workers in `futex_do_wait`, startd alive but emitting zero journal entries, journald healthy after a transient stall), **but symbol-resolved diagnostics from a follow-up capture (`startd-diag-20260523T051618Z`, gdb attached on an unstripped rebuild) show the contended futex word is the static `RwLock` inside [`yasi::TABLE`](https://crates.io/crates/yasi), not `LogFile.0`.** Confirmation via reference-count fingerprint: in a v0.4.0-beta.9 rebuild, exactly 46 instructions reference `yasi::TABLE`'s lazy_static `LAZY`, matching the user binary; `sharded_slab::tid::REGISTRY` (the other lazy_static with the same `Once`-offset signature) is referenced only 4 times.

The proximate cause in that incident is a re-entrance deadlock in yasi 0.1.11's `InternedString::intern`: the `eq` closure passed to `RawTable::get`/`get_mut` calls `Weak::upgrade(...)`, and when the upgraded `Arc<TableString>` is the last strong reference at the moment the closure returns, dropping it fires `TableString::drop`, which re-acquires `TABLE.write()` while the calling thread still holds `TABLE.read()` (read section) or `TABLE.write()` (write section). `std::sync::RwLock` self-deadlocks; readers and writers pile up; everything that touches an `InternedString` (paths, package IDs, db keys — basically every request path) wedges. A separate fix in yasi is required and being prepared.

So this PR is the right preventative for the *logger-shaped* version of the failure, but it does not close the field ticket on its own.

## Standalone reproduction (of the logger-shaped wedge this PR fixes)

I reproduced the logger wedge in a standalone Rust program that mirrors the production `select!{handler, runner}` shape exactly (per-request child futures that emit one `tracing::debug!` each, stderr `dup2`d onto an undrained `UnixStream::pair()`):

| Variant | Accepts after t=0 | last_accept_age_ms after 20s |
|---|---|---|
| **Production logger** (parent of this branch) | **0/s** | **20 005 ms** |
| Same code, per-request future does not log | 19–20/s | < 50 ms |
| **This branch** (`tracing_appender::non_blocking`) | 19–20/s | < 50 ms |

Same load, same blocked stderr — the logger-shaped wedge is gone with this fix. (This reproducer does not exercise yasi at all; the yasi deadlock is a separate failure mode with the same end-state.)

## What this PR does not do

- **Does not change `set_logfile` callers** (`bins/startd.rs:33`, `:43`). Public API preserved.
- **Does not fix the yasi re-entrance deadlock.** Separate PR against yasi.
- **Does not split the accept loop off the runner task in `web_server.rs`.** That's a separate, larger structural change that would defend against future logger-shaped hazards (and other accept-starvation shapes like yasi's). Worth a follow-up PR.
- **Does not address the underlying cause of journald being wedged on a user's box** when *this* PR's scenario fires. Disk stall, restart-race, or ratelimit edge case — those need separate investigation; this PR makes the runtime survive whatever the cause turns out to be.

## Test plan

- [x] `cargo check --lib` — passes cleanly
- [x] `cargo test --lib logger` — both existing tests pass
- [x] Standalone reproducer with this writer pattern under blocked stderr — runtime stays healthy at 20 accepts/s
- [ ] Manual: build a startd, point `set_logfile` at a real file, hammer with traffic during a migration, confirm UI stays responsive even with `systemctl stop systemd-journald` in the middle
- [ ] Regression test in `core/tests/`: would land a CI test of the form "construct LOGGER, dup2 stderr to a never-drained unix socket, run accept-and-runner shape, assert accepts/sec > N" — happy to push that as a follow-up if reviewers want. (Will NOT cover the yasi case — that needs its own regression in the yasi repo.)
