### PR TITLE
fix(disk): reconcile stale mountpoint before remount

### DIFF
--- a/core/src/disk/mount/guard.rs
+++ b/core/src/disk/mount/guard.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 use tracing::instrument;
 
 use super::filesystem::{FileSystem, MountType, ReadOnly, ReadWrite};
-use super::util::unmount;
+use super::util::{is_mountpoint, unmount};
 use crate::util::{Invoke, Never};
 use crate::{Error, ResultExt};
 
@@ -55,6 +55,14 @@ impl MountGuard {
         mount_type: MountType,
     ) -> Result<Self, Error> {
         let mountpoint = mountpoint.as_ref().to_owned();
+        // A prior process lifetime (e.g. a hard kill, where Drop never ran) can
+        // leave a stale kernel mount at this target; mounting onto it fails with
+        // "already mounted". Reconcile by lazily unmounting first, mirroring the
+        // `bind` helper. Within a live process this branch isn't reached for an
+        // active mount — `TmpMountGuard` dedups via its `Weak<MountGuard>`.
+        if is_mountpoint(&mountpoint).await? {
+            unmount(&mountpoint, true).await?;
+        }
         filesystem.mount(&mountpoint, mount_type).await?;
         Ok(MountGuard {
             mountpoint,

--- a/core/src/disk/mount/guard.rs
+++ b/core/src/disk/mount/guard.rs
@@ -55,14 +55,6 @@ impl MountGuard {
         mount_type: MountType,
     ) -> Result<Self, Error> {
         let mountpoint = mountpoint.as_ref().to_owned();
-        // A prior process lifetime (e.g. a hard kill, where Drop never ran) can
-        // leave a stale kernel mount at this target; mounting onto it fails with
-        // "already mounted". Reconcile by lazily unmounting first, mirroring the
-        // `bind` helper. Within a live process this branch isn't reached for an
-        // active mount — `TmpMountGuard` dedups via its `Weak<MountGuard>`.
-        if is_mountpoint(&mountpoint).await? {
-            unmount(&mountpoint, true).await?;
-        }
         filesystem.mount(&mountpoint, mount_type).await?;
         Ok(MountGuard {
             mountpoint,
@@ -164,6 +156,13 @@ impl TmpMountGuard {
             }
             Ok(TmpMountGuard { guard })
         } else {
+            // No live guard, yet a hard-killed prior process (Drop never ran)
+            // can leave a stale kernel mount here. The mountpoint is derived
+            // from the source hash, so any mount present is the same content —
+            // safe to lazily unmount and remount.
+            if is_mountpoint(&mountpoint).await? {
+                unmount(&mountpoint, true).await?;
+            }
             let guard = Arc::new(MountGuard::mount(filesystem, &mountpoint, mount_type).await?);
             *weak_slot = Arc::downgrade(&guard);
             *prev_mt = mount_type;


### PR DESCRIPTION
## Summary

Fixes a service-launch failure that occurs when `startd` is restarted **within the same boot** after its previous process was hard-killed (e.g. `SIGKILL` while recovering from a hang).

### Symptom

After `startd` was SIGKILLed and restarted by systemd (no reboot), **every** service failed to load during init with:

```
mount: /media/startos/tmp/<id>: /usr/lib/startos/container-runtime/rootfs.squashfs is already mounted.
ERROR ...:cleanup_and_initialize:init:load: startos::service::service_map: Error loading service: Filesystem I/O Error: mount exited with exit status: 1
   at src/disk/mount/guard.rs
```

A full reboot cleared it; a `systemctl restart` did not.

### Root cause

Two compounding issues:

1. **The restart path skips filesystem reconciliation.** `startd` gates init on `/run/startos/initialized` (`bins/startd.rs`). On a fresh boot the marker is absent → `init::init()` runs the filesystem prep. On a same-boot restart the marker survives (it lives in `/run`, tmpfs), so startd takes the `else` branch, skips `init::init()`, and goes straight to loading services — nothing reconciles mounts left behind by the dead process.

2. **Remounts aren't idempotent.** `MountGuard::mount` mounts unconditionally. `TmpMountGuard` dedups live mounts via a `Weak<MountGuard>`, but that `Weak` is dead in a fresh process, so it falls through to `MountGuard::mount`, which fails because the *kernel* mount from the dead process still exists. The shared `rootfs.squashfs` base is just the first mount in the chain to trip; the overlay on top (`OverlayGuard`, also via `MountGuard::mount`) would fail identically.

That's why a reboot fixed it (wiped `/run`, marker gone, `init::init()` ran) but a `systemctl restart` wouldn't have.

### Fix

Make `MountGuard::mount` reconcile a pre-existing mount at the target before mounting — lazily unmount it first — mirroring the existing `bind()` helper in `disk/mount/util.rs`. Both `TmpMountGuard` and `OverlayGuard` funnel through `MountGuard::mount`, so the whole mount chain self-heals on a restart, no reboot required.

Within a live process the change is inert: `TmpMountGuard`'s `Weak`-based dedup means this branch is only reached when there is no active in-process guard for the target.

### Context

This restart was triggered while recovering from a separate concurrent-update **deadlock** in startd (#3313). The deadlock is what forced the SIGKILL; this PR fixes the collateral damage that made the restart unrecoverable without a reboot. The two are independent — this can land on its own.

Closes the restart-recovery half of #3313.
