### PR TITLE
fix(net): tear down NetService synchronously on container destroy (lighter alt to #3281)

### DIFF
--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -495,7 +495,7 @@ pub struct NetService {
     synced: Watch<u64>,
 }
 impl NetService {
-    fn dummy() -> Self {
+    pub(crate) fn dummy() -> Self {
         Self {
             shutdown: true,
             data: Arc::new(Mutex::new(NetServiceData {
@@ -810,6 +810,7 @@ impl NetService {
                 crate::ErrorKind::Network,
             ));
         }
+        self.shutdown = true;
         let current = self.synced.peek(|v| *v);
         self.clear_bindings(Default::default()).await?;
         let mut w = self.synced.clone();

--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -810,12 +810,13 @@ impl NetService {
                 crate::ErrorKind::Network,
             ));
         }
-        self.shutdown = true;
         let current = self.synced.peek(|v| *v);
         self.clear_bindings(Default::default()).await?;
         let mut w = self.synced.clone();
         w.wait_for(|v| *v > current).await;
         self.sync_task.abort();
+        // Set only after teardown succeeds, so an earlier failure leaves Drop's fallback armed.
+        self.shutdown = true;
         // Clean up any outbound gateway ip rules for this service
         let service_ip = self.data.lock().await.ip.to_string();
         loop {

--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -813,10 +813,13 @@ impl NetService {
         let current = self.synced.peek(|v| *v);
         self.clear_bindings(Default::default()).await?;
         let mut w = self.synced.clone();
-        w.wait_for(|v| *v > current).await;
+        tokio::select! {
+            _ = w.wait_for(|v| *v > current) => {}
+            // sync-task already dead (e.g. aborted by a prior remove_all):
+            // `synced` will never advance again, so don't block on it.
+            _ = &mut self.sync_task => {}
+        }
         self.sync_task.abort();
-        // Set only after teardown succeeds, so an earlier failure leaves Drop's fallback armed.
-        self.shutdown = true;
         // Clean up any outbound gateway ip rules for this service
         let service_ip = self.data.lock().await.ip.to_string();
         loop {
@@ -834,6 +837,8 @@ impl NetService {
                 break;
             }
         }
+        // Set last: an earlier failure leaves shutdown false so Drop's fallback re-runs.
+        self.shutdown = true;
         Ok(())
     }
 

--- a/core/src/service/persistent_container.rs
+++ b/core/src/service/persistent_container.rs
@@ -445,6 +445,7 @@ impl PersistentContainer {
         let images = std::mem::take(&mut self.images);
         let subcontainers = self.subcontainers.clone();
         let lxc_container = self.lxc_container.take();
+        let net_service = std::mem::replace(&mut self.net_service, NetService::dummy());
         self.destroyed = true;
         Some(async move {
             let mut errs = ErrorCollection::new();
@@ -460,6 +461,7 @@ impl PersistentContainer {
                 shutdown.shutdown();
                 errs.handle(hdl.await.with_kind(ErrorKind::Cancelled));
             }
+            net_service.remove_all().await.log_err();
             for (_, volume) in volumes {
                 errs.handle(volume.unmount(true).await);
             }


### PR DESCRIPTION
## Summary

A lighter-touch alternative to #3281 for the same bug: after an in-place package upgrade where the LXC container is recreated with a new `lxcbr0` IP, a `net.forward` entry can stay pinned to the **previous** container's IP, dropping sibling-container traffic until a full `server.restart`.

#3281 fixes this *downstream* in the forward table (replacing the single per-`ForwardRequirements` target slot with a push-only `Vec` and a "newest live wins" reconcile). This PR fixes it at the *source* instead, by removing the condition that lets two `NetService`s exist at once.

## Root cause

The upgrade path already tears the old service down before the new one binds — `ServiceMap::install` awaits `service.uninstall(...)` (→ `shutdown` → `persistent_container.exit` → `destroy`) **before** `Service::install` creates the new container's `NetService`.

But `NetService` teardown specifically escapes that ordering. `PersistentContainer::destroy()` takes/awaits the lxc container, volumes, mounts, etc., but **never touches `net_service`** — it's only cleaned up when the struct is dropped, via `NetService`'s `Drop`, which does a **detached `tokio::spawn(remove_all())`**. Because that's fire-and-forget, the old service's sync-task stays alive (still subscribed to `/public/packageData/{id}/hosts`) and keeps calling `update_request` while the new `NetService` binds the new container IP. Two services then race `update_request` for the same external port — last-writer-wins, and once the loser's `Arc` dies the entry is pruned and never reinstalled. That race is exactly what #3281 patches around.

## Fix

Tear the `NetService` down **synchronously, in the awaited `destroy()` future**, so the old sync-task is aborted and its forwards cleared before the replacement binds:

- `PersistentContainer::destroy()` now `mem::replace`s `net_service` out with a dummy and `remove_all().await`s it inside the teardown future (logged, not propagated — matching the prior detached `.log_err()` behavior; the only change is *ordering*).
- `NetService::remove_all()` sets `shutdown = true` on its success path so a direct (non-`Drop`) call doesn't trigger a redundant re-spawn when the consumed value drops. `dummy()` is now `pub(crate)`.

With the two services no longer coexisting, the forward-table race can't happen, so the `Vec`/reconcile changes in #3281 aren't needed.

The detached `Drop` path stays as a fallback for any `PersistentContainer` dropped without going through `destroy()` (error paths).

No forwarding gap: the old container is already stopped synchronously before `Service::install` runs, so there's no live old backend whose forward we'd be removing early.

## Test

- `cargo check -p start-os --lib`: clean (pre-existing warnings only).
- E2E (in-place `namecoin-electrumx` upgrade on a v0.4-beta VM, verifying the 50004 forward refreshes to the new container IP with no `server.restart`) still to run — will follow up.

## Relationship to #3281

Same bug, two layers. This removes the concurrency; #3281 makes the forward table tolerate it. They're not mutually exclusive, but if this lands the heavier data-structure change shouldn't be necessary. cc the #3281 discussion.
