### PR TITLE
fix(cli): lock cookie store on a stable file to stop publish race

### DIFF
--- a/core/src/context/cli.rs
+++ b/core/src/context/cli.rs
@@ -58,23 +58,48 @@ impl Drop for CliContextSeed {
                 rt.shutdown_background();
             }
         }
-        let tmp = format!("{}.tmp", self.cookie_path.display());
+        // Failing to persist the cookie cache must not crash an otherwise
+        // successful command (e.g. `s9pk publish`), so log instead of panicking.
+        self.save_cookie_store().log_err();
+    }
+}
+impl CliContextSeed {
+    /// Persist the cookie store to `cookie_path` atomically (write-temp-then-rename),
+    /// serialized across processes by an exclusive lock on a *stable* sidecar lock
+    /// file. `cookie_path` is derived from `$HOME`, so concurrent `start-cli`
+    /// invocations (the release pipeline publishes one s9pk per arch in parallel)
+    /// share it. The lock must be held on a file that is never renamed away — the
+    /// previous code locked the temp file itself, which each writer recreates, so it
+    /// served no cross-process purpose and the writers raced on the rename: whoever
+    /// renamed first moved the temp out from under the other, which then panicked
+    /// with ENOENT.
+    fn save_cookie_store(&self) -> Result<(), Error> {
         let parent_dir = self.cookie_path.parent().unwrap_or(Path::new("/"));
         if !parent_dir.exists() {
-            std::fs::create_dir_all(&parent_dir).unwrap();
+            std::fs::create_dir_all(parent_dir)
+                .with_ctx(|_| (ErrorKind::Filesystem, parent_dir.display()))?;
         }
-        let mut writer = fd_lock_rs::FdLock::lock(
-            File::create(&tmp)
-                .with_ctx(|_| (ErrorKind::Filesystem, &tmp))
-                .unwrap(),
+        let lock_path = format!("{}.lock", self.cookie_path.display());
+        let _lock = fd_lock_rs::FdLock::lock(
+            File::create(&lock_path).with_ctx(|_| (ErrorKind::Filesystem, &lock_path))?,
             fd_lock_rs::LockType::Exclusive,
             true,
         )
-        .unwrap();
-        let store = self.cookie_store.lock().unwrap();
-        cookie_store::serde::json::save(&store, &mut *writer).unwrap();
-        writer.sync_all().unwrap();
-        std::fs::rename(tmp, &self.cookie_path).unwrap();
+        .with_ctx(|_| (ErrorKind::Filesystem, &lock_path))?;
+        let tmp = format!("{}.tmp", self.cookie_path.display());
+        let mut writer = File::create(&tmp).with_ctx(|_| (ErrorKind::Filesystem, &tmp))?;
+        {
+            let store = self
+                .cookie_store
+                .lock()
+                .map_err(|_| Error::new(eyre!("cookie store mutex poisoned"), ErrorKind::Unknown))?;
+            cookie_store::serde::json::save(&store, &mut writer)
+                .map_err(|e| Error::new(eyre!("{e}"), ErrorKind::Filesystem))?;
+        }
+        writer.sync_all().with_ctx(|_| (ErrorKind::Filesystem, &tmp))?;
+        std::fs::rename(&tmp, &self.cookie_path)
+            .with_ctx(|_| (ErrorKind::Filesystem, self.cookie_path.display()))?;
+        Ok(())
     }
 }
 

--- a/core/src/context/cli.rs
+++ b/core/src/context/cli.rs
@@ -58,21 +58,13 @@ impl Drop for CliContextSeed {
                 rt.shutdown_background();
             }
         }
