### PR TITLE
fixes from integration testing

### DIFF
--- a/core/src/disk/mount/guard.rs
+++ b/core/src/disk/mount/guard.rs
@@ -116,7 +116,9 @@ async fn tmp_mountpoint(source: &impl FileSystem) -> Result<PathBuf, Error> {
 }
 
 lazy_static! {
-    static ref TMP_MOUNTS: Mutex<BTreeMap<PathBuf, (MountType, Weak<MountGuard>)>> =
+    // Maps each tmp mountpoint to its own lock. The outer map lock is held only
+    // while fetching/creating a slot — never across the mount itself.
+    static ref TMP_MOUNTS: Mutex<BTreeMap<PathBuf, Arc<Mutex<(MountType, Weak<MountGuard>)>>>> =
         Mutex::new(BTreeMap::new());
 }
 
@@ -129,11 +131,18 @@ impl TmpMountGuard {
     #[instrument(skip_all)]
     pub async fn mount(filesystem: &impl FileSystem, mount_type: MountType) -> Result<Self, Error> {
         let mountpoint = tmp_mountpoint(filesystem).await?;
-        let mut tmp_mounts = TMP_MOUNTS.lock().await;
-        if !tmp_mounts.contains_key(&mountpoint) {
-            tmp_mounts.insert(mountpoint.clone(), (mount_type, Weak::new()));
-        }
-        let (prev_mt, weak_slot) = tmp_mounts.get_mut(&mountpoint).unwrap();
+        // Grab the per-mountpoint slot, then drop the outer map lock before
+        // mounting. Holding the global lock across the mount self-deadlocks:
+        // `IdMapped::mount` re-enters `TmpMountGuard::mount` to stage its inner
+        // filesystem, which needs the same lock.
+        let slot = TMP_MOUNTS
+            .lock()
+            .await
+            .entry(mountpoint.clone())
+            .or_insert_with(|| Arc::new(Mutex::new((mount_type, Weak::new()))))
+            .clone();
+        let mut slot = slot.lock().await;
+        let (prev_mt, weak_slot) = &mut *slot;
         if let Some(guard) = weak_slot.upgrade() {
             // upgrade to rw
             if *prev_mt == ReadOnly && mount_type != ReadOnly {

--- a/core/src/net/forward.rs
+++ b/core/src/net/forward.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write;
 use std::net::{IpAddr, SocketAddrV4};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
@@ -272,7 +273,9 @@ pub async fn nft_ensure_base() -> Result<(), Error> {
     Ok(())
 }
 
-async fn nft_handles(chain: &str, comment: &str) -> Vec<u32> {
+/// Rules in `chain` tagged with `comment`, as `(handle, body)` where `body` is
+/// the rule text preceding the `comment "..."` token.
+async fn nft_rules_with_comment(chain: &str, comment: &str) -> Vec<(u32, String)> {
     let out = Command::new("nft")
         .arg("-a")
         .arg("list")
@@ -286,16 +289,28 @@ async fn nft_handles(chain: &str, comment: &str) -> Vec<u32> {
     let needle = format!("comment \"{comment}\"");
     String::from_utf8_lossy(&out)
         .lines()
-        .filter(|line| line.contains(&needle))
-        .filter_map(|line| line.rsplit_once("# handle ")?.1.trim().parse::<u32>().ok())
+        .filter_map(|line| {
+            let handle = line.rsplit_once("# handle ")?.1.trim().parse::<u32>().ok()?;
+            let body = line.split_once(&needle)?.0.trim().to_owned();
+            Some((handle, body))
+        })
         .collect()
 }
 
 /// Idempotently install (or, with `undo`, remove) the rule tagged `comment` in
-/// `chain` of `table ip startos`. Any prior rule(s) with the same comment in
-/// that chain are removed first, so this reconciles rather than blindly
-/// appends. `prepend` inserts at the top of the chain (needed for the
-/// mark-restore rule, which must run before the per-interface set-mark rules).
+/// `chain` of `table ip startos`. The reconcile is applied as a single atomic
+/// nft transaction — every prior rule with this comment is deleted and the new
+/// rule added in one invocation — and is a no-op when the chain already holds
+/// exactly the desired rule. `prepend` inserts at the top of the chain (needed
+/// for the mark-restore rule, which must run before the per-interface set-mark
+/// rules).
+///
+/// Lock-free under concurrency: the only way the transaction can fail is a
+/// stale handle — another reconcile of the *same* comment deleted/replaced the
+/// rule between our list and our delete. That race is benign (nft commits
+/// atomically, so the other writer's rule is already in place) and only arises
+/// for callers without a single-writer guarantee (e.g. the tunnel masq rules);
+/// we warn, re-read, and retry, converging via the no-op check above.
 pub async fn nft_rule(
     chain: &str,
     comment: &str,
@@ -304,22 +319,61 @@ pub async fn nft_rule(
     rule: &str,
 ) -> Result<(), Error> {
     nft_ensure_base().await?;
-    for handle in nft_handles(chain, comment).await {
-        Command::new("nft")
-            .arg(format!("delete rule ip startos {chain} handle {handle}"))
-            .invoke(ErrorKind::Network)
-            .await?;
-    }
-    if !undo {
-        let verb = if prepend { "insert" } else { "add" };
-        Command::new("nft")
-            .arg(format!(
+
+    const MAX_ATTEMPTS: usize = 5;
+    let mut last_err = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let existing = nft_rules_with_comment(chain, comment).await;
+
+        // Already converged: nothing to undo, or exactly the desired rule present.
+        if undo {
+            if existing.is_empty() {
+                return Ok(());
+            }
+        } else if let [(_, body)] = existing.as_slice() {
+            if body == rule {
+                return Ok(());
+            }
+        }
+
+        // Single atomic transaction: drop every prior copy, then add the
+        // desired rule. Convergent from any starting state (0, 1, or N stale
+        // copies), with no window where the rule is missing or duplicated.
+        let mut script = String::new();
+        for (handle, _) in &existing {
+            writeln!(script, "delete rule ip startos {chain} handle {handle}").unwrap();
+        }
+        if !undo {
+            let verb = if prepend { "insert" } else { "add" };
+            writeln!(
+                script,
                 "{verb} rule ip startos {chain} {rule} comment \"{comment}\""
-            ))
+            )
+            .unwrap();
+        }
+        if script.is_empty() {
+            return Ok(());
+        }
+
+        match Command::new("nft")
+            .arg(&script)
             .invoke(ErrorKind::Network)
-            .await?;
+            .await
+        {
+            Ok(_) => return Ok(()),
+            // Stale handle: a concurrent reconcile of this comment won the race.
+            // Re-read and retry; the no-op check above usually returns on the
+            // next pass. Any other error is real and surfaces immediately.
+            Err(e) if e.source.to_string().contains("No such file or directory") => {
+                tracing::warn!(
+                    "nft_rule {chain}/{comment}: stale handle on attempt {attempt}/{MAX_ATTEMPTS}"
+                );
+                last_err = Some(e);
+            }
+            Err(e) => return Err(e),
+        }
     }
-    Ok(())
+    Err(last_err.expect("loop only exits here via the stale-handle path, which sets last_err"))
 }
 
 impl PortForwardController {

--- a/core/src/net/gateway.rs
+++ b/core/src/net/gateway.rs
@@ -31,7 +31,7 @@ use zbus::{Connection, proxy};
 use crate::context::{CliContext, RpcContext};
 use crate::db::model::Database;
 use crate::db::model::public::{IpInfo, NetworkInterfaceInfo, NetworkInterfaceType};
-use crate::net::forward::{START9_BRIDGE_IFACE, nft_rule};
+use crate::net::forward::{START9_BRIDGE_IFACE, nft_ensure_base};
 use crate::net::gateway::device::DeviceProxy;
 use crate::net::host::all_hosts;
 use crate::net::utils::{bind_mio_listener, find_wifi_iface};
@@ -752,6 +752,7 @@ async fn watcher(
                             t!("net.gateway.no-devices-returned")
                         );
                         let mut ifaces = BTreeSet::new();
+                        let mut policy_ifaces: BTreeMap<GatewayId, u32> = BTreeMap::new();
                         let mut jobs = Vec::new();
                         for device in devices {
                             use futures::future::Either;
@@ -763,6 +764,18 @@ async fn watcher(
                                 continue;
                             }
                             let iface: GatewayId = iface.into();
+                            // Only policy-route managed, connected gateways —
+                            // mirrors the gating in `watch_ip` and excludes
+                            // unmanaged plumbing like container veth pairs.
+                            if device_proxy.managed().await?
+                                && &*device_proxy.active_connection().await? != "/"
+                                && let Some(table_id) = policy_table_for(
+                                    device_type_of(device_proxy.device_type().await?),
+                                    &iface,
+                                )
+                            {
+                                policy_ifaces.insert(iface.clone(), table_id);
+                            }
                             if watch_activation.peek(|a| a.contains_key(&iface)) {
                                 jobs.push(Either::Left(watch_activated(
                                     &connection,
@@ -793,6 +806,7 @@ async fn watcher(
                             changed
                         });
                         gc_policy_routing(&ifaces).await;
+                        reconcile_mangle_rules(&policy_ifaces).await.log_err();
                         for result in futures::future::join_all(jobs).await {
                             result.log_err();
                         }
@@ -842,8 +856,9 @@ struct PolicyRoutingGuard {
     table_id: u32,
 }
 
-/// Remove stale per-interface policy-routing state (fwmark rules, routing
-/// tables, iptables CONNMARK rules) for interfaces that no longer exist.
+/// Remove stale per-interface policy-routing state (fwmark ip rules and their
+/// routing tables) for interfaces that no longer exist. The nft mark rules are
+/// owned declaratively by [`reconcile_mangle_rules`], so they need no GC here.
 async fn gc_policy_routing(active_ifaces: &BTreeSet<GatewayId>) {
     let active_tables: BTreeSet<u32> = active_ifaces
         .iter()
@@ -897,38 +912,64 @@ async fn gc_policy_routing(active_ifaces: &BTreeSet<GatewayId>) {
                 .ok();
         }
     }
+}
 
-    // GC per-interface set-mark rules (tagged `mark-<iface>` in the nft
-    // mangle_prerouting chain) for defunct interfaces.
-    if let Ok(out) = Command::new("nft")
-        .arg("-a")
-        .arg("list")
-        .arg("chain")
-        .arg("ip")
-        .arg("startos")
-        .arg("mangle_prerouting")
-        .invoke(ErrorKind::Network)
-        .await
-    {
-        let text = String::from_utf8_lossy(&out);
-        for line in text.lines() {
-            let Some((_, rest)) = line.split_once("comment \"mark-") else {
-                continue;
-            };
-            let Some(iface) = rest.split('"').next() else {
-                continue;
-            };
-            if iface.is_empty()
-                || active_ifaces.contains(&GatewayId::from(InternedString::intern(iface)))
-            {
-                continue;
-            }
-            tracing::debug!("gc_policy_routing: removing stale nft mark rule for {iface}");
-            nft_rule("mangle_prerouting", &format!("mark-{iface}"), true, false, "")
-                .await
-                .log_err();
-        }
+/// Map a NetworkManager device-type id to our [`NetworkInterfaceType`].
+fn device_type_of(raw: u32) -> Option<NetworkInterfaceType> {
+    match raw {
+        1 => Some(NetworkInterfaceType::Ethernet),
+        2 => Some(NetworkInterfaceType::Wireless),
+        13 => Some(NetworkInterfaceType::Bridge),
+        29 => Some(NetworkInterfaceType::Wireguard),
+        32 => Some(NetworkInterfaceType::Loopback),
+        _ => None,
     }
+}
+
+/// The policy-routing table id (`1000 + ifindex`) for an interface, or `None`
+/// for interface types we don't policy-route (bridges, loopback). Single source
+/// of truth shared by the coordinator (which renders the nft mark rules) and
+/// `watch_ip` (which installs the matching routes and ip rule).
+fn policy_table_for(device_type: Option<NetworkInterfaceType>, iface: &GatewayId) -> Option<u32> {
+    if matches!(
+        device_type,
+        Some(NetworkInterfaceType::Bridge | NetworkInterfaceType::Loopback)
+    ) {
+        return None;
+    }
+    if_nametoindex(iface.as_str()).map(|idx| 1000 + idx).log_err()
+}
+
+/// Declaratively reconcile the StartOS-owned mangle policy-routing rules.
+///
+/// Single-writer (only the gateway coordinator calls this) and applied as one
+/// atomic nft transaction: both mangle chains are flushed and rebuilt from the
+/// active interface set, so there is no multi-writer race and defunct
+/// `mark-<iface>` rules are removed for free by the flush. `restore-mark` is
+/// emitted first so it runs before the per-interface set-mark rules (a new
+/// packet then leaves with mark 0 and routes via the main table).
+async fn reconcile_mangle_rules(policy_ifaces: &BTreeMap<GatewayId, u32>) -> Result<(), Error> {
+    nft_ensure_base().await?;
+    let mut script = String::new();
+    script.push_str("flush chain ip startos mangle_prerouting\n");
+    script.push_str("flush chain ip startos mangle_output\n");
+    script.push_str(
+        "add rule ip startos mangle_prerouting meta mark 0x00000000 meta mark set ct mark comment \"restore-mark\"\n",
+    );
+    script.push_str(
+        "add rule ip startos mangle_output meta mark 0x00000000 meta mark set ct mark comment \"restore-mark\"\n",
+    );
+    for (iface, table_id) in policy_ifaces {
+        script.push_str(&format!(
+            "add rule ip startos mangle_prerouting iifname \"{iface}\" ct state new ct mark set {table_id} comment \"mark-{iface}\"\n",
+            iface = iface.as_str(),
+        ));
+    }
+    Command::new("nft")
+        .arg(&script)
+        .invoke(ErrorKind::Network)
+        .await?;
+    Ok(())
 }
 
 #[instrument(skip(connection, device_proxy, write_to, db))]
@@ -1008,14 +1049,7 @@ async fn watch_ip(
                 loop {
                     until
                         .run(async {
-                            let device_type = match device_proxy.device_type().await? {
-                                1 => Some(NetworkInterfaceType::Ethernet),
-                                2 => Some(NetworkInterfaceType::Wireless),
-                                13 => Some(NetworkInterfaceType::Bridge),
-                                29 => Some(NetworkInterfaceType::Wireguard),
-                                32 => Some(NetworkInterfaceType::Loopback),
-                                _ => None,
-                            };
+                            let device_type = device_type_of(device_proxy.device_type().await?);
 
                             let name = InternedString::from(active_connection_proxy.id().await?);
 
@@ -1049,18 +1083,9 @@ async fn watch_ip(
                             };
 
                             // Policy routing: track per-interface table for cleanup on scope exit
-                            let policy_table_id = if !matches!(
-                                device_type,
-                                Some(NetworkInterfaceType::Bridge | NetworkInterfaceType::Loopback)
-                            ) {
-                                if_nametoindex(iface.as_str())
-                                    .map(|idx| 1000 + idx)
-                                    .log_err()
-                            } else {
-                                None
-                            };
                             let policy_guard: Option<PolicyRoutingGuard> =
-                                policy_table_id.map(|t| PolicyRoutingGuard { table_id: t });
+                                policy_table_for(device_type, &iface)
+                                    .map(|table_id| PolicyRoutingGuard { table_id });
 
                             loop {
                                 until
@@ -1205,48 +1230,9 @@ async fn apply_policy_routing(
         }
     }
 
-    // Ensure global CONNMARK restore rules in mangle PREROUTING (forwarded
-    // packets) and OUTPUT (locally-generated replies). Both are needed:
-    // PREROUTING handles DNAT-forwarded traffic, OUTPUT handles replies from
-    // locally-bound listeners (e.g. vhost). The `-m mark --mark 0` condition
-    // ensures we only restore when the packet has no existing fwmark,
-    // preserving marks set by WireGuard on encapsulation packets.
-    // Prepend so restore-mark runs before the per-interface set-mark rules
-    // below: the first NEW packet then leaves with mark 0 (routed via main),
-    // matching the prior iptables `-I <chain> 1` insertion.
-    nft_rule(
-        "mangle_prerouting",
-        "restore-mark",
-        false,
-        true,
-        "meta mark 0x00000000 meta mark set ct mark",
-    )
-    .await
-    .log_err();
-    nft_rule(
-        "mangle_output",
-        "restore-mark",
-        false,
-        true,
-        "meta mark 0x00000000 meta mark set ct mark",
-    )
-    .await
-    .log_err();
-
-    // Mark NEW connections arriving on this interface with its routing
-    // table ID via conntrack mark
-    nft_rule(
-        "mangle_prerouting",
-        &format!("mark-{}", iface.as_str()),
-        false,
-        false,
-        &format!(
-            "iifname \"{}\" ct state new ct mark set {table_str}",
-            iface.as_str()
-        ),
-    )
-    .await
-    .log_err();
+    // The mangle CONNMARK rules — the global `restore-mark` (mangle PREROUTING +
+    // OUTPUT) and this interface's `mark-<iface>` — are reconciled centrally and
+    // atomically by `reconcile_mangle_rules`, so they are not touched here.
 
     // Ensure fwmark-based ip rule for this interface's table
     let rules_output = String::from_utf8(


### PR DESCRIPTION
Three independent fixes found while integration-testing a direct beta.9 → HEAD update on a dev VM. None relate to the branch they were discovered on — each is an inherited regression or latent bug already in `master`. All verified live on the dev VM (all services come up; gateway nft error spam cleared).

### 1. Mount — `TMP_MOUNTS` self-deadlock on nested idmapped mounts
`TmpMountGuard::mount` held the global `TMP_MOUNTS` mutex across `MountGuard::mount().await`. `IdMapped::mount` re-enters `TmpMountGuard::mount` to stage its inner filesystem, re-acquiring the same non-reentrant mutex from the same task → permanent deadlock → 30s timeout in `LxcManager::create`. **Every service failed to load** (`persistent_container::new` deadlocked mounting the LXC rootfs). Regression from cd1fa1477 (#3248, nested idmapped mounts via `open_tree_attr`).

Fix: `TMP_MOUNTS` becomes a map of per-mountpoint locks; the outer map lock is held only to fetch/create a slot, then released before mounting.

### 2. Net — `nft_rule` reconcile races
`nft_rule` did a non-atomic list-handles → delete → add. Concurrent reconciles of the same comment (the shared `restore-mark` rule applied by every per-interface gateway watcher) raced: one deleted a handle, the other's delete failed with `Could not process rule: No such file or directory` and spammed errors.

Fix: apply the whole reconcile as a single atomic nft transaction (delete every prior copy + add in one invocation), no-op when already converged, bounded retry on a stale handle (the only benign concurrent failure). No global lock.

### 3. Net — single-writer policy-routing mangle rules
Root cause of #2's contention: the global `restore-mark` rules were multi-writer (re-applied by every `watch_ip`).

Fix: the gateway coordinator becomes the sole writer via `reconcile_mangle_rules`, which renders the full desired contents of both StartOS-owned mangle chains (`restore-mark` + one `mark-<iface>` per active gateway) and applies them as one atomic flush+rebuild — the race is now impossible by construction. `gc_policy_routing` trimmed to ip-rule/route-table GC (the flush removes stale mark rules for free). Gating (`managed && active_connection`) mirrors `watch_ip` so unmanaged container veths are excluded; shared `device_type_of` / `policy_table_for` helpers keep the coordinator and `watch_ip` from drifting.

---

Verified on dev VM after deploy: all services running; `mangle_prerouting`/`mangle_output` hold exactly one `restore-mark` plus one `mark-<iface>` per gateway (no container veths); zero `Could not process rule` errors since boot.
