### PR TITLE
fix(core): isolate service-container memory + reserve the host plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMPRESSED_WEB_UIS := web/dist/static/ui/index.html web/dist/static/setup-wizard
 FIRMWARE_ROMS := build/lib/firmware/$(PLATFORM) $(shell jq --raw-output '.[] | select(.platform[] | contains("$(PLATFORM)")) | "./build/lib/firmware/$(PLATFORM)/" + .id + ".rom.gz"' build/lib/firmware.json)
 BUILD_SRC := $(call ls-files, build/lib) build/lib/depends build/lib/conflicts $(FIRMWARE_ROMS) build/lib/migration-images/.done
 IMAGE_RECIPE_SRC := $(call ls-files, build/image-recipe/)
-STARTD_SRC := core/startd.service $(BUILD_SRC)
+STARTD_SRC := core/startd.service core/services.slice $(BUILD_SRC)
 CORE_SRC := $(call ls-files, core) $(shell git ls-files --recurse-submodules patch-db) $(GIT_HASH_FILE)
 WEB_SHARED_SRC := $(call ls-files, web/projects/shared) $(call ls-files, web/projects/marketplace) $(shell ls -p web/ | grep -v / | sed 's/^/web\//g') web/node_modules/.package-lock.json web/config.json patch-db/client/dist/index.js sdk/baseDist/package.json web/patchdb-ui-seed.json sdk/dist/package.json
 WEB_UI_SRC := $(call ls-files, web/projects/ui)
@@ -200,6 +200,7 @@ install: $(STARTOS_TARGETS)
 	
 	$(call mkdir,$(DESTDIR)/lib/systemd/system)
 	$(call cp,core/startd.service,$(DESTDIR)/lib/systemd/system/startd.service)
+	$(call cp,core/services.slice,$(DESTDIR)/lib/systemd/system/services.slice)
 	if /bin/bash -c '[[ "${ENVIRONMENT}" =~ (^|-)unstable($$|-) ]]'; then \
 		sed -i '/^Environment=/a Environment=RUST_BACKTRACE=full' $(DESTDIR)/lib/systemd/system/startd.service; \
 	fi

--- a/build/dpkg-deps/depends
+++ b/build/dpkg-deps/depends
@@ -61,6 +61,7 @@ squashfs-tools-ng
 ssl-cert
 sudo
 systemd
+systemd-oomd
 systemd-resolved
 systemd-sysv
 systemd-timesyncd

--- a/core/services.slice
+++ b/core/services.slice
@@ -1,0 +1,25 @@
+[Unit]
+Description=StartOS service containers
+Before=startd.service
+
+[Slice]
+# Every service container's cgroup is created under this slice by lxc
+# (see core/src/lxc/config.template). startd applies a RAM-dependent
+# MemoryMax / MemoryHigh to it at boot (core system::limit_container_memory) —
+# total RAM minus a fixed reservation for the host management plane — so the
+# *aggregate* footprint of all service containers is bounded.
+#
+# Delegate=yes hands the slice's cgroup subtree to lxc so systemd won't fight
+# the per-container cgroups lxc creates underneath it.
+#
+# ManagedOOM* opts the slice into systemd-oomd: under sustained memory PSI
+# pressure (or swap exhaustion) oomd kills the heaviest *container* cgroup in
+# this slice, turning what used to be a whole-host swap-death wedge into a
+# single failed install. The host plane is spared — system.slice / user.slice
+# carry MemoryMin reservations (debian/startos/postinst) and startd.service
+# sets ManagedOOMPreference=avoid.
+Delegate=yes
+MemoryAccounting=yes
+ManagedOOMMemoryPressure=kill
+ManagedOOMMemoryPressureLimit=60%
+ManagedOOMSwap=kill

--- a/core/src/init.rs
+++ b/core/src/init.rs
@@ -372,6 +372,16 @@ pub async fn init(
     }
     enable_zram.complete();
 