-        // Failing to persist the cookie cache must not crash an otherwise
-        // successful command (e.g. `s9pk publish`), so log instead of panicking.
+        // A cookie-cache write failure must not crash an otherwise-successful command.
         self.save_cookie_store().log_err();
     }
 }
 impl CliContextSeed {
-    /// Persist the cookie store to `cookie_path` atomically (merge-then-write-temp-
-    /// then-rename), serialized across processes by an exclusive lock on a *stable* lock
-    /// file. `cookie_path` is derived from `$HOME`, so concurrent `start-cli`
-    /// invocations (the release pipeline publishes one s9pk per arch in parallel)
-    /// share it. The lock must be held on a file that is never renamed away — the
-    /// previous code locked the temp file itself, which each writer recreates, so it
-    /// served no cross-process purpose and the writers raced on the rename: whoever
-    /// renamed first moved the temp out from under the other, which then panicked
-    /// with ENOENT.
+    /// Lock a stable sidecar file (not the temp, which each writer recreates) so
+    /// concurrent `start-cli` invocations sharing `$HOME` serialize their saves.
     fn save_cookie_store(&self) -> Result<(), Error> {
         let parent_dir = self.cookie_path.parent().unwrap_or(Path::new("/"));
         if !parent_dir.exists() {
@@ -87,9 +79,7 @@ impl CliContextSeed {
         )
         .with_ctx(|_| (ErrorKind::Filesystem, &lock_path))?;
 
-        // Merge onto whatever is on disk now — a concurrent writer may have saved
-        // cookies for other domains since we loaded — rather than clobbering it.
-        // Our in-memory copy wins per-cookie conflicts (last-writer-wins).
+        // Merge onto disk rather than clobber a concurrent writer's other-domain cookies; ours wins conflicts.
         let on_disk = if self.cookie_path.exists() {
             cookie_store::serde::json::load(BufReader::new(
                 File::open(&self.cookie_path)

--- a/core/src/context/cli.rs
+++ b/core/src/context/cli.rs
@@ -64,8 +64,8 @@ impl Drop for CliContextSeed {
     }
 }
 impl CliContextSeed {
-    /// Persist the cookie store to `cookie_path` atomically (write-temp-then-rename),
-    /// serialized across processes by an exclusive lock on a *stable* sidecar lock
+    /// Persist the cookie store to `cookie_path` atomically (merge-then-write-temp-
+    /// then-rename), serialized across processes by an exclusive lock on a *stable* lock
     /// file. `cookie_path` is derived from `$HOME`, so concurrent `start-cli`
     /// invocations (the release pipeline publishes one s9pk per arch in parallel)
     /// share it. The lock must be held on a file that is never renamed away — the
@@ -86,16 +86,39 @@ impl CliContextSeed {
             true,
         )
         .with_ctx(|_| (ErrorKind::Filesystem, &lock_path))?;
-        let tmp = format!("{}.tmp", self.cookie_path.display());
-        let mut writer = File::create(&tmp).with_ctx(|_| (ErrorKind::Filesystem, &tmp))?;
-        {
+
+        // Merge onto whatever is on disk now — a concurrent writer may have saved
+        // cookies for other domains since we loaded — rather than clobbering it.
+        // Our in-memory copy wins per-cookie conflicts (last-writer-wins).
+        let on_disk = if self.cookie_path.exists() {
+            cookie_store::serde::json::load(BufReader::new(
+                File::open(&self.cookie_path)
+                    .with_ctx(|_| (ErrorKind::Filesystem, self.cookie_path.display()))?,
+            ))
+            .unwrap_or_default()
+        } else {
+            CookieStore::default()
+        };
+        let merged = {
             let store = self
                 .cookie_store
                 .lock()
                 .map_err(|_| Error::new(eyre!("cookie store mutex poisoned"), ErrorKind::Unknown))?;
-            cookie_store::serde::json::save(&store, &mut writer)
-                .map_err(|e| Error::new(eyre!("{e}"), ErrorKind::Filesystem))?;
-        }
+            CookieStore::from_cookies(
+                on_disk
+                    .iter_unexpired()
+                    .chain(store.iter_unexpired())
+                    .cloned()
+                    .map(Ok::<_, std::convert::Infallible>),
+                false,
+            )
+            .expect("from_cookies is infallible")
+        };
+
+        let tmp = format!("{}.tmp", self.cookie_path.display());
+        let mut writer = File::create(&tmp).with_ctx(|_| (ErrorKind::Filesystem, &tmp))?;
+        cookie_store::serde::json::save(&merged, &mut writer)
+            .map_err(|e| Error::new(eyre!("{e}"), ErrorKind::Filesystem))?;
         writer.sync_all().with_ctx(|_| (ErrorKind::Filesystem, &tmp))?;
         std::fs::rename(&tmp, &self.cookie_path)
             .with_ctx(|_| (ErrorKind::Filesystem, self.cookie_path.display()))?;


### PR DESCRIPTION
## Summary

`start-cli` persists its cookie store in `Drop for CliContextSeed` via write-temp-then-rename. `cookie_path` derives from `$HOME`, so concurrent `start-cli` invocations share it — and the release pipeline's publish step runs one `s9pk publish` per arch **in parallel** under a single `$HOME`. The existing `FdLock` was held on the *temp file itself*, which each writer recreates, so it gave no cross-process protection: the two writers raced on `rename(tmp → cookies.json)`, the loser found its temp already moved away, and the `.unwrap()` turned that `ENOENT` into a panic — failing the publish step *after* the package had already been uploaded and registered.

Observed in the wild (e.g. [filebrowser-startos run](https://github.com/Start9Labs/filebrowser-startos/actions/runs/26898005709/job/79342660792)):

```
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, ... }
Location: src/context/cli.rs:74   # std::fs::rename(...) at the released tag (v0.4.0-beta.9)
```

## Change

- Hold the exclusive `FdLock` on a **stable sidecar lock file** (`<cookie_path>.lock`, never renamed away) across the write+rename, so concurrent invocations serialize their cookie-store saves.
- Move the save into a `Result`-returning `save_cookie_store()` and have `Drop` `log_err()` it instead of `unwrap()`-ing, so a cookie-cache I/O hiccup can never crash an otherwise-successful command.

The lock guards the save (last-writer-wins on the cache, which is fine — registry publish uses developer-key signing, not cookies), not load→modify→save, to avoid serializing the pipeline's parallel publishes entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)