### PR TITLE
fix(net): route .onion (Tor) and .local (mDNS) in host SOCKS proxy

### DIFF
--- a/core/locales/i18n.yaml
+++ b/core/locales/i18n.yaml
@@ -1918,6 +1918,20 @@ registry.context.missing-hostname:
   fr_FR: "Configuration requise manquante : registry-hostname"
   pl_PL: "Brak wymaganej konfiguracji: registry-hostname"
 
+registry.context.onion-tor-not-installed:
+  en_US: "Cannot reach this Tor (.onion) registry: the Tor service is not installed. Install and start it to use onion registries."
+  de_DE: "Diese Tor-(.onion-)Registry ist nicht erreichbar: Der Tor-Dienst ist nicht installiert. Installieren und starten Sie ihn, um Onion-Registries zu verwenden."
+  es_ES: "No se puede acceder a este registro Tor (.onion): el servicio Tor no está instalado. Instálalo e inícialo para usar registros onion."
+  fr_FR: "Impossible d'accéder à ce registre Tor (.onion) : le service Tor n'est pas installé. Installez-le et démarrez-le pour utiliser les registres onion."
+  pl_PL: "Nie można połączyć się z tym rejestrem Tor (.onion): usługa Tor nie jest zainstalowana. Zainstaluj ją i uruchom, aby korzystać z rejestrów onion."
+
+registry.context.onion-tor-not-running:
+  en_US: "Cannot reach this Tor (.onion) registry: the Tor service is not running. Start the Tor service to use onion registries."
+  de_DE: "Diese Tor-(.onion-)Registry ist nicht erreichbar: Der Tor-Dienst läuft nicht. Starten Sie den Tor-Dienst, um Onion-Registries zu verwenden."
+  es_ES: "No se puede acceder a este registro Tor (.onion): el servicio Tor no está en ejecución. Inicia el servicio Tor para usar registros onion."
+  fr_FR: "Impossible d'accéder à ce registre Tor (.onion) : le service Tor n'est pas démarré. Démarrez le service Tor pour utiliser les registres onion."
+  pl_PL: "Nie można połączyć się z tym rejestrem Tor (.onion): usługa Tor nie jest uruchomiona. Uruchom usługę Tor, aby korzystać z rejestrów onion."
+
 registry.context.registry-required:
   en_US: "`--registry` required"
   de_DE: "`--registry` erforderlich"

--- a/core/src/net/socks.rs
+++ b/core/src/net/socks.rs
@@ -8,6 +8,7 @@ use socks5_impl::server::{AuthAdaptor, ClientConnection, Server};
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::HOST_IP;
+use crate::net::mdns::resolve_mdns;
 use crate::prelude::*;
 use crate::util::actor::background::BackgroundJobQueue;
 use crate::util::future::NonDetachingJoinHandle;
@@ -16,6 +17,49 @@ pub const DEFAULT_SOCKS_LISTEN: SocketAddr = SocketAddr::V4(SocketAddrV4::new(
     Ipv4Addr::new(HOST_IP[0], HOST_IP[1], HOST_IP[2], HOST_IP[3]),
     1080,
 ));
