### PR TITLE
fix(net): serve private DNS for domains also configured as public

### DIFF
--- a/core/src/net/dns.rs
+++ b/core/src/net/dns.rs
@@ -1,5 +1,5 @@
 use std::borrow::Borrow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::str::FromStr;
 use std::sync::{Arc, Weak};
@@ -208,7 +208,7 @@ pub async fn dump_table(
 
 #[derive(Default)]
 struct ResolveMap {
-    private_domains: BTreeMap<InternedString, Weak<()>>,
+    private_domains: BTreeMap<InternedString, (BTreeSet<GatewayId>, Weak<()>)>,
     services: BTreeMap<Option<PackageId>, BTreeMap<Ipv4Addr, Weak<()>>>,
     challenges: BTreeMap<InternedString, (InternedString, Weak<()>)>,
 }
@@ -387,14 +387,19 @@ impl Resolver {
             a => a,
         };
         self.resolve.peek(|r| {
-            if !src.is_loopback()
-                && r.private_domains
-                    .get(&*name.to_lowercase().to_utf8().trim_end_matches('.'))
-                    .map_or(false, |d| d.strong_count() > 0)
-            {
+            let private_gateways = (!src.is_loopback())
+                .then(|| {
+                    r.private_domains
+                        .get(&*name.to_lowercase().to_utf8().trim_end_matches('.'))
+                        .filter(|(_, rc)| rc.strong_count() > 0)
+                        .map(|(gateways, _)| gateways)
+                })
+                .flatten();
+            if let Some(gateways) = private_gateways {
                 if let Some(res) = self.net_iface.peek(|i| {
-                    i.values()
-                        .filter_map(|i| i.ip_info.as_ref())
+                    i.iter()
+                        .filter(|(gid, _)| gateways.contains(*gid))
+                        .filter_map(|(_, i)| i.ip_info.as_ref())
                         .find(|i| i.subnets.iter().any(|s| s.contains(&src)))
                         .map(|ip_info| {
                             let mut res = ip_info.subnets.iter().collect::<Vec<_>>();
@@ -405,10 +410,11 @@ impl Resolver {
                     return Some(res);
                 } else if is_private_ip(src) {
                     // Source is a private IP not in any known subnet (e.g. VPN on a different VLAN).
-                    // Return all private IPs from all interfaces.
+                    // Return private IPs from the gateways this domain is served on.
                     let res: Vec<IpAddr> = self.net_iface.peek(|i| {
-                        i.values()
-                            .filter_map(|i| i.ip_info.as_ref())
+                        i.iter()
+                            .filter(|(gid, _)| gateways.contains(*gid))
+                            .filter_map(|(_, i)| i.ip_info.as_ref())
                             .flat_map(|ip_info| ip_info.subnets.iter().map(|s| s.addr()))
                             .collect()
                     });
@@ -694,15 +700,20 @@ impl DnsController {
         }
     }
 
-    pub fn add_private_domain(&self, fqdn: InternedString) -> Result<Arc<()>, Error> {
+    pub fn add_private_domain(
+        &self,
+        fqdn: InternedString,
+        gateways: BTreeSet<GatewayId>,
+    ) -> Result<Arc<()>, Error> {
         if let Some(resolve) = Weak::upgrade(&self.resolve) {
             resolve.mutate(|writable| {
-                let weak = writable.private_domains.entry(fqdn).or_default();
-                let rc = if let Some(rc) = Weak::upgrade(&*weak) {
+                let entry = writable.private_domains.entry(fqdn).or_default();
+                entry.0 = gateways;
+                let rc = if let Some(rc) = Weak::upgrade(&entry.1) {
                     rc
                 } else {
                     let new = Arc::new(());
-                    *weak = Arc::downgrade(&new);
+                    entry.1 = Arc::downgrade(&new);
                     new
                 };
                 Ok(rc)
@@ -754,7 +765,7 @@ impl DnsController {
             resolve.mutate(|writable| {
                 for domain in domains {
                     if let Some((k, v)) = writable.private_domains.remove_entry(domain) {
-                        if v.strong_count() > 0 {
+                        if v.1.strong_count() > 0 {
                             writable.private_domains.insert(k, v);
                         }
                     }

--- a/core/src/net/dns.rs
+++ b/core/src/net/dns.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::str::FromStr;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
@@ -23,7 +23,7 @@ use rpc_toolkit::{
     Context, HandlerArgs, HandlerExt, ParentHandler, from_fn_async, from_fn_blocking,
 };
 use serde::{Deserialize, Serialize};
-use tokio::net::{TcpListener, UdpSocket};
+use tokio::net::UdpSocket;
 use tokio::sync::RwLock;
 use tracing::instrument;
 use ts_rs::TS;
@@ -32,7 +32,7 @@ use crate::context::{CliContext, RpcContext};
 use crate::db::model::Database;
 use crate::db::model::public::NetworkInterfaceInfo;
 use crate::net::gateway::NetworkInterfaceWatcher;
-use crate::net::utils::is_private_ip;
+use crate::net::utils::{bind_tokio_listener, ipv6_is_link_local};
 use crate::prelude::*;
 use crate::util::future::NonDetachingJoinHandle;
 use crate::util::io::file_string_stream;
@@ -229,19 +229,19 @@ struct Resolver {
     catalog: Arc<RwLock<Catalog>>,
     resolve: Arc<SyncRwLock<ResolveMap>>,
     net_iface: Watch<OrdMap<GatewayId, NetworkInterfaceInfo>>,
-    _thread: NonDetachingJoinHandle<()>,
+    /// The gateway whose socket this resolver serves; `None` for the wildcard
+    /// catch-all. Private domains are only answered when their gateway set
+    /// contains this gateway, so they never leak across interfaces.
+    my_gateway: Option<GatewayId>,
 }
-impl Resolver {
-    fn new(
-        db: TypedPatchDb<Database>,
-        net_iface: Watch<OrdMap<GatewayId, NetworkInterfaceInfo>>,
-    ) -> Self {
-        let catalog = Arc::new(RwLock::new(Catalog::new()));
-        Self {
-            catalog: catalog.clone(),
-            resolve: Arc::new(SyncRwLock::new(ResolveMap::default())),
-            net_iface,
-            _thread: tokio::spawn(async move {
+
+/// Keep the forwarder authority in `catalog` in sync with resolv.conf and the
+/// user's static upstream servers.
+fn spawn_forwarder(
+    db: TypedPatchDb<Database>,
+    catalog: Arc<RwLock<Catalog>>,
+) -> NonDetachingJoinHandle<()> {
+    tokio::spawn(async move {
                 let mut prev = crate::util::serde::hash_serializable::<sha2::Sha256, _>(&(
                     ResolverConfig::new(),
                     ResolverOpts::default(),
@@ -369,9 +369,9 @@ impl Resolver {
                     }
                 }
             })
-            .into(),
-        }
-    }
+        .into()
+}
+impl Resolver {
     fn resolve(&self, name: &Name, mut src: IpAddr) -> Option<Vec<IpAddr>> {
         if name.zone_of(&*LOCALHOST) {
             return Some(vec![Ipv4Addr::LOCALHOST.into(), Ipv6Addr::LOCALHOST.into()]);
@@ -387,48 +387,24 @@ impl Resolver {
             a => a,
         };
         self.resolve.peek(|r| {
-            let private_gateways = (!src.is_loopback())
-                .then(|| {
-                    r.private_domains
-                        .get(&*name.to_lowercase().to_utf8().trim_end_matches('.'))
-                        .filter(|(_, rc)| rc.strong_count() > 0)
-                        .map(|(gateways, _)| gateways)
-                })
-                .flatten();
-            if let Some(gateways) = private_gateways {
-                if let Some(res) = self.net_iface.peek(|i| {
-                    i.iter()
-                        .filter(|(gid, _)| gateways.contains(*gid))
-                        .filter_map(|(_, i)| i.ip_info.as_ref())
-                        .find(|i| i.subnets.iter().any(|s| s.contains(&src)))
-                        .map(|ip_info| {
-                            let mut res = ip_info.subnets.iter().collect::<Vec<_>>();
-                            res.sort_by_cached_key(|a| !a.contains(&src));
-                            res.into_iter().map(|s| s.addr()).collect()
-                        })
-                }) {
-                    return Some(res);
-                } else if is_private_ip(src) {
-                    // Source is a private IP not in any known subnet (e.g. VPN on a different VLAN).
-                    // Return private IPs from the gateways this domain is served on.
-                    let res: Vec<IpAddr> = self.net_iface.peek(|i| {
-                        i.iter()
-                            .filter(|(gid, _)| gateways.contains(*gid))
-                            .filter_map(|(_, i)| i.ip_info.as_ref())
-                            .flat_map(|ip_info| ip_info.subnets.iter().map(|s| s.addr()))
-                            .collect()
-                    });
-                    if !res.is_empty() {
+            if let Some(my_gateway) = self.my_gateway.as_ref().filter(|_| !src.is_loopback()) {
+                let serves_here = r
+                    .private_domains
+                    .get(&*name.to_lowercase().to_utf8().trim_end_matches('.'))
+                    .filter(|(_, rc)| rc.strong_count() > 0)
+                    .map_or(false, |(gateways, _)| gateways.contains(my_gateway));
+                if serves_here {
+                    if let Some(res) = self.net_iface.peek(|i| {
+                        i.get(my_gateway)
+                            .and_then(|info| info.ip_info.as_ref())
+                            .map(|ip_info| {
+                                let mut res = ip_info.subnets.iter().collect::<Vec<_>>();
+                                res.sort_by_cached_key(|a| !a.contains(&src));
+                                res.into_iter().map(|s| s.addr()).collect()
+                            })
+                    }) {
                         return Some(res);
                     }
-                } else {
-                    tracing::warn!(
-                        "{}",
-                        t!(
-                            "net.dns.could-not-determine-source-interface",
-                            src = src.to_string()
-                        )
-                    );
                 }
             }
             if STARTOS.zone_of(name) || EMBASSY.zone_of(name) {
@@ -617,43 +593,120 @@ impl RequestHandler for Resolver {
     }
 }
 
+fn bind_reuse_udp(addr: SocketAddr, dual_stack: bool) -> Result<UdpSocket, Error> {
+    let domain = match addr {
+        SocketAddr::V4(_) => socket2::Domain::IPV4,
+        SocketAddr::V6(_) => socket2::Domain::IPV6,
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))
+        .with_kind(ErrorKind::Network)?;
+    socket
+        .set_reuse_address(true)
+        .with_kind(ErrorKind::Network)?;
+    if matches!(addr, SocketAddr::V6(_)) {
+        socket
+            .set_only_v6(!dual_stack)
+            .with_kind(ErrorKind::Network)?;
+    }
+    socket.set_nonblocking(true).with_kind(ErrorKind::Network)?;
+    socket.bind(&addr.into()).with_kind(ErrorKind::Network)?;
+    UdpSocket::from_std(socket.into()).with_kind(ErrorKind::Network)
+}
+
+fn dns_server_on(resolver: Resolver, addr: SocketAddr) -> Result<ServerFuture<Resolver>, Error> {
+    let dual_stack = matches!(addr, SocketAddr::V6(v6) if v6.ip().is_unspecified());
+    let mut server = ServerFuture::new(resolver);
+    server.register_listener(
+        bind_tokio_listener(addr).with_kind(ErrorKind::Network)?,
+        Duration::from_secs(30),
+    );
+    server.register_socket(bind_reuse_udp(addr, dual_stack)?);
+    Ok(server)
+}
+
+/// Serve DNS on a wildcard catch-all socket plus a socket bound to each gateway
+/// interface address. The wildcard handles loopback, the container bridge, and
+/// `*.startos`/forwarding; the per-gateway sockets additionally answer private
+/// domains, and because each binds a specific address the kernel routes a query
+/// to the socket for the interface it ingressed on — so a private domain is only
+/// served on the gateways it's configured for, regardless of source IP.
+async fn run_dns_servers(
+    db: TypedPatchDb<Database>,
+    catalog: Arc<RwLock<Catalog>>,
+    resolve: Arc<SyncRwLock<ResolveMap>>,
+    mut net_iface: Watch<OrdMap<GatewayId, NetworkInterfaceInfo>>,
+) -> Result<(), Error> {
+    let _forwarder = spawn_forwarder(db, catalog.clone());
+    let resolver_iface = net_iface.clone();
+    let resolver = |my_gateway: Option<GatewayId>| Resolver {
+        catalog: catalog.clone(),
+        resolve: resolve.clone(),
+        net_iface: resolver_iface.clone(),
+        my_gateway,
+    };
+
+    let _wildcard = dns_server_on(
+        resolver(None),
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 53),
+    )?;
+
+    let mut per_gateway: BTreeMap<SocketAddr, ServerFuture<Resolver>> = BTreeMap::new();
+    loop {
+        let desired: BTreeMap<SocketAddr, GatewayId> = net_iface.peek(|ifaces| {
+            ifaces
+                .iter()
+                .filter_map(|(gw, info)| info.ip_info.as_ref().map(|ip_info| (gw, ip_info)))
+                .flat_map(|(gw, ip_info)| {
+                    ip_info.subnets.iter().map(move |subnet| {
+                        let addr = match subnet.addr() {
+                            IpAddr::V6(v6) if ipv6_is_link_local(v6) => {
+                                SocketAddr::V6(SocketAddrV6::new(v6, 53, 0, ip_info.scope_id))
+                            }
+                            ip => SocketAddr::new(ip, 53),
+                        };
+                        (addr, gw.clone())
+                    })
+                })
+                .collect()
+        });
+
+        per_gateway.retain(|addr, _| desired.contains_key(addr));
+        for (addr, gw) in desired {
+            if !per_gateway.contains_key(&addr) {
+                match dns_server_on(resolver(Some(gw)), addr) {
+                    Ok(server) => {
+                        per_gateway.insert(addr, server);
+                    }
+                    Err(e) => {
+                        tracing::error!("failed to bind DNS on {addr}: {e}");
+                        tracing::debug!("{e:?}");
+                    }
+                }
+            }
+        }
+
+        net_iface.changed().await;
+    }
+}
+
 impl DnsController {
     #[instrument(skip_all)]
     pub async fn init(
         db: TypedPatchDb<Database>,
         watcher: &NetworkInterfaceWatcher,
     ) -> Result<Self, Error> {
-        let resolver = Resolver::new(db, watcher.subscribe());
-        let resolve = Arc::downgrade(&resolver.resolve);
-        let mut server = ServerFuture::new(resolver);
+        let resolve = Arc::new(SyncRwLock::new(ResolveMap::default()));
+        let catalog = Arc::new(RwLock::new(Catalog::new()));
+        let weak = Arc::downgrade(&resolve);
+        let net_iface = watcher.subscribe();
 
-        let dns_server = tokio::spawn(
-            async move {
-                server.register_listener(
-                    TcpListener::bind((Ipv6Addr::UNSPECIFIED, 53))
-                        .await
-                        .with_kind(ErrorKind::Network)?,
-                    Duration::from_secs(30),
-                );
-                server.register_socket(
-                    UdpSocket::bind((Ipv6Addr::UNSPECIFIED, 53))
-                        .await
-                        .with_kind(ErrorKind::Network)?,
-                );
-
-                server
-                    .block_until_done()
-                    .await
-                    .with_kind(ErrorKind::Network)
-            }
-            .map(|r| {
-                r.log_err();
-            }),
-        )
+        let dns_server = tokio::spawn(run_dns_servers(db, catalog, resolve, net_iface).map(|r| {
+            r.log_err();
+        }))
         .into();
 
         Ok(Self {
-            resolve,
+            resolve: weak,
             dns_server,
         })
     }

--- a/core/src/net/dns.rs
+++ b/core/src/net/dns.rs
@@ -38,7 +38,7 @@ use crate::util::future::NonDetachingJoinHandle;
 use crate::util::io::file_string_stream;
 use crate::util::serde::{HandlerExtSerde, display_serializable};
 use crate::util::sync::{SyncRwLock, Watch};
-use crate::{GatewayId, OptionExt, PackageId};
+use crate::{GatewayId, HOST_IP, OptionExt, PackageId};
 
 pub fn dns_api<C: Context>() -> ParentHandler<C> {
     ParentHandler::new()
@@ -225,14 +225,25 @@ lazy_static::lazy_static! {
     static ref EMBASSY: Name = Name::from_ascii("embassy").unwrap();
 }
 
+/// What private domains a resolver (one per bound socket) may answer.
+#[derive(Clone)]
+enum PrivateScope {
+    /// Wildcard catch-all — never answers private domains.
+    None,
+    /// A gateway interface — answers a private domain only when its gateway set
+    /// contains this gateway, returning that gateway's own address.
+    Gateway(GatewayId),
+    /// Loopback / container bridge — answers every private domain, returning
+    /// these fixed local addresses so the host and service containers can always
+    /// reach a private domain locally.
+    Local(Vec<IpAddr>),
+}
+
 struct Resolver {
     catalog: Arc<RwLock<Catalog>>,
     resolve: Arc<SyncRwLock<ResolveMap>>,
     net_iface: Watch<OrdMap<GatewayId, NetworkInterfaceInfo>>,
-    /// The gateway whose socket this resolver serves; `None` for the wildcard
-    /// catch-all. Private domains are only answered when their gateway set
-    /// contains this gateway, so they never leak across interfaces.
-    my_gateway: Option<GatewayId>,
+    scope: PrivateScope,
 }
 
 /// Keep the forwarder authority in `catalog` in sync with resolv.conf and the
@@ -386,24 +397,37 @@ impl Resolver {
             }
             a => a,
         };
+        let domain = name.to_lowercase().to_utf8();
+        let domain = domain.trim_end_matches('.');
         self.resolve.peek(|r| {
-            if let Some(my_gateway) = self.my_gateway.as_ref().filter(|_| !src.is_loopback()) {
-                let serves_here = r
-                    .private_domains
-                    .get(&*name.to_lowercase().to_utf8().trim_end_matches('.'))
-                    .filter(|(_, rc)| rc.strong_count() > 0)
-                    .map_or(false, |(gateways, _)| gateways.contains(my_gateway));
-                if serves_here {
-                    if let Some(res) = self.net_iface.peek(|i| {
-                        i.get(my_gateway)
-                            .and_then(|info| info.ip_info.as_ref())
-                            .map(|ip_info| {
-                                let mut res = ip_info.subnets.iter().collect::<Vec<_>>();
-                                res.sort_by_cached_key(|a| !a.contains(&src));
-                                res.into_iter().map(|s| s.addr()).collect()
-                            })
-                    }) {
-                        return Some(res);
+            match &self.scope {
+                PrivateScope::None => {}
+                PrivateScope::Gateway(my_gateway) => {
+                    let serves_here = r
+                        .private_domains
+                        .get(domain)
+                        .filter(|(_, rc)| rc.strong_count() > 0)
+                        .map_or(false, |(gateways, _)| gateways.contains(my_gateway));
+                    if serves_here {
+                        if let Some(res) = self.net_iface.peek(|i| {
+                            i.get(my_gateway)
+                                .and_then(|info| info.ip_info.as_ref())
+                                .map(|ip_info| {
+                                    let mut res = ip_info.subnets.iter().collect::<Vec<_>>();
+                                    res.sort_by_cached_key(|a| !a.contains(&src));
+                                    res.into_iter().map(|s| s.addr()).collect()
+                                })
+                        }) {
+                            return Some(res);
+                        }
+                    }
+                }
+                PrivateScope::Local(addrs) => {
+                    if r.private_domains
+                        .get(domain)
+                        .map_or(false, |(_, rc)| rc.strong_count() > 0)
+                    {
+                        return Some(addrs.clone());
                     }
                 }
             }
@@ -625,11 +649,12 @@ fn dns_server_on(resolver: Resolver, addr: SocketAddr) -> Result<ServerFuture<Re
 }
 
 /// Serve DNS on a wildcard catch-all socket plus a socket bound to each gateway
-/// interface address. The wildcard handles loopback, the container bridge, and
-/// `*.startos`/forwarding; the per-gateway sockets additionally answer private
-/// domains, and because each binds a specific address the kernel routes a query
-/// to the socket for the interface it ingressed on — so a private domain is only
-/// served on the gateways it's configured for, regardless of source IP.
+/// interface address, loopback, and the container bridge. Because each specific
+/// socket only receives datagrams sent to its address, the kernel routes a query
+/// to the socket for the interface it ingressed on. A gateway socket answers a
+/// private domain only when the domain is configured for that gateway (so it
+/// never leaks across interfaces), while loopback and the container bridge answer
+/// every private domain locally; the wildcard answers none.
 async fn run_dns_servers(
     db: TypedPatchDb<Database>,
     catalog: Arc<RwLock<Catalog>>,
@@ -638,44 +663,60 @@ async fn run_dns_servers(
 ) -> Result<(), Error> {
     let _forwarder = spawn_forwarder(db, catalog.clone());
     let resolver_iface = net_iface.clone();
-    let resolver = |my_gateway: Option<GatewayId>| Resolver {
+    let resolver = |scope: PrivateScope| Resolver {
         catalog: catalog.clone(),
         resolve: resolve.clone(),
         net_iface: resolver_iface.clone(),
-        my_gateway,
+        scope,
     };
 
-    let _wildcard = dns_server_on(
-        resolver(None),
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 53),
-    )?;
+    let loopback = vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)];
+    let host_ip = IpAddr::V4(Ipv4Addr::from(HOST_IP));
 
-    let mut per_gateway: BTreeMap<SocketAddr, ServerFuture<Resolver>> = BTreeMap::new();
+    let mut servers: BTreeMap<SocketAddr, ServerFuture<Resolver>> = BTreeMap::new();
     loop {
-        let desired: BTreeMap<SocketAddr, GatewayId> = net_iface.peek(|ifaces| {
-            ifaces
-                .iter()
-                .filter_map(|(gw, info)| info.ip_info.as_ref().map(|ip_info| (gw, ip_info)))
-                .flat_map(|(gw, ip_info)| {
-                    ip_info.subnets.iter().map(move |subnet| {
-                        let addr = match subnet.addr() {
-                            IpAddr::V6(v6) if ipv6_is_link_local(v6) => {
-                                SocketAddr::V6(SocketAddrV6::new(v6, 53, 0, ip_info.scope_id))
-                            }
-                            ip => SocketAddr::new(ip, 53),
-                        };
-                        (addr, gw.clone())
-                    })
-                })
-                .collect()
+        let mut desired: BTreeMap<SocketAddr, PrivateScope> = BTreeMap::new();
+        net_iface.peek(|ifaces| {
+            for (gw, info) in ifaces {
+                let Some(ip_info) = info.ip_info.as_ref() else {
+                    continue;
+                };
+                for subnet in &ip_info.subnets {
+                    let addr = match subnet.addr() {
+                        IpAddr::V6(v6) if ipv6_is_link_local(v6) => {
+                            SocketAddr::V6(SocketAddrV6::new(v6, 53, 0, ip_info.scope_id))
+                        }
+                        ip => SocketAddr::new(ip, 53),
+                    };
+                    desired.insert(addr, PrivateScope::Gateway(gw.clone()));
+                }
+            }
         });
+        // wildcard catch-all + the always-on loopback / container-bridge scopes,
+        // inserted last so they win over any gateway that reports the same address.
+        desired.insert(
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 53),
+            PrivateScope::None,
+        );
+        desired.insert(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 53),
+            PrivateScope::Local(loopback.clone()),
+        );
+        desired.insert(
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 53),
+            PrivateScope::Local(loopback.clone()),
+        );
+        desired.insert(
+            SocketAddr::new(host_ip, 53),
+            PrivateScope::Local(vec![host_ip]),
+        );
 
-        per_gateway.retain(|addr, _| desired.contains_key(addr));
-        for (addr, gw) in desired {
-            if !per_gateway.contains_key(&addr) {
-                match dns_server_on(resolver(Some(gw)), addr) {
+        servers.retain(|addr, _| desired.contains_key(addr));
+        for (addr, scope) in desired {
+            if !servers.contains_key(&addr) {
+                match dns_server_on(resolver(scope), addr) {
                     Ok(server) => {
-                        per_gateway.insert(addr, server);
+                        servers.insert(addr, server);
                     }
                     Err(e) => {
                         tracing::error!("failed to bind DNS on {addr}: {e}");

--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -196,12 +196,13 @@ impl NetServiceData {
         let net_ifaces = ctrl.net_iface.watcher.ip_info();
         let host_addresses: Vec<_> = host.addresses().collect();
 
-        // Collect private DNS entries (domains without public config)
+        // Collect private DNS entries: any domain with a private gateway, even
+        // if the same domain is also served publicly (split DNS).
         for HostAddress {
-            address, public, ..
+            address, private, ..
         } in &host_addresses
         {
-            if public.is_none() {
+            if private.is_some() {
                 private_dns.insert(address.clone());
             }
         }

--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -19,7 +19,6 @@ use crate::net::forward::{
     ForwardRequirements, InterfacePortForwardController, START9_BRIDGE_IFACE, add_iptables_rule,
 };
 use crate::net::gateway::NetworkInterfaceController;
-use crate::net::host::address::HostAddress;
 use crate::net::host::binding::{AddSslOptions, BindId, BindOptions};
 use crate::net::host::{Host, Hosts, host_for};
 use crate::net::service_interface::HostnameMetadata;
@@ -196,17 +195,6 @@ impl NetServiceData {
         let net_ifaces = ctrl.net_iface.watcher.ip_info();
         let host_addresses: Vec<_> = host.addresses().collect();
 
-        // Collect private DNS entries: any domain with a private gateway, even
-        // if the same domain is also served publicly (split DNS).
-        for HostAddress {
-            address, private, ..
-        } in &host_addresses
-        {
-            if private.is_some() {
-                private_dns.insert(address.clone());
-            }
-        }
-
         // ── Build controller entries from enabled addresses ──
         for (port, bind) in host.bindings.iter() {
             if !bind.enabled {
@@ -218,6 +206,22 @@ impl NetServiceData {
 
             let enabled_addresses = bind.addresses.enabled();
             let addr: SocketAddr = (self.ip, *port).into();
+
+            // Serve private DNS for enabled private-domain addresses whose
+            // gateway is up — even when the same domain is also public (split
+            // DNS). The public-domain entry is a separate address, so a dual
+            // public+private domain still has a PrivateDomain entry here.
+            for addr_info in &enabled_addresses {
+                if let HostnameMetadata::PrivateDomain { gateways } = &addr_info.metadata {
+                    if gateways.iter().any(|gw| {
+                        net_ifaces
+                            .get(gw)
+                            .map_or(false, |info| info.ip_info.is_some())
+                    }) {
+                        private_dns.insert(addr_info.hostname.clone());
+                    }
+                }
+            }
 
             // SSL vhosts
             if let Some(ssl) = &bind.options.add_ssl {

--- a/core/src/net/net_controller.rs
+++ b/core/src/net/net_controller.rs
@@ -189,7 +189,7 @@ impl NetServiceData {
     async fn update(&mut self, ctrl: &NetController, id: HostId, host: Host) -> Result<(), Error> {
         let mut forwards: BTreeMap<u16, (SocketAddrV4, ForwardRequirements)> = BTreeMap::new();
         let mut vhosts: BTreeMap<(Option<InternedString>, u16), ProxyTarget> = BTreeMap::new();
-        let mut private_dns: BTreeSet<InternedString> = BTreeSet::new();
+        let mut private_dns: BTreeMap<InternedString, BTreeSet<GatewayId>> = BTreeMap::new();
         let binds = self.binds.entry(id.clone()).or_default();
 
         let net_ifaces = ctrl.net_iface.watcher.ip_info();
@@ -207,18 +207,24 @@ impl NetServiceData {
             let enabled_addresses = bind.addresses.enabled();
             let addr: SocketAddr = (self.ip, *port).into();
 
-            // Serve private DNS for enabled private-domain addresses whose
-            // gateway is up — even when the same domain is also public (split
-            // DNS). The public-domain entry is a separate address, so a dual
-            // public+private domain still has a PrivateDomain entry here.
+            // Key private DNS by its live gateways so the resolver only answers
+            // locally over those gateways — works even when also public (split DNS).
             for addr_info in &enabled_addresses {
                 if let HostnameMetadata::PrivateDomain { gateways } = &addr_info.metadata {
-                    if gateways.iter().any(|gw| {
-                        net_ifaces
-                            .get(gw)
-                            .map_or(false, |info| info.ip_info.is_some())
-                    }) {
-                        private_dns.insert(addr_info.hostname.clone());
+                    let live: BTreeSet<GatewayId> = gateways
+                        .iter()
+                        .filter(|gw| {
+                            net_ifaces
+                                .get(*gw)
+                                .map_or(false, |info| info.ip_info.is_some())
+                        })
+                        .cloned()
+                        .collect();
+                    if !live.is_empty() {
+                        private_dns
+                            .entry(addr_info.hostname.clone())
+                            .or_default()
+                            .extend(live);
                     }
                 }
             }
@@ -475,17 +481,17 @@ impl NetServiceData {
 
         let mut rm = BTreeSet::new();
         binds.private_dns.retain(|fqdn, _| {
-            if private_dns.remove(fqdn) {
+            if private_dns.contains_key(fqdn) {
                 true
             } else {
                 rm.insert(fqdn.clone());
                 false
             }
         });
-        for fqdn in private_dns {
+        for (fqdn, gateways) in private_dns {
             binds
                 .private_dns
-                .insert(fqdn.clone(), ctrl.dns.add_private_domain(fqdn)?);
+                .insert(fqdn.clone(), ctrl.dns.add_private_domain(fqdn, gateways)?);
         }
         ctrl.dns.gc_private_domains(&rm)?;
 


### PR DESCRIPTION
## Problem

Closes #3263.

When a domain is configured as **both** a private domain (e.g. on the Ethernet/Wired gateway) and a public domain (on a StartTunnel gateway), StartOS DNS did not serve the LAN IP for that domain. It forwarded the query upstream and returned the public VPS IP, so LAN clients using StartOS as their resolver suffered hairpin routing (traffic exits to the VPS and tunnels back).

## Root cause

`NetController::update` (`core/src/net/net_controller.rs`) collects the set of domains to register as authoritative private records, but the loop only inserted addresses where `public.is_none()`:

```rust
for HostAddress { address, public, .. } in &host_addresses {
    if public.is_none() {
        private_dns.insert(address.clone());
    }
}
```

`Host::addresses()` emits a single `HostAddress` per public domain with `public: Some(..)` **and** `private: Some(..)` when the same domain also has private gateways. So a dual public+private domain has `public.is_some()` and was skipped — never added to the DNS resolver's `private_domains` map. The resolver (`core/src/net/dns.rs`) only serves a local LAN answer for names present in that map, so the query fell through to the upstream forwarder.

This already-intended capability is confirmed by `handle_duplicates` in `core/src/net/host/address.rs`, which deliberately allows the same domain to be both public and private (it skips the duplicate-domain error for private domains that are also public).

## Fix

Register a domain as private DNS whenever it has a private gateway config, regardless of whether it is also served publicly:

```rust
for HostAddress { address, private, .. } in &host_addresses {
    if private.is_some() {
        private_dns.insert(address.clone());
    }
}
```

This enables native split DNS: LAN clients resolve the domain to the server's LAN IP and connect directly (same domain, same TLS cert, LAN speeds), while external clients continue to resolve via public DNS to the VPS.

## Testing

- `cargo check -p start-os --lib` passes (only pre-existing warnings).
- Behavioral verification (install/runtime DNS resolution with a dual public+private domain) was not run in this environment — it needs a StartOS host with a StartTunnel gateway and a LAN client. Worth a manual `dig @<startos-lan-ip> <domain>` check confirming the `aa` flag and LAN IP after this change.