### PR TITLE
fix: /media/startos owned root:root on migrated installs (#3311)

### DIFF
--- a/core/src/version/v0_4_0_beta_10.rs
+++ b/core/src/version/v0_4_0_beta_10.rs
@@ -1,9 +1,12 @@
 use exver::{PreReleaseSegment, VersionRange};
 use imbl_value::json;
+use tokio::process::Command;
 
 use super::v0_3_5::V0_3_0_COMPAT;
 use super::{VersionT, v0_4_0_beta_9};
+use crate::context::RpcContext;
 use crate::prelude::*;
+use crate::util::Invoke;
 
 lazy_static::lazy_static! {
     static ref V0_4_0_beta_10: exver::Version = exver::Version::new(
@@ -61,6 +64,25 @@ impl VersionT for Version {
             .join(":");
         server_info.insert("caFingerprint".into(), json!(repaired));
         Ok(Value::Null)
+    }
+    async fn post_up(self, _ctx: &RpcContext, _input: Value) -> Result<(), Error> {
+        // Older installs copied /media/startos into the persistent config overlay as
+        // root:root, shadowing the squashfs's root:startos on every boot. Fix the
+        // persisted entry so migrated nodes match fresh installs (#3311).
+        let overlay_media_startos = "/media/startos/config/overlay/media/startos";
+        if tokio::fs::metadata(overlay_media_startos).await.is_ok() {
+            Command::new("chown")
+                .arg("root:startos")
+                .arg(overlay_media_startos)
+                .invoke(ErrorKind::Filesystem)
+                .await?;
+            Command::new("chmod")
+                .arg("750")
+                .arg(overlay_media_startos)
+                .invoke(ErrorKind::Filesystem)
+                .await?;
+        }
+        Ok(())
     }
     fn down(self, _db: &mut Value) -> Result<(), Error> {
         Ok(())


### PR DESCRIPTION
## Problem

Closes #3311. On servers **migrated** from 0.3.5.1, the host gateway directory `/media/startos` is owned `root:root` instead of `root:startos`, so the `start9` SSH user gets *Permission denied* browsing `/media/startos/data/...` and needs `sudo`. Fresh 0.4.0 installs are correct (`drwxr-x--- root startos`). Services are unaffected — it's a host-gateway / SSH-convenience issue — but migrated and fresh installs should match.

## Root cause

`/media/startos`'s `root:startos` group is applied **only at image-build time** (`build/image-recipe/build.sh` bakes `chmod 750` + `chown root:startos` into the squashfs). There is no runtime, boot, or migration code that re-applies it.

The root filesystem is an overlay assembled in the initramfs:
```
lowerdir = /startos/config/overlay : /lower(squashfs)   # config/overlay has HIGHER priority
upperdir = tmpfs (wiped every boot)
```
The persistent `config/overlay` layer sits **above** the squashfs. `os_install` mounts an overlay with `upperdir = config/overlay` and bind-mounts the rootfs at `…/media/startos/root`, which materializes a `media/startos` entry into the persistent overlay — and its ownership is frozen at creation time. On the migrated node that entry is `root:root`, so the merged `/media/startos` shows `root:root` forever, shadowing the squashfs's `root:startos`. This also explains why `chown` reverts on reboot: it only copies up to the ephemeral tmpfs upper, while the persisted `root:root` re-asserts.

## Fix

`v0_4_0_beta_10` `post_up`: chown/chmod the persisted `config/overlay/media/startos` entry to `root:startos` / `750`, fixing it in the overlay where it actually lives so migrated nodes match fresh installs. Idempotent.

(An earlier revision also added a per-boot chown in `init.rs`; dropped per review — the overlay is the right place to fix it.)

## Testing

`cargo check --lib` passes (only pre-existing warnings). Not yet validated on a live migrated VM — the underlying overlay state requires a real 0.3.5.1→0.4.0 migration to reproduce.