### PR TITLE
fix(core): keep replayed task state when target service is unavailable

### DIFF
--- a/core/src/service/effects/action.rs
+++ b/core/src/service/effects/action.rs
@@ -313,20 +313,22 @@ async fn create_task(
                         if *once {
                             return Ok(());
                         } else {
-                            false
+                            Some(false)
                         }
                     } else {
-                        true
+                        Some(true)
                     }
                 } else {
-                    // Action or service not available — assume active.
-                    // Will be retested when the action is exported (export_action)
-                    // or service init completes (Service::recheck_tasks).
-                    true
+                    // Action or service not available (e.g. still initializing during
+                    // server boot), so the condition can't be evaluated yet. Resolved
+                    // below from the prior entry for this replay_id; retested when the
+                    // action is exported (export_action) or the service's init
+                    // completes (Service::recheck_tasks).
+                    None
                 }
             }
         },
-        None => true,
+        None => Some(true),
     };
     context
         .seed
@@ -338,6 +340,18 @@ async fn create_task(
                 .as_package_data_mut()
                 .as_idx_mut(src_id)
                 .or_not_found(src_id)?;
+            let active = match active {
+                Some(active) => active,
+                // Unknown: a replayed task keeps its previous state rather than
+                // force-stopping the service on an assumption (the common case is
+                // server boot, where the target service initializes later and the
+                // recheck then corrects the state). A brand new task is
+                // conservatively active.
+                None => match pde.as_tasks().as_idx(&replay_id) {
+                    Some(entry) => entry.as_active().de()?,
+                    None => true,
+                },
+            };
             if active && task.severity == TaskSeverity::Critical {
                 pde.as_status_info_mut().stop()?;
             }


### PR DESCRIPTION
## Summary

On server boot, a service's init replays `createTask` while its target dependency may still be initializing. `create_task` treated "target service unavailable" as "task is active" and, for critical severity, force-stopped the requesting service — overwriting its persisted `desired: Running`. Once the dependency finished initializing, `recheck_tasks` deactivated the (satisfied) task, but nothing restarts a service stopped this way — so services that were running before shutdown stayed stopped after boot, with no critical task ever visible. Consistently reproducible with bolt12-pay → lnd: the boot-time `init` completes and no `start` RPC ever follows, because `desired` was flipped during the init window.

With this change, when the task condition can't be evaluated (target not loaded or not yet initialized), `create_task` resolves the active state from the prior task entry for the same `replay_id` instead of assuming active — a replayed task keeps its pre-shutdown state, so a satisfied critical task no longer stops the service at boot. A brand-new task (no prior entry) remains conservatively active, and `recheck_tasks` still activates the task and stops the requester once a genuine conflict is established against the target's real action input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)