+    // Cap the aggregate memory of the service-container slice (services.slice)
+    // so the host management plane (startd, sshd) always keeps its reservation
+    // and a burst of concurrent installs can't swap-thrash the box into a wedge;
+    // systemd-oomd reclaims/kills within the slice under sustained pressure.
+    // Best-effort: a failure here must never block boot.
+    if let Err(e) = crate::system::limit_container_memory().await {
+        tracing::warn!("could not cap service-container memory: {e}");
+        tracing::debug!("{e:?}");
+    }
+
     update_server_info.start();
     sync_kiosk(server_info.as_kiosk().de()?.unwrap_or(false)).await?;
     let ram = get_mem_info().await?.total.0 as u64 * 1024 * 1024;

--- a/core/src/lxc/config.template
+++ b/core/src/lxc/config.template
@@ -10,6 +10,16 @@ lxc.apparmor.profile = generated
 lxc.apparmor.allow_nesting = 1
 lxc.idmap = u 0 100000 65536
 lxc.idmap = g 0 100000 65536
+
+# Place every service container's cgroup under the `services.slice` systemd
+# slice (see core/services.slice + system::limit_container_memory) instead of
+# lxc's default per-container `lxc.payload.*`. The slice carries an aggregate
+# `MemoryMax`/`MemoryHigh` and is opted into systemd-oomd PSI monitoring, so a
+# burst of concurrent installs is reclaimed/OOM-killed *within the slice* while
+# the host management plane (startd, sshd; protected by MemoryMin) stays up.
+lxc.cgroup.dir.monitor = services.slice/monitor/{guid}
+lxc.cgroup.dir.container = services.slice/payload/{guid}
+lxc.cgroup.dir.container.inner = ns
 lxc.rootfs.path = dir:/var/lib/lxc/{guid}/rootfs
 lxc.uts.name = {guid}
 

--- a/core/src/system/mod.rs
+++ b/core/src/system/mod.rs
@@ -79,6 +79,55 @@ pub async fn enable_zram() -> Result<(), Error> {
     Ok(())
 }
 
+/// The systemd slice that holds every service container's cgroup — lxc places
+/// containers under it (see `core/src/lxc/config.template`) and the unit
+/// (`core/services.slice`) opts it into `systemd-oomd` PSI monitoring. Capping
+/// it bounds the *aggregate* memory of all service containers.
+const CONTAINER_SLICE: &str = "services.slice";
+
+/// Bound the memory all service containers may collectively use, reserving a
+/// fixed amount for the host management plane (startd, sshd, journald). The cap
+/// is applied with `systemctl set-property` so systemd owns it (survives a
+/// daemon-reload) and so it composes with the slice's `ManagedOOMMemoryPressure`
+/// — under sustained pressure `systemd-oomd` kills the heaviest **container**
+/// cgroup in this slice, never the host plane (which `MemoryMin` protects).
+///
+/// `HOST_RESERVE_MIB` is a constant, not a fraction of RAM: the host plane's
+/// footprint (~210 MiB idle + install/admin headroom) doesn't scale with box
+/// size. It is kept in lock-step with the `MemoryMin` drop-ins shipped by
+/// `debian/startos/postinst` (`system.slice` 768M + `user.slice` 256M = 1 GiB).
+pub async fn limit_container_memory() -> Result<(), Error> {
+    const HOST_RESERVE_MIB: u64 = 1024;
+    let total_mib = get_mem_info().await?.total.0 as u64;
+    let container_max_mib = total_mib.saturating_sub(HOST_RESERVE_MIB).max(512);
+    // begin proactive reclaim a little before the hard cap so the limit
+    // degrades gracefully (throttle) instead of going straight to OOM.
+    let container_high_mib = container_max_mib - container_max_mib / 10;
+
+    Command::new("systemctl")
+        .arg("set-property")
+        .arg("--runtime")
+        .arg(CONTAINER_SLICE)
+        .arg(format!("MemoryHigh={container_high_mib}M"))
+        .arg(format!("MemoryMax={container_max_mib}M"))
+        .invoke(ErrorKind::Systemd)
+        .await?;
+    // Materialize the slice now so its cgroup exists with the cap + ManagedOOM
+    // settings applied before any container is placed in it.
+    Command::new("systemctl")
+        .arg("start")
+        .arg(CONTAINER_SLICE)
+        .invoke(ErrorKind::Systemd)
+        .await?;
+
+    tracing::info!(
+        "service containers ({CONTAINER_SLICE}) capped at {container_max_mib} MiB \
+         (high {container_high_mib} MiB); {HOST_RESERVE_MIB} MiB reserved for the \
+         host plane of {total_mib} MiB total"
+    );
+    Ok(())
+}
+
 #[derive(Deserialize, Serialize, Parser, TS)]
 #[group(skip)]
 #[serde(rename_all = "camelCase")]