+
+/// SOCKS5 proxy exposed by the `tor` service (the user-installable Tor plugin),
+/// reachable from the host via the embedded DNS once that service is running.
+/// Matches the default the registry server uses for its own onion requests.
+const TOR_PROXY: (&str, u16) = ("tor.startos", 9050);
+
+/// Open a connection to a SOCKS `CONNECT` target, special-casing the two address
+/// families the host's resolver/router can't reach on its own:
+///
+/// - `*.onion` is tunneled through the Tor service's SOCKS5 proxy ([`TOR_PROXY`]).
+///   Requires the `tor` service installed and running; otherwise `tor.startos`
+///   doesn't resolve and the connection fails.
+/// - `*.local` is resolved over mDNS via Avahi. The host runs systemd-resolved
+///   with `MulticastDNS=no` and forwards `.local` to unicast upstreams, so
+///   `getaddrinfo` never sees it — [`resolve_mdns`] queries `avahi` directly.
+///
+/// Everything else (clearnet hostnames, `*.startos`, raw IPs) connects directly
+/// through the host's normal resolution path.
+async fn connect_target(addr: Address) -> Result<TcpStream, Error> {
+    match addr {
+        Address::DomainAddress(domain, port) if domain.ends_with(".onion") => {
+            let mut tor = TcpStream::connect(TOR_PROXY)
+                .await
+                .with_kind(ErrorKind::Network)?;
+            socks5_impl::client::connect(&mut tor, Address::DomainAddress(domain, port), None)
+                .await
+                .with_kind(ErrorKind::Network)?;
+            Ok(tor)
+        }
+        Address::DomainAddress(domain, port) if domain.ends_with(".local") => {
+            let ip = resolve_mdns(&domain).await?;
+            TcpStream::connect((ip, port))
+                .await
+                .with_kind(ErrorKind::Network)
+        }
+        Address::DomainAddress(domain, port) => TcpStream::connect((domain, port))
+            .await
+            .with_kind(ErrorKind::Network),
+        Address::SocketAddress(addr) => {
+            TcpStream::connect(addr).await.with_kind(ErrorKind::Network)
+        }
+    }
+}
 
 pub struct SocksController {
     _thread: NonDetachingJoinHandle<()>,
@@ -56,14 +100,9 @@ impl SocksController {
                                                 .with_kind(ErrorKind::Network)?
                                             {
                                                 ClientConnection::Connect(reply, addr) => {
-                                                    if let Ok(mut target) = match addr {
-                                                        Address::DomainAddress(domain, port) => {
-                                                            TcpStream::connect((domain, port)).await
-                                                        }
-                                                        Address::SocketAddress(addr) => {
-                                                            TcpStream::connect(addr).await
-                                                        }
-                                                    } {
+                                                    if let Ok(mut target) =
+                                                        connect_target(addr).await
+                                                    {
                                                         if let Err(e) =
                                                             socket2::SockRef::from(&target)
                                                                 .set_keepalive(true)

--- a/core/src/registry/context.rs
+++ b/core/src/registry/context.rs
@@ -290,8 +290,9 @@ impl CallRemote<RegistryContext, RegistryUrlParams> for RpcContext {
 
         method = method.strip_prefix("registry.").unwrap_or(method);
         let sig_context = registry.host_str().map(InternedString::from);
+        let is_onion = registry.host_str().map_or(false, |h| h.ends_with(".onion"));
 
-        let mut res = crate::middleware::auth::signature::call_remote(
+        let mut res = match crate::middleware::auth::signature::call_remote(
             self,
             registry,
             headers,
@@ -299,7 +300,12 @@ impl CallRemote<RegistryContext, RegistryUrlParams> for RpcContext {
             method,
             params.clone(),
         )
-        .await?;
+        .await
+        {
+            Ok(res) => res,
+            Err(e) if is_onion => return Err(onion_tor_hint(self, e).await),
+            Err(e) => return Err(e),
+        };
 
         if let Some(device_info) = device_info {
             device_info.filter_for_hardware(method, params, &mut res)?;
@@ -307,6 +313,27 @@ impl CallRemote<RegistryContext, RegistryUrlParams> for RpcContext {
 
         Ok(res)
     }
+}
+
+/// Reaching a `.onion` registry requires the host to proxy through the Tor
+/// service's SOCKS proxy (`tor.startos:9050`). When that service is missing or
+/// stopped, the request fails with reqwest's opaque "error sending request" —
+/// replace it with actionable guidance. If Tor is up, the failure belongs to the
+/// onion service itself, so the original error is preserved.
+async fn onion_tor_hint(ctx: &RpcContext, original: RpcError) -> RpcError {
+    let running = async {
+        let tor_id = "tor".parse::<crate::PackageId>().ok()?;
+        let peek = ctx.db.peek().await;
+        let entry = peek.as_public().as_package_data().as_idx(&tor_id)?;
+        Some(entry.as_status_info().as_started().de().ok()?.is_some())
+    }
+    .await;
+    let msg = match running {
+        Some(true) => return original,
+        Some(false) => t!("registry.context.onion-tor-not-running"),
+        None => t!("registry.context.onion-tor-not-installed"),
+    };
+    Error::new(eyre!("{msg}"), ErrorKind::Network).into()
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
## Summary

Adding or browsing a `.onion` or `.local` (mDNS) registry from the marketplace failed with `RPC ERROR: ... error sending request for url (http://…onion/rpc/v0)` — only IPv4 registries worked (Start9Labs/startos-registry-startos#7).

The host proxies **all** outbound RPC and package-download traffic through its own SOCKS5 proxy (`RpcContext` → `Proxy::all(socks5h://10.0.3.1:1080)`), but `SocksController` did a naive `TcpStream::connect` using the host resolver, which can't reach:

- **`.onion`** — no DNS record, and it was never routed to Tor.
- **`.local`** — the host runs systemd-resolved with `MulticastDNS=no` and forwards `.local` to unicast upstreams, so `getaddrinfo` never resolves it.

The registry *server* already proxies its own onion requests through `tor.startos:9050`; the host side simply never got the equivalent.

## Changes

- **`net/socks.rs`** — the proxy now routes `.onion` targets through the Tor service's SOCKS proxy (`tor.startos:9050`) and resolves `.local` over mDNS via Avahi; everything else (clearnet, `*.startos`, raw IPs) connects directly. Because this is the single choke point for host-originated traffic, it fixes both adding/browsing onion & mDNS registries **and** installing packages from them.
- **`registry/context.rs`** — when an `.onion` registry is unreachable because the Tor service isn't installed or running, return an actionable error ("install/start the Tor service") instead of reqwest's opaque "error sending request". If Tor is running, the original error is preserved (the failure is the onion endpoint's, not Tor's).
- **`locales/i18n.yaml`** — two new `registry.context.*` keys across all 5 locales.

Onion registries require the Tor service to be installed and running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
