### PR TITLE
fix(service): create_task self-deadlock during setupInit

### DIFF
--- a/core/src/service/effects/action.rs
+++ b/core/src/service/effects/action.rs
@@ -248,13 +248,11 @@ async fn create_task(
                         ErrorKind::InvalidRequest,
                     ));
                 };
-                let prev = if let Some(service) = context
-                    .seed
-                    .ctx
-                    .services
-                    .get(&task.package_id)
-                    .await
-                    .as_ref()
+                // try_get to avoid deadlock during self-calls on install
+                let guard = context.seed.ctx.services.try_get(&task.package_id);
+                let prev = if let Some(service) = guard
+                    .as_deref()
+                    .and_then(Option::as_ref)
                     .filter(|s| s.is_initialized())
                 {
                     service


### PR DESCRIPTION
## Summary

A service that calls `sdk.action.createOwnTask` from inside its `setupOnInit` handler with a `when: 'input-not-matches'` trigger deadlocks — init never returns, the package wedges in `updating` state, the log stops at `Initializing...` with no `Initialization complete.` line.

Cause is a lock-ordering cycle on the service's `ServiceMap` entry:

- `ServiceMap::load` / `ServiceMap::install` acquire a **write** lock on the entry via `get_mut` and hold it for the entire duration of `persistent_container.init(...)`.
- That init invokes the container's JS `setupInit` handler.
- The handler calls `effects.action.createTask` back into startd.
- `create_task`'s `input-not-matches` branch calls `services.get(&task.package_id).await` — a **blocking read** on the same entry the loader is holding write-locked.
- The read waits on the loader. The loader waits on init. Init waits on the `createTask` response. ∞.

## The blocking read is unproductive anyway

`services.get` here is filtered by `.is_initialized()`, which is only set to `true` **after** `persistent_container.init()` returns (`persistent_container.rs:425` — `self.state.send_modify(|s| s.rt_initialized = true)`). For a service calling `create_task` from its own `setupInit`, the filter would always reject.

The branch already handles "service not initialized — assume active, retest in `recheck_tasks` after init" (lines 278-283). The fix just makes us reach that branch by failing the lock acquisition instead of waiting on it.

## Fix

Swap `services.get(...).await` for `services.try_get(...)`. A contended (or empty) entry falls through to the existing "assume active" branch instead of blocking. `recheck_tasks` runs unconditionally after init (`service/mod.rs:358`), so validation still happens — just not under the loader's lock.

## Reproducer

`wordpress-startos` PR https://github.com/Start9Labs/wordpress-startos/pull/1 hits this on every update once any site exists. The package-side workaround (omit `input` + `when` from `createOwnTask`) sidesteps the broken branch, but a clean fix here lets packages use the documented `TaskOptions` shape.

Trace bisection on the package side:

| `createOwnTask` shape | Init outcome |
|---|---|
| `{ reason, replayId }` | Initialization complete. (<1ms) |
| `{ reason, replayId, input, when }` | hangs at `Initializing...`, package wedges in `updating` |

After this fix, the second variant lands in the existing not-initialized branch and `create_task` returns immediately.

## Test plan

- [x] `cargo check -p start-os --lib` — clean
- [ ] Manual: sideload the buggy `wordpress-startos` build (with `input` + `when` on `createOwnTask`) onto a beta-9 image carrying this patch, trigger update with a site already present, confirm init completes and `recheck_tasks` validates the task afterwards.
- [ ] Consider an integration test covering "service calls own `createTask` with input-not-matches trigger during init" — happy to add one if there's a preferred test scaffold to mirror.