--- a/debian/startos/postinst
+++ b/debian/startos/postinst
@@ -135,6 +135,7 @@ EOF
 $SYSTEMCTL enable startd.service
 $SYSTEMCTL enable systemd-resolved.service
 $SYSTEMCTL enable ssh.service
+$SYSTEMCTL enable systemd-oomd.service
 $SYSTEMCTL disable wpa_supplicant.service
 $SYSTEMCTL mask systemd-networkd-wait-online.service # currently use `NetworkManager-wait-online.service`
 
@@ -171,6 +172,45 @@ echo 'port=0' > /etc/dnsmasq.conf
 sed -i 's/\[Service\]/[Service]\nEnvironment=SYSTEMD_LOG_LEVEL=debug/' /lib/systemd/system/systemd-timesyncd.service
 sed -i "s/\.debian\./\./g;s/#FallbackNTP=/FallbackNTP=/"  /etc/systemd/timesyncd.conf
 sed -i '/\(^\|#\)RootDistanceMaxSec=/c\RootDistanceMaxSec=10' /etc/systemd/timesyncd.conf
+
+# Reserve memory for the host management plane so a burst of resource-hungry
+# service containers can never starve startd / sshd / journald and wedge the
+# box (the lxc service containers live under the `startos.payload` cgroup, which
+# startd caps separately at init — see core system::limit_container_memory).
+# MemoryMin is a hard protection: under memory pressure the kernel reclaims and,
+# if needed, OOM-kills inside the container cgroups before ever touching this
+# reserved memory, so sshd stays reachable and startd keeps running.
+#
+# Sizing (constant, not a fraction of RAM — the host plane's needs don't grow
+# with box size): measured idle footprint is ~178 MiB system.slice + ~33 MiB
+# init.scope + ~58 MiB per SSH session. 768 MiB for system.slice leaves ~4x
+# headroom for startd's install-time working set + journald; 256 MiB for
+# user.slice guarantees an admin can always log in to recover.
+mkdir -p /etc/systemd/system/system.slice.d
+cat > /etc/systemd/system/system.slice.d/10-startos-memory-reserve.conf << 'EOF'
+[Slice]
+MemoryAccounting=yes
+MemoryMin=768M
+EOF
+mkdir -p /etc/systemd/system/user.slice.d
+cat > /etc/systemd/system/user.slice.d/10-startos-memory-reserve.conf << 'EOF'
+[Slice]
+MemoryAccounting=yes
+MemoryMin=256M
+EOF
+
+# systemd-oomd: how long memory PSI pressure must stay above a slice's
+# ManagedOOMMemoryPressureLimit before oomd kills its heaviest child. The
+# service-container slice (startos.slice) opts in via ManagedOOMMemoryPressure=
+# kill; 20s avoids reacting to brief install/backup spikes while still catching
+# a real runaway in seconds instead of the ~30-min swap-death it replaces. The
+# host plane is spared: startd sets ManagedOOMPreference=avoid and system.slice/
+# user.slice carry the MemoryMin reservations above.
+mkdir -p /etc/systemd/oomd.conf.d
+cat > /etc/systemd/oomd.conf.d/10-startos.conf << 'EOF'
+[OOM]
+DefaultMemoryPressureDurationSec=20s
+EOF
 
 mkdir -p /etc/nginx/ssl
 


### PR DESCRIPTION
## Problem

