### PR TITLE
fix(tunnel): clamp forwarded TCP MSS to WireGuard path MTU

### DIFF
--- a/core/src/net/forward.rs
+++ b/core/src/net/forward.rs
@@ -254,10 +254,14 @@ pub struct PortForwardController {
     _thread: NonDetachingJoinHandle<()>,
 }
 
-pub async fn add_iptables_rule(nat: bool, undo: bool, args: &[&str]) -> Result<(), Error> {
+pub async fn add_iptables_rule(
+    table: Option<&str>,
+    undo: bool,
+    args: &[&str],
+) -> Result<(), Error> {
     let mut cmd = Command::new("iptables");
-    if nat {
-        cmd.arg("-t").arg("nat");
+    if let Some(table) = table {
+        cmd.arg("-t").arg(table);
     }
     let exists = cmd
         .arg("-C")
@@ -267,8 +271,8 @@ pub async fn add_iptables_rule(nat: bool, undo: bool, args: &[&str]) -> Result<(
         .is_ok();
     if undo != !exists {
         let mut cmd = Command::new("iptables");
-        if nat {
-            cmd.arg("-t").arg("nat");
+        if let Some(table) = table {
+            cmd.arg("-t").arg(table);
         }
         if undo {
             cmd.arg("-D");
@@ -292,7 +296,7 @@ impl PortForwardController {
                     .invoke(ErrorKind::Network)
                     .await?;
                 add_iptables_rule(
-                    false,
+                    None,
                     false,
                     &[
                         "FORWARD",

--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -65,7 +65,7 @@ impl NetController {
                 .0],
         )?);
         add_iptables_rule(
-            false,
+            None,
             false,
             &[
                 "FORWARD",

--- a/core/src/tunnel/api.rs
+++ b/core/src/tunnel/api.rs
@@ -249,7 +249,7 @@ pub async fn add_subnet(
             .collect::<Vec<_>>()
     }) {
         add_iptables_rule(
-            true,
+            Some("nat"),
             false,
             &[
                 "POSTROUTING",
@@ -296,7 +296,7 @@ pub async fn remove_subnet(
             .collect::<Vec<_>>()
     }) {
         add_iptables_rule(
-            true,
+            Some("nat"),
             true,
             &[
                 "POSTROUTING",

--- a/core/src/tunnel/context.rs
+++ b/core/src/tunnel/context.rs
@@ -126,7 +126,7 @@ impl TunnelContext {
         let net_iface = Watch::new(net_iface);
         let forward = PortForwardController::new();
         add_iptables_rule(
-            false,
+            None,
             false,
             &[
                 "FORWARD",
@@ -138,6 +138,26 @@ impl TunnelContext {
                 "NEW",
                 "-j",
                 "ACCEPT",
+            ],
+        )
+        .await?;
+        // Clamp TCP MSS on forwarded SYNs to the WireGuard path MTU so large
+        // TLS ClientHellos (desktop Firefox/Chromium with X25519MLKEM768
+        // post-quantum key shares) don't get silently dropped after
+        // encapsulation. See start-os#3261.
+        add_iptables_rule(
+            Some("mangle"),
+            false,
+            &[
+                "FORWARD",
+                "-p",
+                "tcp",
+                "--tcp-flags",
+                "SYN,RST",
+                "SYN",
+                "-j",
+                "TCPMSS",
+                "--clamp-mss-to-pmtu",
             ],
         )
         .await?;
@@ -159,7 +179,7 @@ impl TunnelContext {
         }) {
             for subnet in peek.as_wg().as_subnets().keys()? {
                 add_iptables_rule(
-                    true,
+                    Some("nat"),
                     false,
                     &[
                         "POSTROUTING",


### PR DESCRIPTION
## Summary

- Add a `mangle FORWARD … TCPMSS --clamp-mss-to-pmtu` rule on `TunnelContext::init`, alongside the existing FORWARD/MASQUERADE rules, so large TLS ClientHellos don't get silently dropped after WireGuard encapsulation.
- Extend `add_iptables_rule` from `nat: bool` to `table: Option<&str>` so the same idempotent probe-then-append helper covers the mangle table too; update the five existing call sites.

Fixes #3261.

## Why

Desktop Firefox/Chromium currently send TLS ClientHellos of ~1900 bytes — largely the X25519MLKEM768 post-quantum hybrid key share. That splits into two TCP segments; after ~60 bytes of WireGuard overhead the larger segment exceeds the tunnel's effective path MTU on common cloud paths (the reporter measured 1328–1428 bytes on a DigitalOcean droplet) and is silently dropped. PMTUD doesn't rescue the endpoints because the drop happens inside the encrypted tunnel. curl/wget/Android browsers send a small enough ClientHello (~500 bytes) to fit in one segment, so the bug only surfaces for desktop browsers.

Clamping the MSS in `SYN`/`SYN-ACK` on the FORWARD chain forces both endpoints to negotiate a segment size that survives encapsulation. The reporter confirmed this exact rule resolves the issue.

The helper's existing `iptables -C` probe makes the rule a no-op on restart, satisfying the "idempotent on init" requirement.

## Test plan

- [x] `cargo check --lib` clean on `core/`.
- [ ] On a StartTunnel VPS, after rebooting tunnelbox: `iptables -t mangle -S FORWARD | grep TCPMSS` shows exactly one `--clamp-mss-to-pmtu` rule (no duplicates after re-init).
- [ ] Desktop Firefox / Chromium on Linux can load an https service through StartTunnel without `NS_ERROR_NET_INTERRUPT` / handshake timeout.
- [ ] `tcpdump -i wg0` confirms both TCP segments of the ClientHello are forwarded.