### PR TITLE
feat(migration): rename fedimintd to fedimint-guardian

### DIFF
--- a/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
+++ b/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
@@ -405,6 +405,9 @@ export class SystemForEmbassy implements System {
     if (this.manifest.id === "monerod") {
       this.manifest.id = "monerod-legacy"
     }
+    if (this.manifest.id === "fedimintd") {
+      this.manifest.id = "fedimint-guardian"
+    }
   }
 
   async init(

--- a/core/src/s9pk/v2/compat.rs
+++ b/core/src/s9pk/v2/compat.rs
@@ -203,6 +203,9 @@ impl TryFrom<ManifestV1> for Manifest {
         if &*value.id == "monerod" {
             value.id = "monerod-legacy".parse()?;
         }
+        if &*value.id == "fedimintd" {
+            value.id = "fedimint-guardian".parse()?;
+        }
         Ok(Self {
             id: value.id,
             version: version.into(),

--- a/core/src/version/v0_3_6_alpha_0.rs
+++ b/core/src/version/v0_3_6_alpha_0.rs
@@ -409,6 +409,17 @@ impl VersionT for Version {
             .await?;
         }
 
+        if tokio::fs::metadata("/media/startos/data/package-data/volumes/fedimintd")
+            .await
+            .is_ok()
+        {
+            tokio::fs::rename(
+                "/media/startos/data/package-data/volumes/fedimintd",
+                "/media/startos/data/package-data/volumes/fedimint-guardian",
+            )
+            .await?;
+        }
+
         // Load bundled migration images (start9/compat, start9/utils,
         // tonistiigi/binfmt) so the v1->v2 s9pk conversion doesn't need
         // internet access.
@@ -539,6 +550,7 @@ impl VersionT for Version {
                                 "ghost" => "ghost-legacy",
                                 "synapse" => "synapse-legacy",
                                 "monerod" => "monerod-legacy",
+                                "fedimintd" => "fedimint-guardian",
                                 other => other,
                             };
                             let version_path = Path::new(DATA_DIR)


### PR DESCRIPTION
## Summary

Adds the `fedimintd` → `fedimint-guardian` package-ID rename to the 0.3.5.1 → 0.4.0 migration, mirroring the existing renames for `nostr`, `ghost`, `synapse`, and `monerod`.

Covers all four migration paths where those renames live:

- **`core/src/version/v0_3_6_alpha_0.rs`** — volume directory rename in `post_up`, plus the `new_package_id` match so `.version` is written under the new id.
- **`core/src/s9pk/v2/compat.rs`** — v1→v2 manifest id rewrite (Rust conversion path).
- **`container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts`** — the parallel runtime-side manifest id rewrite (TS).