Service containers (LXC) run with **no memory limit** and the box has **no proactive OOM daemon**, so a burst of concurrent installs — each unpacking GB-scale images + first-boot/migrations — can overcommit RAM, thrash on zram, and wedge the **entire host**: `sshd`/`startd` get starved servicing page faults. Observed: a 5-install burst pinned a 16 GB host unresponsive ~30 min while the *host itself* was idle (the guest thrashed internally on zram compress/decompress, no fast-fail).

## Fix — container slice + systemd-oomd + host reservation

| Layer | Mechanism | Role |
|---|---|---|
| **Container slice** | `core/services.slice` (lxc places every container under it); `MemoryMax`/`MemoryHigh` set at boot | Bounds the **aggregate** RAM of all containers; pressure → in-slice reclaim then in-slice OOM, not box-wide |
| **Proactive OOM** | `systemd-oomd`, `ManagedOOMMemoryPressure=kill` + `ManagedOOMSwap=kill` on the slice, PSI duration 20s | Under sustained pressure, kills the heaviest **container** in seconds — the fast-fail that turns a 30-min wedge into one failed install |
| **Host reservation** | systemd `MemoryMin` on `system.slice` (768M) + `user.slice` (256M) | Host plane keeps its memory; kernel/oomd kill containers first (`startd` already `ManagedOOMPreference=avoid`) |

Files:
- **`core/services.slice`** (new) — the slice unit; `Delegate=yes`, `MemoryAccounting=yes`, `ManagedOOM*`. Installed via the Makefile next to `startd.service`.
- **`core/src/lxc/config.template`** — `lxc.cgroup.dir.{monitor,container}` now place containers under `services.slice/{monitor,payload}/<guid>`.
- **`core/src/system/mod.rs`** — `limit_container_memory()` now `systemctl set-property --runtime services.slice MemoryMax=… MemoryHigh=…` (= total − 1 GiB host reserve) and materializes the slice. Called best-effort from `init.rs` (never blocks boot).
- **`debian/startos/postinst`** — `MemoryMin` drop-ins; enable `systemd-oomd`; `oomd.conf.d` PSI duration.
- **`build/dpkg-deps/depends`** — add `systemd-oomd` (the tracked dep source; `build/lib/depends` is generated from it at build time).

**Why not just shrink zram?** An earlier draft capped zram to `total/8` — that gutted zram's value (cold-page compression, spike absorption — biggest win on small devices) **and didn't fix the failure**: a small pool thrashes too, just sooner. The wedge was the *absence of a fast-fail*, not zram's size. With oomd doing PSI-based kills, zram stays at its existing `total/4` and can't wedge the box.

**Sizing:** host reserve is a **constant 1 GiB**, not a fraction of RAM — the host plane (~178 MiB `system.slice` + ~33 MiB `init.scope` + ~58 MiB/SSH session measured) doesn't grow with box size. The Rust `HOST_RESERVE_MIB` and the `MemoryMin` drop-ins are kept in lock-step.

## Validation
- `cargo check` clean; `bash -n` clean on the postinst.
- ✅ **Built (`make update-deb`) and tested on a device** (StartOS 0.4.0-beta.10, 16 GiB x86_64):
  - `systemd-oomd` installed + active; `oomctl` confirms it monitors `/services.slice` at **60% / 20s**.
  - All **26 service containers placed under `services.slice`** (lxc honored `cgroup.dir.container.inner`); `MemoryMax` = **14969 MiB** (total − 1 GiB), `MemoryHigh` = 13473 MiB.
  - `system.slice MemoryMin=768M`, `user.slice MemoryMin=256M`.
  - **Stress test:** a runaway allocator placed in `services.slice` peaked at `MemoryHigh` (13472 MiB), was **OOM-killed (`Result=oom-kill`) in ~14 s**, and the slice recovered. Throughout, `MemAvailable` stayed **> 2.2 GiB**, **load < 0.5**, SSH answered every poll, `sshd`+`startd` stayed active, and **all 26 real services survived**. (The original uncapped failure hit load **195** and hung SSH for ~30 min.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
