### PR TITLE
fix(cli): ws_continuation honors --root-ca / --insecure

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6552,6 +6552,7 @@ dependencies = [
  "mbrman",
  "miette",
  "mio",
+ "native-tls",
  "new_mime_guess",
  "nix 0.30.1",
  "nom 8.0.0",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -150,6 +150,7 @@ log = "0.4.20"
 mbrman = "0.6.0"
 miette = { version = "7.6.0", features = ["fancy"] }
 mio = "1"
+native-tls = "0.2.11"
 new_mime_guess = "4"
 nix = { version = "0.30.1", features = [
   "fs",

--- a/core/src/context/cli.rs
+++ b/core/src/context/cli.rs
@@ -18,7 +18,7 @@ use rpc_toolkit::yajrc::RpcError;
 use rpc_toolkit::{CallRemote, Context, Empty};
 use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{Connector, MaybeTlsStream, WebSocketStream};
 use tracing::instrument;
 
 use super::setup::CURRENT_SECRET;
@@ -48,6 +48,8 @@ pub struct CliContextSeed {
     pub cookie_path: PathBuf,
     pub developer_key_path: PathBuf,
     pub developer_key: OnceCell<ed25519_dalek::SigningKey>,
+    pub root_ca: Vec<PathBuf>,
+    pub insecure: bool,
 }
 impl Drop for CliContextSeed {
     fn drop(&mut self) {
@@ -170,7 +172,29 @@ impl CliContext {
                 .developer_key_path
                 .unwrap_or_else(default_developer_key_path),
             developer_key: OnceCell::new(),
+            root_ca: config.root_ca.unwrap_or_default(),
+            insecure: config.insecure,
         })))
+    }
+
+    fn ws_tls_connector(&self) -> Result<Option<Connector>, Error> {
+        if self.root_ca.is_empty() && !self.insecure {
+            return Ok(None);
+        }
+        let mut builder = native_tls::TlsConnector::builder();
+        if self.insecure {
+            builder.danger_accept_invalid_certs(true);
+            builder.danger_accept_invalid_hostnames(true);
+        }
+        for ca_path in &self.root_ca {
+            let pem = std::fs::read(ca_path)
+                .with_ctx(|_| (crate::ErrorKind::Filesystem, ca_path.display()))?;
+            let cert = native_tls::Certificate::from_pem(&pem)
+                .with_kind(crate::ErrorKind::OpenSsl)?;
+            builder.add_root_certificate(cert);
+        }
+        let connector = builder.build().with_kind(crate::ErrorKind::OpenSsl)?;
+        Ok(Some(Connector::NativeTls(connector)))
     }
 
     /// BLOCKING
@@ -257,9 +281,15 @@ impl CliContext {
             .push("ws")
             .push("rpc")
             .push(guid.as_ref());
-        let (stream, _) =
-                // base_url is "http://127.0.0.1/", with a trailing slash, so we don't put a leading slash in this path:
-                tokio_tungstenite::connect_async(url).await.with_kind(ErrorKind::Network)?;
+        let connector = self.ws_tls_connector()?;
+        let (stream, _) = tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            None,
+            false,
+            connector,
+        )
+        .await
+        .with_kind(ErrorKind::Network)?;
         Ok(stream)
     }
 


### PR DESCRIPTION
## Summary

`CliContext::ws_continuation` was building the websocket via
`tokio_tungstenite::connect_async(url)` with no TLS config, so the
`--root-ca` and `--insecure` flags that `reqwest` honors for normal
RPC and `rest_continuation` were silently dropped. Anything that
needed the WS leg — sideload progress, `package attach`, `package install -s` —
failed against a fresh post-install StartOS with
`TLS error: … self-signed certificate in certificate chain`.

`CliContextSeed` now carries `root_ca` and `insecure` alongside the
existing `reqwest::Client` config, and `ws_continuation` builds a
`native_tls::TlsConnector` mirroring the same settings, wraps it in
`tokio_tungstenite::Connector::NativeTls`, and connects via
`connect_async_tls_with_config`. When neither flag is set the
connector is `None`, preserving the prior behavior.

(The earlier version of this PR also auto-refreshed `web/package-lock.json`
inside the `npm ci` Makefile rule; dropped at @drbonez's request — keeping the
lockfile in sync with `package.json` is the developer's responsibility.)

## Test plan

- [x] cargo check --lib --bin start-cli --bin start-container — clean
- [x] cargo test --lib --features test export_manpage_start_cli — passes (no CLI surface change, no manpage drift)
- [ ] Maintainer: validate sideload / package install -s over --insecure against a fresh post-install StartOS