### PR TITLE
fix(cli): generic non-tty fallback for choose

### DIFF
--- a/core/locales/i18n.yaml
+++ b/core/locales/i18n.yaml
@@ -2705,6 +2705,27 @@ util.tui.selected-choice-not-in-input:
   fr_FR: "le choix sélectionné n'apparaît pas dans l'entrée"
   pl_PL: "wybrany wybór nie pojawia się w danych wejściowych"
 
+util.tui.select-by-number:
+  en_US: "Please enter a number between 1 and %{max}:"
+  de_DE: "Bitte geben Sie eine Zahl zwischen 1 und %{max} ein:"
+  es_ES: "Por favor, ingrese un número entre 1 y %{max}:"
+  fr_FR: "Veuillez entrer un nombre entre 1 et %{max} :"
+  pl_PL: "Proszę wprowadzić liczbę od 1 do %{max}:"
+
+util.tui.invalid-selection:
+  en_US: "Invalid selection — must be a number between 1 and %{max}"
+  de_DE: "Ungültige Auswahl — muss eine Zahl zwischen 1 und %{max} sein"
+  es_ES: "Selección inválida — debe ser un número entre 1 y %{max}"
+  fr_FR: "Sélection invalide — doit être un nombre entre 1 et %{max}"
+  pl_PL: "Nieprawidłowy wybór — musi być liczbą od 1 do %{max}"
+
+util.tui.could-not-read-response:
+  en_US: "Could not read response from stdin"
+  de_DE: "Antwort konnte nicht von stdin gelesen werden"
+  es_ES: "No se pudo leer la respuesta desde stdin"
+  fr_FR: "Impossible de lire la réponse depuis stdin"
+  pl_PL: "Nie można odczytać odpowiedzi ze standardowego wejścia"
+
 # util/serde.rs
 util.serde.must-specify-units-for-duration:
   en_US: "Must specify units for duration"

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -1271,7 +1271,10 @@ pub async fn cli_attach(
         {
             Ok(a) => a,
             Err(e) => {
-                if e.kind != ErrorKind::InvalidRequest {
+                if e.kind != ErrorKind::InvalidRequest
+                    || !stdin.is_terminal()
+                    || !stdout.is_terminal()
+                {
                     return Err(e);
                 }
                 let prompt = e.to_string();

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -1271,10 +1271,7 @@ pub async fn cli_attach(
         {
             Ok(a) => a,
             Err(e) => {
-                if e.kind != ErrorKind::InvalidRequest
-                    || !stdin.is_terminal()
-                    || !stdout.is_terminal()
-                {
+                if e.kind != ErrorKind::InvalidRequest {
                     return Err(e);
                 }
                 let prompt = e.to_string();

--- a/core/src/util/tui.rs
+++ b/core/src/util/tui.rs
@@ -1,7 +1,8 @@
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::str::FromStr;
 
 use r3bl_tui::{DefaultIoDevices, ReadlineAsyncContext, ReadlineEvent};
+use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::prelude::*;
 
@@ -106,43 +107,94 @@ pub async fn choose_custom_display<'t, T>(
     choices: &'t [T],
     mut display: impl FnMut(&T) -> String,
 ) -> Result<&'t T, Error> {
-    let mut io = DefaultIoDevices::default();
-    let style = r3bl_tui::readline_async::StyleSheet::default();
     let string_choices = choices.into_iter().map(|c| display(c)).collect::<Vec<_>>();
-    let choice = r3bl_tui::readline_async::choose(
-        prompt,
-        string_choices.clone(),
-        None,
-        None,
-        r3bl_tui::HowToChoose::Single,
-        style,
-        (
-            &mut io.output_device,
-            &mut io.input_device,
-            io.maybe_shared_writer,
-        ),
-    )
-    .await
-    .map_err(map_miette)?;
-    if choice.len() < 1 {
-        return Err(Error::new(
-            eyre!("{}", t!("util.tui.aborted")),
-            ErrorKind::Cancelled,
-        ));
+
+    if std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
+        let mut io = DefaultIoDevices::default();
+        let style = r3bl_tui::readline_async::StyleSheet::default();
+        let choice = r3bl_tui::readline_async::choose(
+            prompt,
+            string_choices.clone(),
+            None,
+            None,
+            r3bl_tui::HowToChoose::Single,
+            style,
+            (
+                &mut io.output_device,
+                &mut io.input_device,
+                io.maybe_shared_writer,
+            ),
+        )
+        .await
+        .map_err(map_miette)?;
+        if choice.len() < 1 {
+            return Err(Error::new(
+                eyre!("{}", t!("util.tui.aborted")),
+                ErrorKind::Cancelled,
+            ));
+        }
+        let (idx, choice_str) = string_choices
+            .iter()
+            .enumerate()
+            .find(|(_, s)| s.as_str() == choice[0].as_str())
+            .ok_or_else(|| {
+                Error::new(
+                    eyre!("{}", t!("util.tui.selected-choice-not-in-input")),
+                    ErrorKind::Incoherent,
+                )
+            })?;
+        let choice = &choices[idx];
+        println!("{prompt} {choice_str}");
+        return Ok(&choice);
     }
-    let (idx, choice_str) = string_choices
+
+    let listing = string_choices
         .iter()
         .enumerate()
-        .find(|(_, s)| s.as_str() == choice[0].as_str())
-        .ok_or_else(|| {
-            Error::new(
-                eyre!("{}", t!("util.tui.selected-choice-not-in-input")),
-                ErrorKind::Incoherent,
-            )
-        })?;
-    let choice = &choices[idx];
-    println!("{prompt} {choice_str}");
-    Ok(&choice)
+        .map(|(i, s)| format!("  {}) {s}", i + 1))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    {
+        let mut stderr = std::io::stderr().lock();
+        writeln!(&mut stderr, "{prompt}")?;
+        writeln!(&mut stderr, "{listing}")?;
+        write!(
+            &mut stderr,
+            "{} ",
+            t!("util.tui.select-by-number", max = string_choices.len())
+        )?;
+        stderr.flush()?;
+    }
+
+    let mut line = String::new();
+    let n = BufReader::new(tokio::io::stdin())
+        .read_line(&mut line)
+        .await?;
+    if n == 0 {
+        return Err(Error::new(
+            eyre!(
+                "{}\n{prompt}\n{listing}",
+                t!("util.tui.could-not-read-response"),
+            ),
+            ErrorKind::InvalidRequest,
+        ));
+    }
+    let trimmed = line.trim();
+    let invalid = || {
+        Error::new(
+            eyre!(
+                "{}",
+                t!("util.tui.invalid-selection", max = string_choices.len())
+            ),
+            ErrorKind::InvalidRequest,
+        )
+    };
+    let idx: usize = trimmed.parse().map_err(|_| invalid())?;
+    if idx < 1 || idx > string_choices.len() {
+        return Err(invalid());
+    }
+    Ok(&choices[idx - 1])
 }
 
 pub async fn choose<'t, T: std::fmt::Display>(

--- a/core/src/util/tui.rs
+++ b/core/src/util/tui.rs
@@ -2,7 +2,7 @@ use std::io::{IsTerminal, Write};
 use std::str::FromStr;
 
 use r3bl_tui::{DefaultIoDevices, ReadlineAsyncContext, ReadlineEvent};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
 
 use crate::prelude::*;
 
@@ -148,6 +148,27 @@ pub async fn choose_custom_display<'t, T>(
         return Ok(&choice);
     }
 
+    let mut stderr = std::io::stderr().lock();
+    let idx = choose_non_tty(
+        prompt,
+        &string_choices,
+        BufReader::new(tokio::io::stdin()),
+        &mut stderr,
+    )
+    .await?;
+    Ok(&choices[idx])
+}
+
+async fn choose_non_tty<R, W>(
+    prompt: &str,
+    string_choices: &[String],
+    mut input: R,
+    mut err: W,
+) -> Result<usize, Error>
+where
+    R: AsyncBufRead + Unpin,
+    W: Write,
+{
     let listing = string_choices
         .iter()
         .enumerate()
@@ -155,22 +176,17 @@ pub async fn choose_custom_display<'t, T>(
         .collect::<Vec<_>>()
         .join("\n");
 
-    {
-        let mut stderr = std::io::stderr().lock();
-        writeln!(&mut stderr, "{prompt}")?;
-        writeln!(&mut stderr, "{listing}")?;
-        write!(
-            &mut stderr,
-            "{} ",
-            t!("util.tui.select-by-number", max = string_choices.len())
-        )?;
-        stderr.flush()?;
-    }
+    writeln!(&mut err, "{prompt}")?;
+    writeln!(&mut err, "{listing}")?;
+    write!(
+        &mut err,
+        "{} ",
+        t!("util.tui.select-by-number", max = string_choices.len())
+    )?;
+    err.flush()?;
 
     let mut line = String::new();
-    let n = BufReader::new(tokio::io::stdin())
-        .read_line(&mut line)
-        .await?;
+    let n = input.read_line(&mut line).await?;
     if n == 0 {
         return Err(Error::new(
             eyre!(
@@ -194,7 +210,7 @@ pub async fn choose_custom_display<'t, T>(
     if idx < 1 || idx > string_choices.len() {
         return Err(invalid());
     }
-    Ok(&choices[idx - 1])
+    Ok(idx - 1)
 }
 
 pub async fn choose<'t, T: std::fmt::Display>(
@@ -202,4 +218,81 @@ pub async fn choose<'t, T: std::fmt::Display>(
     choices: &'t [T],
 ) -> Result<&'t T, Error> {
     choose_custom_display(prompt, choices, |t| t.to_string()).await
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn run(input: &[u8]) -> (Result<usize, Error>, String) {
+        let choices = vec![
+            "alpha".to_string(),
+            "bravo".to_string(),
+            "charlie".to_string(),
+        ];
+        let mut err: Vec<u8> = Vec::new();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let res = rt.block_on(choose_non_tty(
+            "pick one",
+            &choices,
+            tokio::io::BufReader::new(input),
+            &mut err,
+        ));
+        (res, String::from_utf8(err).unwrap())
+    }
+
+    #[test]
+    fn valid_selection_returns_index() {
+        let (res, stderr) = run(b"2\n");
+        assert_eq!(res.unwrap(), 1);
+        assert!(stderr.contains("pick one"));
+        assert!(stderr.contains("  1) alpha"));
+        assert!(stderr.contains("  2) bravo"));
+        assert!(stderr.contains("  3) charlie"));
+        assert!(stderr.contains("between 1 and 3"));
+    }
+
+    #[test]
+    fn whitespace_around_selection_ok() {
+        let (res, _) = run(b"  3  \n");
+        assert_eq!(res.unwrap(), 2);
+    }
+
+    #[test]
+    fn out_of_range_errors() {
+        let (res, _) = run(b"4\n");
+        let e = res.unwrap_err();
+        assert_eq!(e.kind, ErrorKind::InvalidRequest);
+        assert!(format!("{e}").contains("Invalid selection"));
+    }
+
+    #[test]
+    fn zero_is_out_of_range() {
+        let (res, _) = run(b"0\n");
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn non_numeric_errors() {
+        let (res, _) = run(b"foo\n");
+        let e = res.unwrap_err();
+        assert_eq!(e.kind, ErrorKind::InvalidRequest);
+        assert!(format!("{e}").contains("Invalid selection"));
+    }
+
+    #[test]
+    fn eof_errors_with_listing() {
+        let (res, _) = run(b"");
+        let e = res.unwrap_err();
+        assert_eq!(e.kind, ErrorKind::InvalidRequest);
+        let msg = format!("{e}");
+        assert!(msg.contains("Could not read response from stdin"));
+        assert!(msg.contains("pick one"));
+        assert!(msg.contains("  1) alpha"));
+        assert!(msg.contains("  2) bravo"));
+        assert!(msg.contains("  3) charlie"));
+    }
 }


### PR DESCRIPTION
## Summary
Moves the non-interactive fallback into `choose_custom_display` (and so `choose`) so every caller benefits — `start-cli package attach`'s subcontainer disambiguation and `start-cli package install`'s flavor selection both stop hanging / opening an unusable r3bl_tui prompt when run without a TTY.

When stdin or stdout is not a TTY:

- Print the prompt + numbered options to stderr.
- Read one line from stdin.
  - If parsed as `1..=N`, return that choice.
  - If invalid → `Invalid selection — must be a number between 1 and N`.
  - If stdin gives EOF → error with prompt + listing + `Could not read response from stdin`.

Adds i18n keys `util.tui.select-by-number`, `util.tui.invalid-selection`, `util.tui.could-not-read-response` (all 5 locales).

## Test plan
- [ ] Interactive TTY: `start-cli package attach <id>` on a service with multiple subcontainers still shows the existing r3bl_tui chooser and selection works.
- [ ] Piped stdin: `echo 2 | start-cli package attach <id>` picks option 2 and continues.
- [ ] No stdin attached: `start-cli package attach <id> </dev/null` errors with the prompt, the listing, and "Could not read response from stdin"; non-zero exit.
- [ ] Bad input: `echo foo | start-cli package attach <id>` errors with the invalid-selection message.