### PR TITLE
fix(gateways): auto-detect gateway type from StartTunnel config header when unset

### DIFF
--- a/core/src/net/tunnel.rs
+++ b/core/src/net/tunnel.rs
@@ -77,6 +77,18 @@ pub async fn add_tunnel(
         set_as_default_outbound,
     }: AddTunnelParams,
 ) -> Result<GatewayId, Error> {
+    // Caller may declare the type; fall back to auto-detection only when absent.
+    // StartTunnel configs carry a marker => inbound/outbound; anything else
+    // (e.g. a commercial VPN like Mullvad) => outbound-only.
+    let gateway_type = gateway_type.unwrap_or_else(|| {
+        let marker = crate::tunnel::wg::START_TUNNEL_MARKER.to_lowercase();
+        if config.to_lowercase().contains(&marker) {
+            GatewayType::InboundOutbound
+        } else {
+            GatewayType::OutboundOnly
+        }
+    });
+
     let ifaces = ctx.net_controller.net_iface.watcher.subscribe();
     let mut iface = GatewayId::from(InternedString::intern("wg0"));
     if !ifaces.send_if_modified(|i| {
@@ -88,7 +100,7 @@ pub async fn add_tunnel(
                         name: Some(name),
                         secure: None,
                         ip_info: None,
-                        gateway_type,
+                        gateway_type: Some(gateway_type),
                     },
                 );
                 return true;

--- a/core/src/tunnel/client.conf.template
+++ b/core/src/tunnel/client.conf.template
@@ -1,4 +1,4 @@
-# StartTunnel config for {name}
+# {marker} config for {name}
 
 [Interface]
 Address = {addr}

--- a/core/src/tunnel/wg.rs
+++ b/core/src/tunnel/wg.rs
@@ -16,6 +16,16 @@ use crate::util::serde::Base64;
 
 pub const WIREGUARD_INTERFACE_NAME: &str = "wg-start-tunnel";
 
+/// Brand token written into every StartTunnel client config's header (see
+/// client.conf.template, rendered as `# StartTunnel config for <name>`).
+/// `add_tunnel` looks for this token (case-insensitively) to classify a pasted
+/// config as an inbound/outbound StartTunnel gateway — vs outbound-only for
+/// plain WireGuard configs like Mullvad. Matching just the brand token keeps
+/// detection working across StartTunnel/StartOS version skew and any future
+/// rewording of the surrounding header, and stays backwards-compatible with
+/// configs generated before this check existed.
+pub const START_TUNNEL_MARKER: &str = "StartTunnel";
+
 #[derive(Deserialize, Serialize, HasModel, TS)]
 #[serde(rename_all = "camelCase")]
 #[model = "Model<Self>"]
@@ -226,6 +236,7 @@ impl std::fmt::Display for ClientConfig {
         write!(
             f,
             include_str!("./client.conf.template"),
+            marker = START_TUNNEL_MARKER,
             name = self.client_config.name,
             privkey = self.client_config.key.to_padded_string(),
             psk = self.client_config.psk.to_padded_string(),

--- a/web/projects/ui/src/app/routes/portal/routes/system/routes/gateways/gateways.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/system/routes/gateways/gateways.component.ts
@@ -275,7 +275,7 @@ export default class GatewaysComponent {
                     input.config.selection === 'paste'
                       ? input.config.value.file
                       : await (input.config.value.file as any as File).text(),
-                  type: null, // @TODO Aiden why is attr here?
+                  type: null, // let StartOS auto-detect from the config
                   setAsDefaultOutbound: false,
                 })
                 return true

--- a/web/projects/ui/src/app/services/api/embassy-mock-api.service.ts
+++ b/web/projects/ui/src/app/services/api/embassy-mock-api.service.ts
@@ -659,7 +659,11 @@ export class MockApiService extends ApiService {
             lanIp: ['192.168.1.10'],
             dnsServers: [],
           },
-          type: 'inbound-outbound',
+          type:
+            params.type ??
+            (params.config.toLowerCase().includes('starttunnel')
+              ? 'inbound-outbound'
+              : 'outbound-only'),
         },
       },
     ]


### PR DESCRIPTION
## Problem

Adding a WireGuard gateway stored whatever `type` the client sent, and the web Add Gateway form hardcoded it:

```ts
type: null, // @TODO Aiden why is attr here?
```

The gateways table renders anything that isn't exactly `outbound-only` as **"Inbound/Outbound"**, so a null type meant outbound-only configs — including commercial VPNs like **Mullvad** — were mislabeled as inbound-capable. Nothing ever populated the type when the client didn't.

## Approach

Keep the client's ability to **declare** the gateway type, and only **fall back to auto-detection when it's null/absent**:

- `type` provided ⇒ use it as-is.
- `type` null/absent ⇒ detect from the config. StartTunnel client configs carry the brand token in their header (`# StartTunnel config for <name>`), so a **case-insensitive match for `StartTunnel`** ⇒ `inbound-outbound`; anything else (Mullvad, any plain WireGuard config) ⇒ `outbound-only`.

The web form passes `type: null`, so pasted configs are classified automatically — while API/CLI callers can still override.

## Why match just the brand token

- **Version skew:** StartTunnel runs on the VPS and StartOS at home; they update independently. Keying on the full header phrase would break if a future StartTunnel reworded it. Matching just `StartTunnel` survives that.
- **Backwards compatible:** configs generated before this change already contain the token, so they're detected without regenerating.
- **Low false-positive risk:** the contiguous token `starttunnel` doesn't appear in normal WireGuard/VPN configs, and detection is only the fallback when no type was declared. (Deliberately *not* accepting a spaced `start tunnel`, which is a substring of `restart tunnel` and friends.)

## Changes

- `core/src/tunnel/wg.rs`: `START_TUNNEL_MARKER = "StartTunnel"`, single-sourced into `client.conf.template` (`# {marker} config for {name}`) so the emitted header and the detection token can't drift. Rendered output is byte-identical to before.
- `core/src/net/tunnel.rs`: `AddTunnelParams.type` retained; `add_tunnel` resolves it with `gateway_type.unwrap_or_else(detect)`, where `detect` is a case-insensitive substring check.
- Web: replaced the confused `@TODO` comment on `type: null` with a clear one (null ⇒ server auto-detects); mock API mirrors the same precedence (declared type, else detect).

No binding or man-page change — `AddTunnelParams` keeps its `type` field.

## Note

- **No back-fill:** gateways added before this change keep their already-stored type. The original config isn't retained, so we can't re-derive it; re-adding fixes it.

## Test

- `cargo check` (core lib) — clean.
- `web` `tsc --project projects/ui/tsconfig.json --noEmit` — 0 errors; pre-commit `check:ui` passes.
