### PR TITLE
fix: zero-pad CA fingerprint hex bytes (+ beta.10 repair migration)

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6482,7 +6482,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "start-os"
-version = "0.4.0-beta.9"
+version = "0.4.0-beta.10"
 dependencies = [
  "aes",
  "async-acme",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 name = "start-os"
 readme = "README.md"
 repository = "https://github.com/Start9Labs/start-os"
-version = "0.4.0-beta.9" # VERSION_BUMP
+version = "0.4.0-beta.10" # VERSION_BUMP
 
 [lib]
 name = "startos"

--- a/core/src/db/model/public.rs
+++ b/core/src/db/model/public.rs
@@ -139,7 +139,7 @@ impl Public {
                     .digest(MessageDigest::sha256())
                     .unwrap()
                     .iter()
-                    .map(|x| format!("{x:X}"))
+                    .map(|x| format!("{x:02X}"))
                     .join(":"),
                 ntp_synced: false,
                 zram: true,

--- a/core/src/version/mod.rs
+++ b/core/src/version/mod.rs
@@ -73,8 +73,9 @@ mod v0_4_0_beta_6;
 mod v0_4_0_beta_7;
 mod v0_4_0_beta_8;
 mod v0_4_0_beta_9;
+mod v0_4_0_beta_10;
 
-pub type Current = v0_4_0_beta_9::Version; // VERSION_BUMP
+pub type Current = v0_4_0_beta_10::Version; // VERSION_BUMP
 
 impl Current {
     #[instrument(skip(self, db))]
@@ -215,7 +216,8 @@ enum Version {
     V0_4_0_beta_6(Wrapper<v0_4_0_beta_6::Version>),
     V0_4_0_beta_7(Wrapper<v0_4_0_beta_7::Version>),
     V0_4_0_beta_8(Wrapper<v0_4_0_beta_8::Version>),
-    V0_4_0_beta_9(Wrapper<v0_4_0_beta_9::Version>), // VERSION_BUMP
+    V0_4_0_beta_9(Wrapper<v0_4_0_beta_9::Version>),
+    V0_4_0_beta_10(Wrapper<v0_4_0_beta_10::Version>), // VERSION_BUMP
     Other(exver::Version),
 }
 
@@ -291,7 +293,8 @@ impl Version {
             Self::V0_4_0_beta_6(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_7(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_8(v) => DynVersion(Box::new(v.0)),
-            Self::V0_4_0_beta_9(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
+            Self::V0_4_0_beta_9(v) => DynVersion(Box::new(v.0)),
+            Self::V0_4_0_beta_10(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
             Self::Other(v) => {
                 return Err(Error::new(
                     eyre!("unknown version {v}"),
@@ -359,7 +362,8 @@ impl Version {
             Version::V0_4_0_beta_6(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_7(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_8(Wrapper(x)) => x.semver(),
-            Version::V0_4_0_beta_9(Wrapper(x)) => x.semver(), // VERSION_BUMP
+            Version::V0_4_0_beta_9(Wrapper(x)) => x.semver(),
+            Version::V0_4_0_beta_10(Wrapper(x)) => x.semver(), // VERSION_BUMP
             Version::Other(x) => x.clone(),
         }
     }

--- a/core/src/version/v0_4_0_beta_10.rs
+++ b/core/src/version/v0_4_0_beta_10.rs
@@ -1,0 +1,68 @@
+use exver::{PreReleaseSegment, VersionRange};
+use imbl_value::json;
+
+use super::v0_3_5::V0_3_0_COMPAT;
+use super::{VersionT, v0_4_0_beta_9};
+use crate::prelude::*;
+
+lazy_static::lazy_static! {
+    static ref V0_4_0_beta_10: exver::Version = exver::Version::new(
+        [0, 4, 0],
+        [PreReleaseSegment::String("beta".into()), 10.into()]
+    );
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Version;
+
+impl VersionT for Version {
+    type Previous = v0_4_0_beta_9::Version;
+    type PreUpRes = ();
+
+    async fn pre_up(self) -> Result<Self::PreUpRes, Error> {
+        Ok(())
+    }
+    fn semver(self) -> exver::Version {
+        V0_4_0_beta_10.clone()
+    }
+    fn compat(self) -> &'static VersionRange {
+        &V0_3_0_COMPAT
+    }
+    #[instrument(skip_all)]
+    fn up(self, db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+        // The Root CA fingerprint was formatted with `{:X}` (no width), dropping
+        // the leading zero of any byte < 0x10 (e.g. `A3:3:D2` instead of
+        // `A3:03:D2`), so the value shown in the UI didn't match what devices
+        // report. Each `{:X}` byte is 1 char (< 0x10) or 2 chars, so left-padding
+        // every 1-char segment to two digits exactly reconstructs the `{:02X}`
+        // form. Idempotent: already-correct (all-2-char) fingerprints are unchanged.
+        let Some(server_info) = db["public"]["serverInfo"].as_object_mut() else {
+            return Err(Error::new(
+                eyre!("db.public.serverInfo is not an object"),
+                ErrorKind::Database,
+            ));
+        };
+        let Some(fingerprint) = server_info.get("caFingerprint").and_then(|v| v.as_str()) else {
+            return Err(Error::new(
+                eyre!("db.public.serverInfo.caFingerprint is not a string"),
+                ErrorKind::Database,
+            ));
+        };
+        let repaired = fingerprint
+            .split(':')
+            .map(|seg| {
+                if seg.len() < 2 {
+                    format!("0{seg}")
+                } else {
+                    seg.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(":");
+        server_info.insert("caFingerprint".into(), json!(repaired));
+        Ok(Value::Null)
+    }
+    fn down(self, _db: &mut Value) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0 — StartOS 0.4.0-beta.9 (2026-05-20)
+## 2.0.0 — StartOS 0.4.0-beta.10 (2026-06-07)
 
 ### Added
 

--- a/sdk/package/lib/StartSdk.ts
+++ b/sdk/package/lib/StartSdk.ts
@@ -74,7 +74,7 @@ import { createVolumes } from './util/Volume'
 import { getDataVersion, setDataVersion } from './version'
 
 /** The minimum StartOS version required by this SDK release */
-export const OSVersion = testTypeVersion('0.4.0-beta.9')
+export const OSVersion = testTypeVersion('0.4.0-beta.10')
 
 // prettier-ignore
 type AnyNeverCond<T extends any[], Then, Else> = 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.9",
+  "version": "0.4.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startos-ui",
-      "version": "0.4.0-beta.9",
+      "version": "0.4.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^21.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0-beta.9",
+  "version": "0.4.0-beta.10",
   "author": "Start9 Labs, Inc",
   "homepage": "https://start9.com/",
   "license": "MIT",


### PR DESCRIPTION
## Summary

The Root CA SHA-256 fingerprint in `Public::init` formatted each digest byte with `{:X}` (no width), so any byte `< 0x10` lost its leading zero — e.g. `…C4:88:A3:3:D2…` instead of `…C4:88:A3:03:D2…`. The displayed value then didn't match the fingerprint a device (e.g. Android) reports for the same cert. Reported against 0.4.0.

This PR does three things:

1. **Fix the source** — format each byte with `{:02X}` so fresh installs get the correct value.
2. **Repair existing installs** — `caFingerprint` is computed once at `Database::init` and persisted in patch-db, so a binary upgrade alone wouldn't fix already-initialized systems. A migration in the new **0.4.0-beta.10** corrects the stored value.
3. **Cut 0.4.0-beta.10** — the version bump that carries the migration (also the OS version `start-sdk` 2.0 requires).

### Migration (`v0_4_0_beta_10` `up()`)

Pure string repair on `db.public.serverInfo.caFingerprint` — no cert/crypto access needed. The old `{:X}` output makes every colon-separated byte either 1 char (value `< 0x10`) or 2 chars, so left-padding each 1-char segment to two digits exactly reconstructs the `{:02X}` form. Idempotent: already-correct (all-2-char) fingerprints pass through unchanged.

### Version bump (per `docs/VERSION_BUMP.md`)

beta.9 → **beta.10**:
- `core/Cargo.toml` + `Cargo.lock`
- the version registry in `core/src/version/mod.rs` (5 spots)
- `web/package.json` + `package-lock.json`
- **SDK `OSVersion`** → `0.4.0-beta.10` (`sdk/package/lib/StartSdk.ts`), since `start-sdk` 2.0 requires beta.10. The unpublished `2.0.0` `CHANGELOG.md` heading is updated in place to match (npm latest is still `1.5.3`). The SDK package version is already `2.0.0`.

The `start-os` **library compiles** (`cargo check`); the `startbox`/`tunnelbox` binaries require a built `web/dist` to embed, which is the usual web-before-bins build order and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
