### PR TITLE
fix(deps): migrate to hickory 0.26 (resolve DNS RUSTSEC advisories)

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -137,7 +137,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -148,7 +148,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -878,6 +878,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1854,18 +1865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,7 +1898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2354,6 +2353,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2561,24 +2561,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
- "serde",
+ "jni 0.22.4",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -2587,22 +2585,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "serde",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2610,16 +2634,16 @@ dependencies = [
 
 [[package]]
 name = "hickory-server"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53e5fe811b941c74ee46b8818228bfd2bc2688ba276a0eaeb0f2c95ea3b2585"
+checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "hickory-resolver",
  "ipnet",
@@ -3201,7 +3225,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3329,6 +3353,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3896,6 +3950,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -4753,10 +4813,11 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prefix-trie"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cf4c7c25f1dd66c76b451e9041a8cfce26e4ca754934fa7aed8d5a59a01d20"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
+ "either",
  "ipnet",
  "num-traits",
 ]
@@ -5141,6 +5202,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5196,6 +5268,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -5629,7 +5707,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5701,7 +5779,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls 0.23.39",
@@ -5711,7 +5789,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6160,6 +6238,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple-bytes"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6253,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6843,7 +6937,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6873,7 +6967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7546,7 +7640,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8077,7 +8171,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -100,7 +100,7 @@ futures = "0.3.28"
 gpt = "4.1.0"
 hashing-serializer = "0.1.1"
 hex = "0.4.3"
-hickory-server = { version = "0.25.2", features = ["resolver"] }
+hickory-server = { version = "0.26.1", features = ["resolver"] }
 hmac = "0.12.1"
 http = "1.0.0"
 http-body-util = "0.1"

--- a/core/src/net/dns.rs
+++ b/core/src/net/dns.rs
@@ -12,7 +12,6 @@ use hickory_server::net::NetError;
 use hickory_server::net::runtime::Time;
 use hickory_server::proto::op::{Header, HeaderCounts, Metadata, ResponseCode};
 use hickory_server::proto::rr::{Name, Record, RecordType};
-use hickory_server::resolver as hickory_resolver;
 use hickory_server::resolver::config::{
     ConnectionConfig, NameServerConfig, ResolverConfig, ResolverOpts,
 };
@@ -245,6 +244,26 @@ pub(crate) fn name_server_socket_addr(ns: &NameServerConfig) -> SocketAddr {
     SocketAddr::new(ns.ip, ns.connections.first().map_or(53, |c| c.port))
 }
 
+/// Parse systemd-resolved's resolv.conf. hickory 0.26 only exposes
+/// `system_conf::parse_resolv_conf` on non-apple unix; this path only runs on
+/// the (Linux) server, so non-Linux targets just need a stub to compile.
+#[cfg(target_os = "linux")]
+pub(crate) fn parse_resolv_conf(
+    data: impl AsRef<[u8]>,
+) -> Result<(ResolverConfig, ResolverOpts), Error> {
+    hickory_server::resolver::system_conf::parse_resolv_conf(data).with_kind(ErrorKind::ParseSysInfo)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn parse_resolv_conf(
+    _data: impl AsRef<[u8]>,
+) -> Result<(ResolverConfig, ResolverOpts), Error> {
+    Err(Error::new(
+        eyre!("resolv.conf parsing is only supported on Linux"),
+        ErrorKind::ParseSysInfo,
+    ))
+}
+
 /// What private domains a resolver (one per bound socket) may answer.
 #[derive(Clone)]
 enum PrivateScope {
@@ -301,9 +320,7 @@ fn spawn_forwarder(
                                             eyre!("resolv.conf stream ended"),
                                             ErrorKind::Network,
                                         ))?;
-                                    let (config, mut opts) =
-                                        hickory_resolver::system_conf::parse_resolv_conf(conf)
-                                            .with_kind(ErrorKind::ParseSysInfo)?;
+                                    let (config, mut opts) = parse_resolv_conf(conf)?;
                                     opts.timeout = Duration::from_secs(30);
                                     last_config = Some((config, opts));
                                     true

--- a/core/src/net/dns.rs
+++ b/core/src/net/dns.rs
@@ -8,14 +8,17 @@ use std::time::Duration;
 use clap::Parser;
 use color_eyre::eyre::eyre;
 use futures::{FutureExt, StreamExt, TryStreamExt};
-use hickory_server::authority::{AuthorityObject, Catalog, MessageResponseBuilder};
-use hickory_server::proto::op::{Header, ResponseCode};
+use hickory_server::net::NetError;
+use hickory_server::net::runtime::Time;
+use hickory_server::proto::op::{Header, HeaderCounts, Metadata, ResponseCode};
 use hickory_server::proto::rr::{Name, Record, RecordType};
-use hickory_server::proto::xfer::Protocol;
-use hickory_server::resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
-use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
-use hickory_server::store::forwarder::{ForwardAuthority, ForwardConfig};
-use hickory_server::{ServerFuture, resolver as hickory_resolver};
+use hickory_server::resolver as hickory_resolver;
+use hickory_server::resolver::config::{
+    ConnectionConfig, NameServerConfig, ResolverConfig, ResolverOpts,
+};
+use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo, Server};
+use hickory_server::store::forwarder::{ForwardConfig, ForwardZoneHandler};
+use hickory_server::zone_handler::{Catalog, MessageResponseBuilder, ZoneHandler};
 use imbl::OrdMap;
 use imbl_value::InternedString;
 use itertools::Itertools;
