### PR TITLE
feat(tunnel): show forwarded protocols column in port-forwards table

### DIFF
--- a/web/projects/start-tunnel/src/app/routes/home/routes/port-forwards/index.ts
+++ b/web/projects/start-tunnel/src/app/routes/home/routes/port-forwards/index.ts
@@ -78,7 +78,7 @@ import { MappedDevice, MappedForward } from './utils'
             <td>{{ forward.externalport }}</td>
             <td>{{ forward.device.name }}</td>
             <td>{{ forward.internalport }}</td>
-            <td>TCP, UDP</td>
+            <td>TCP/UDP</td>
             <td>
               <button
                 tuiIconButton

--- a/web/projects/start-tunnel/src/app/routes/home/routes/port-forwards/index.ts
+++ b/web/projects/start-tunnel/src/app/routes/home/routes/port-forwards/index.ts
@@ -45,6 +45,7 @@ import { MappedDevice, MappedForward } from './utils'
           <th>External Port</th>
           <th>Device</th>
           <th>Internal Port</th>
+          <th>Protocol</th>
           <th [style.padding-inline-end.rem]="0.625">
             <button tuiButton size="xs" iconStart="@tui.plus" (click)="onAdd()">
               Add
@@ -77,6 +78,7 @@ import { MappedDevice, MappedForward } from './utils'
             <td>{{ forward.externalport }}</td>
             <td>{{ forward.device.name }}</td>
             <td>{{ forward.internalport }}</td>
+            <td>TCP, UDP</td>
             <td>
               <button
                 tuiIconButton
@@ -112,7 +114,7 @@ import { MappedDevice, MappedForward } from './utils'
           </tr>
         } @empty {
           <tr>
-            <td colspan="7">
+            <td colspan="8">
               <app-placeholder icon="@tui.globe">
                 No port forwards
               </app-placeholder>


### PR DESCRIPTION
Adds a **Protocol** column to the StartTunnel port-forwards table, surfacing that each forward currently exposes both TCP and UDP (`TCP, UDP` for every row).

This is the short-term, display-only step from #3258. The longer-term part — a TCP/UDP multiselect plus the backend that actually restricts forwarding to the chosen protocol(s) — is intentionally deferred and not included here. StartOS service-interface forwarding is untouched.

Part of #3258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)