@@ -225,6 +228,23 @@ lazy_static::lazy_static! {
     static ref EMBASSY: Name = Name::from_ascii("embassy").unwrap();
 }
 
+/// Per-connection outgoing-response buffer size for TCP DNS listeners.
+pub(crate) const DNS_RESPONSE_BUFFER_SIZE: usize = 32;
+
+/// A forwarding upstream for `addr`, reachable over both UDP and TCP on its port.
+pub(crate) fn forward_name_server(addr: SocketAddr) -> NameServerConfig {
+    let mut udp = ConnectionConfig::udp();
+    udp.port = addr.port();
+    let mut tcp = ConnectionConfig::tcp();
+    tcp.port = addr.port();
+    NameServerConfig::new(addr.ip(), true, vec![udp, tcp])
+}
+
+/// The socket address a parsed upstream `NameServerConfig` points at.
+pub(crate) fn name_server_socket_addr(ns: &NameServerConfig) -> SocketAddr {
+    SocketAddr::new(ns.ip, ns.connections.first().map_or(53, |c| c.port))
+}
+
 /// What private domains a resolver (one per bound socket) may answer.
 #[derive(Clone)]
 enum PrivateScope {
@@ -254,7 +274,7 @@ fn spawn_forwarder(
 ) -> NonDetachingJoinHandle<()> {
     tokio::spawn(async move {
                 let mut prev = crate::util::serde::hash_serializable::<sha2::Sha256, _>(&(
-                    ResolverConfig::new(),
+                    ResolverConfig::from_parts(None, Vec::new(), Vec::new()),
                     ResolverOpts::default(),
                     Option::<std::collections::VecDeque<SocketAddr>>::None,
                 ))
@@ -319,8 +339,8 @@ fn spawn_forwarder(
                                         .ser(
                                             &config
                                                 .name_servers()
-                                                .into_iter()
-                                                .map(|n| n.socket_addr)
+                                                .iter()
+                                                .map(name_server_socket_addr)
                                                 .dedup()
                                                 .skip(2)
                                                 .collect(),
@@ -329,28 +349,15 @@ fn spawn_forwarder(
                                 .await
                                 .result?;
                             }
-                            let forward_servers = if let Some(servers) = &static_servers {
-                                servers
-                                    .iter()
-                                    .flat_map(|addr| {
-                                        [
-                                            NameServerConfig::new(*addr, Protocol::Udp),
-                                            NameServerConfig::new(*addr, Protocol::Tcp),
-                                        ]
-                                    })
-                                    .map(|n| to_value(&n))
-                                    .collect::<Result<_, Error>>()?
-                            } else {
-                                config
-                                    .name_servers()
-                                    .into_iter()
-                                    .skip(4)
-                                    .map(to_value)
-                                    .collect::<Result<_, Error>>()?
-                            };
-                            let auth: Vec<Arc<dyn AuthorityObject>> = vec![Arc::new(
-                                ForwardAuthority::builder_tokio(ForwardConfig {
-                                    name_servers: from_value(Value::Array(forward_servers))?,
+                            let forward_servers: Vec<NameServerConfig> =
+                                if let Some(servers) = &static_servers {
+                                    servers.iter().map(|addr| forward_name_server(*addr)).collect()
+                                } else {
+                                    config.name_servers().iter().skip(2).cloned().collect()
+                                };
+                            let auth: Vec<Arc<dyn ZoneHandler>> = vec![Arc::new(
+                                ForwardZoneHandler::builder_tokio(ForwardConfig {
+                                    name_servers: forward_servers,
                                     options: Some(opts.clone()),
                                 })
                                 .build()
@@ -463,13 +470,15 @@ impl Resolver {
 
 #[async_trait::async_trait]
 impl RequestHandler for Resolver {
-    async fn handle_request<R: ResponseHandler>(
+    async fn handle_request<R: ResponseHandler, T: Time>(
         &self,
         request: &Request,
         mut response_handle: R,
     ) -> ResponseInfo {
         match async {
-            let req = request.request_info()?;
+            let req = request
+                .request_info()
+                .map_err(|e| NetError::from(e.to_string()))?;
             let query = req.query;
             let name = query.name();
 
@@ -480,8 +489,8 @@ impl RequestHandler for Resolver {
                     r.challenges.retain(|_, (_, weak)| weak.strong_count() > 0);
                     r.challenges.remove(&name_str).map(|(val, _)| val)
                 }) {
-                    let mut header = Header::response_from_request(request.header());
-                    header.set_recursion_available(true);
+                    let mut header = Metadata::response_from_request(&request.metadata);
+                    header.recursion_available = true;
                     return response_handle
                         .send_response(
                             MessageResponseBuilder::from_message_request(&*request).build(
@@ -508,8 +517,8 @@ impl RequestHandler for Resolver {
             if let Some(ip) = self.resolve(name, req.src.ip()) {
                 match query.query_type() {
                     RecordType::A => {
-                        let mut header = Header::response_from_request(request.header());
-                        header.set_recursion_available(true);
+                        let mut header = Metadata::response_from_request(&request.metadata);
+                        header.recursion_available = true;
                         response_handle
                             .send_response(
                                 MessageResponseBuilder::from_message_request(&*request).build(
@@ -535,8 +544,8 @@ impl RequestHandler for Resolver {
                             .map(Some)
                     }
                     RecordType::AAAA => {
-                        let mut header = Header::response_from_request(request.header());
-                        header.set_recursion_available(true);
+                        let mut header = Metadata::response_from_request(&request.metadata);
+                        header.recursion_available = true;
                         response_handle
                             .send_response(
                                 MessageResponseBuilder::from_message_request(&*request).build(
@@ -562,12 +571,12 @@ impl RequestHandler for Resolver {
                             .map(Some)
                     }
                     _ => {
-                        let mut header = Header::response_from_request(request.header());
-                        header.set_recursion_available(true);
+                        let mut header = Metadata::response_from_request(&request.metadata);
+                        header.recursion_available = true;
                         response_handle
                             .send_response(
                                 MessageResponseBuilder::from_message_request(&*request).build(
-                                    header.into(),
+                                    header,
                                     [],
                                     [],
                                     [],
@@ -592,13 +601,13 @@ impl RequestHandler for Resolver {
                     t!("net.dns.error-resolving-internal", error = e.to_string())
                 );
                 tracing::debug!("{e:?}");
-                let mut header = Header::response_from_request(request.header());
-                header.set_recursion_available(true);
-                header.set_response_code(ResponseCode::ServFail);
+                let mut header = Metadata::response_from_request(&request.metadata);
+                header.recursion_available = true;
+                header.response_code = ResponseCode::ServFail;
                 return response_handle
                     .send_response(
                         MessageResponseBuilder::from_message_request(&*request).build(
-                            header.into(),
+                            header,
                             [],
                             [],
                             [],
@@ -606,13 +615,19 @@ impl RequestHandler for Resolver {
                         ),
                     )
                     .await
-                    .unwrap_or_else(|_| header.into());
+                    .unwrap_or_else(|_| {
+                        Header {
+                            metadata: header,
+                            counts: HeaderCounts::default(),
+                        }
+                        .into()
+                    });
             }
         }
         self.catalog
             .read()
             .await
-            .handle_request(request, response_handle)
+            .handle_request::<R, T>(request, response_handle)
             .await
     }
 }
@@ -637,12 +652,13 @@ fn bind_reuse_udp(addr: SocketAddr, dual_stack: bool) -> Result<UdpSocket, Error
     UdpSocket::from_std(socket.into()).with_kind(ErrorKind::Network)
 }
 
-fn dns_server_on(resolver: Resolver, addr: SocketAddr) -> Result<ServerFuture<Resolver>, Error> {
+fn dns_server_on(resolver: Resolver, addr: SocketAddr) -> Result<Server<Resolver>, Error> {
     let dual_stack = matches!(addr, SocketAddr::V6(v6) if v6.ip().is_unspecified());
-    let mut server = ServerFuture::new(resolver);
+    let mut server = Server::new(resolver);
     server.register_listener(
         bind_tokio_listener(addr).with_kind(ErrorKind::Network)?,
         Duration::from_secs(30),
+        DNS_RESPONSE_BUFFER_SIZE,
     );
     server.register_socket(bind_reuse_udp(addr, dual_stack)?);
     Ok(server)
@@ -673,7 +689,7 @@ async fn run_dns_servers(
     let loopback = vec![IpAddr::V4(Ipv4Addr::LOCALHOST), IpAddr::V6(Ipv6Addr::LOCALHOST)];
     let host_ip = IpAddr::V4(Ipv4Addr::from(HOST_IP));
 
-    let mut servers: BTreeMap<SocketAddr, ServerFuture<Resolver>> = BTreeMap::new();
+    let mut servers: BTreeMap<SocketAddr, Server<Resolver>> = BTreeMap::new();
     loop {
         let mut desired: BTreeMap<SocketAddr, PrivateScope> = BTreeMap::new();
         net_iface.peek(|ifaces| {

--- a/core/src/net/gateway.rs
+++ b/core/src/net/gateway.rs
@@ -338,10 +338,12 @@ pub async fn check_dns(
     ctx: RpcContext,
     CheckDnsParams { gateway }: CheckDnsParams,
 ) -> Result<bool, Error> {
-    use hickory_server::proto::xfer::Protocol;
+    use hickory_server::net::runtime::TokioRuntimeProvider;
+    use hickory_server::proto::rr::RData;
     use hickory_server::resolver::Resolver;
-    use hickory_server::resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
-    use hickory_server::resolver::name_server::TokioConnectionProvider;
+    use hickory_server::resolver::config::{ResolverConfig, ResolverOpts};
+
+    use crate::net::dns::forward_name_server;
 
     let ip_info = ctx.net_controller.net_iface.watcher.ip_info();
     let gw_info = ip_info
@@ -372,29 +374,24 @@ pub async fn check_dns(
                 .dns
                 .add_challenge(challenge_domain.clone(), challenge_value.clone())?;
 
-            let mut config = ResolverConfig::new();
-            config.add_name_server(NameServerConfig::new(
-                SocketAddr::new(*dns_ip, 53),
-                Protocol::Udp,
-            ));
-            config.add_name_server(NameServerConfig::new(
-                SocketAddr::new(*dns_ip, 53),
-                Protocol::Tcp,
-            ));
+            let mut config = ResolverConfig::from_parts(None, Vec::new(), Vec::new());
+            config.add_name_server(forward_name_server(SocketAddr::new(*dns_ip, 53)));
             let mut opts = ResolverOpts::default();
             opts.timeout = Duration::from_secs(5);
             opts.attempts = 1;
 
-            let resolver =
-                Resolver::builder_with_config(config, TokioConnectionProvider::default())
-                    .with_options(opts)
-                    .build();
+            let resolver = Resolver::builder_with_config(config, TokioRuntimeProvider::default())
+                .with_options(opts)
+                .build()
+                .map_err(|e| Error::new(eyre!("{e}"), ErrorKind::Network))?;
             let txt_lookup = resolver.txt_lookup(&*challenge_domain).await;
 
             return Ok(match txt_lookup {
-                Ok(lookup) => lookup.iter().any(|txt| {
-                    txt.iter()
-                        .any(|data| data.as_ref() == challenge_value.as_bytes())
+                Ok(lookup) => lookup.answers().iter().any(|record| {
+                    matches!(&record.data, RData::TXT(txt) if txt
+                        .txt_data
+                        .iter()
+                        .any(|data| data.as_ref() == challenge_value.as_bytes()))
                 }),
                 Err(_) => false,
             });

--- a/core/src/tunnel/dns.rs
+++ b/core/src/tunnel/dns.rs
@@ -12,7 +12,9 @@ use hickory_server::zone_handler::{Catalog, ZoneHandler};
 use ipnet::Ipv4Net;
 use tokio::net::{TcpListener, UdpSocket};
 
-use crate::net::dns::{DNS_RESPONSE_BUFFER_SIZE, forward_name_server, name_server_socket_addr};
+use crate::net::dns::{
+    DNS_RESPONSE_BUFFER_SIZE, forward_name_server, name_server_socket_addr, parse_resolv_conf,
+};
 use crate::prelude::*;
 use crate::tunnel::wg::{DnsConfig, WgServer};
 use crate::util::future::NonDetachingJoinHandle;
@@ -107,7 +109,7 @@ async fn systemd_resolved_upstreams() -> Vec<SocketAddr> {
     let Ok(contents) = read_file_to_string("/run/systemd/resolve/resolv.conf").await else {
         return Vec::new();
     };
-    match hickory_resolver::system_conf::parse_resolv_conf(contents) {
+    match parse_resolv_conf(contents) {
         Ok((config, _)) => resolv_conf_upstreams(&config),
         Err(_) => Vec::new(),
     }

--- a/core/src/tunnel/dns.rs
+++ b/core/src/tunnel/dns.rs
@@ -3,17 +3,16 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::Duration;
 
-use hickory_server::authority::{AuthorityObject, Catalog};
 use hickory_server::proto::rr::Name;
-use hickory_server::proto::xfer::Protocol;
-use hickory_server::resolver::config::{
-    NameServerConfig, NameServerConfigGroup, ResolverConfig, ResolverOpts,
-};
-use hickory_server::store::forwarder::{ForwardAuthority, ForwardConfig};
-use hickory_server::{ServerFuture, resolver as hickory_resolver};
+use hickory_server::resolver as hickory_resolver;
+use hickory_server::resolver::config::{NameServerConfig, ResolverConfig, ResolverOpts};
+use hickory_server::server::Server;
+use hickory_server::store::forwarder::{ForwardConfig, ForwardZoneHandler};
+use hickory_server::zone_handler::{Catalog, ZoneHandler};
 use ipnet::Ipv4Net;
 use tokio::net::{TcpListener, UdpSocket};
 
+use crate::net::dns::{DNS_RESPONSE_BUFFER_SIZE, forward_name_server, name_server_socket_addr};
 use crate::prelude::*;
 use crate::tunnel::wg::{DnsConfig, WgServer};
 use crate::util::future::NonDetachingJoinHandle;
@@ -120,7 +119,7 @@ fn resolv_conf_upstreams(config: &ResolverConfig) -> Vec<SocketAddr> {
     config
         .name_servers()
         .iter()
-        .map(|ns| ns.socket_addr)
+        .map(name_server_socket_addr)
         .filter(|addr| !addr.ip().is_loopback())
         .filter(|addr| seen.insert(*addr))
         .collect()
@@ -138,9 +137,9 @@ async fn bind_proxy(
         .await
         .with_kind(ErrorKind::Network)?;
 
-    let mut server = ServerFuture::new(forwarding_catalog(upstreams)?);
+    let mut server = Server::new(forwarding_catalog(upstreams)?);
     server.register_socket(udp);
-    server.register_listener(tcp, FORWARD_TIMEOUT);
+    server.register_listener(tcp, FORWARD_TIMEOUT, DNS_RESPONSE_BUFFER_SIZE);
 
     Ok(tokio::spawn(async move {
         server
@@ -156,26 +155,19 @@ async fn bind_proxy(
 /// `upstreams` (UDP + TCP per server). `Catalog` itself implements
 /// `RequestHandler`, so no custom handler is needed for a pure forwarder.
 fn forwarding_catalog(upstreams: Vec<SocketAddr>) -> Result<Catalog, Error> {
-    let name_servers: Vec<NameServerConfig> = upstreams
-        .into_iter()
-        .flat_map(|addr| {
-            [
-                NameServerConfig::new(addr, Protocol::Udp),
-                NameServerConfig::new(addr, Protocol::Tcp),
-            ]
-        })
-        .collect();
+    let name_servers: Vec<NameServerConfig> =
+        upstreams.into_iter().map(forward_name_server).collect();
     let mut opts = ResolverOpts::default();
     opts.timeout = FORWARD_TIMEOUT;
-    let authority = ForwardAuthority::builder_tokio(ForwardConfig {
-        name_servers: NameServerConfigGroup::from(name_servers),
+    let authority = ForwardZoneHandler::builder_tokio(ForwardConfig {
+        name_servers,
         options: Some(opts),
     })
     .build()
     .map_err(|e| Error::new(eyre!("{e}"), ErrorKind::Network))?;
 
     let mut catalog = Catalog::new();
-    let auth: Vec<Arc<dyn AuthorityObject>> = vec![Arc::new(authority)];
+    let auth: Vec<Arc<dyn ZoneHandler>> = vec![Arc::new(authority)];
     catalog.upsert(Name::root().into(), auth);
     Ok(catalog)
 }


### PR DESCRIPTION
Migrates the DNS stack to **hickory 0.26** (`hickory-server` 0.25.2 → 0.26.1), clearing the two `hickory-proto` Dependabot/RUSTSEC advisories that have **no fix on the 0.25 line**:

- **NSEC3 closest-encloser proof validation enters an unbounded loop on cross-zone responses** (high; no patched 0.25 release — only escapable by leaving the ≤0.25.2 range)
- **O(n²) name compression → CPU exhaustion during message encoding** (fixed in 0.26.1)

This is the follow-up promised in the Dependabot sweep (#3301), kept separate because 0.26 is a breaking API migration.

## API migration (across `net/dns.rs`, `net/gateway.rs`, `tunnel/dns.rs`)
- `authority` module → `zone_handler`; `AuthorityObject` → `ZoneHandler`
- `ServerFuture` → `Server`; `RequestHandler::handle_request` gains a `T: Time` type parameter (forwarded to `Catalog::handle_request`)
- `Header` → `Metadata` for response metadata (now pub fields `recursion_available`, `response_code` instead of setters); the error-path `ResponseInfo` is built from `Header { metadata, counts }`
- `Protocol` moved to `net::xfer`; `TokioConnectionProvider` → `net::runtime::TokioRuntimeProvider`; `Time`/`NetError` now under `net`
- `NameServerConfig::new(SocketAddr, Protocol)` → per-connection model (`ip` + `Vec<ConnectionConfig>`); added a `forward_name_server` helper shared across the three files
- `ResolverConfig::new()` → `from_parts(...)`; `NameServerConfigGroup` removed (`ForwardConfig.name_servers` is now plain `Vec<NameServerConfig>`)
- `ResolverBuilder::build()` now returns `Result`
- `Server::register_listener` takes a new `response_buffer_size` argument (const `DNS_RESPONSE_BUFFER_SIZE = 32`, matching hickory's own default)
- `txt_lookup` returns a generic `Lookup`; the gateway DNS-check now iterates `answers()` and matches `RData::TXT`

## Behavior note (please eyeball)
The resolv.conf forwarder changed `skip(4)` → **`skip(2)`**. In 0.25 `parse_resolv_conf` emitted *two* `NameServerConfig`s per nameserver (one UDP, one TCP), so `skip(4)` skipped the first two upstreams. In 0.26 each nameserver is a single `NameServerConfig` holding both connections, so `skip(2)` preserves the original "skip the first two upstreams" intent.

## Verification
- `cargo check --lib` is clean; lib tests compile. (Full bin/ISO build needs the prebuilt web assets, not run here.)
- **Not runtime-tested on a VM** — this touches live DNS serving + the gateway DNS-reachability check, so a reviewer pass on the `Metadata`/response-building changes and a quick on-device DNS sanity check (private-domain A/AAAA resolution, TXT challenge in `check_dns`, tunnel forwarder) would be worthwhile before merge.
