### PR TITLE
fix: graceful shutdown on external (UPS/qm/ACPI) shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COMPRESSED_WEB_UIS := web/dist/static/ui/index.html web/dist/static/setup-wizard
 FIRMWARE_ROMS := build/lib/firmware/$(PLATFORM) $(shell jq --raw-output '.[] | select(.platform[] | contains("$(PLATFORM)")) | "./build/lib/firmware/$(PLATFORM)/" + .id + ".rom.gz"' build/lib/firmware.json)
 BUILD_SRC := $(call ls-files, build/lib) build/lib/depends build/lib/conflicts $(FIRMWARE_ROMS) build/lib/migration-images/.done
 IMAGE_RECIPE_SRC := $(call ls-files, build/image-recipe/)
-STARTD_SRC := core/startd.service core/services.slice $(BUILD_SRC)
+STARTD_SRC := core/startd.service core/services.slice core/startos-shutdown.service core/startos-restart.service $(BUILD_SRC)
 CORE_SRC := $(call ls-files, core) $(shell git ls-files --recurse-submodules patch-db) $(GIT_HASH_FILE)
 WEB_SHARED_SRC := $(call ls-files, web/projects/shared) $(call ls-files, web/projects/marketplace) $(shell ls -p web/ | grep -v / | sed 's/^/web\//g') web/node_modules/.package-lock.json web/config.json patch-db/client/dist/index.js sdk/baseDist/package.json web/patchdb-ui-seed.json sdk/dist/package.json
 WEB_UI_SRC := $(call ls-files, web/projects/ui)
@@ -201,6 +201,8 @@ install: $(STARTOS_TARGETS)
 	$(call mkdir,$(DESTDIR)/lib/systemd/system)
 	$(call cp,core/startd.service,$(DESTDIR)/lib/systemd/system/startd.service)
 	$(call cp,core/services.slice,$(DESTDIR)/lib/systemd/system/services.slice)
+	$(call cp,core/startos-shutdown.service,$(DESTDIR)/lib/systemd/system/startos-shutdown.service)
+	$(call cp,core/startos-restart.service,$(DESTDIR)/lib/systemd/system/startos-restart.service)
 	if /bin/bash -c '[[ "${ENVIRONMENT}" =~ (^|-)unstable($$|-) ]]'; then \
 		sed -i '/^Environment=/a Environment=RUST_BACKTRACE=full' $(DESTDIR)/lib/systemd/system/startd.service; \
 	fi

--- a/core/locales/i18n.yaml
+++ b/core/locales/i18n.yaml
@@ -3383,6 +3383,13 @@ help.arg.no-verify:
   fr_FR: "Ignorer la vérification de signature"
   pl_PL: "Pomiń weryfikację podpisu"
 
+help.arg.nowait:
+  en_US: "Return immediately instead of waiting for graceful shutdown to complete"
+  de_DE: "Sofort zurückkehren, anstatt auf den Abschluss des ordnungsgemäßen Herunterfahrens zu warten"
+  es_ES: "Volver inmediatamente en lugar de esperar a que se complete el apagado controlado"
+  fr_FR: "Renvoyer immédiatement au lieu d'attendre la fin de l'arrêt propre"
+  pl_PL: "Zwróć natychmiast zamiast czekać na zakończenie kontrolowanego zamykania"
+
 help.arg.nvidia-container:
   en_US: "Enable NVIDIA container support"
   de_DE: "NVIDIA-Container-Unterstützung aktivieren"

--- a/core/src/context/rpc.rs
+++ b/core/src/context/rpc.rs
@@ -53,6 +53,7 @@ use crate::{DATA_DIR, PLATFORM, PackageId};
 
 pub struct RpcContextSeed {
     is_closed: AtomicBool,
+    closed: watch::Sender<bool>,
     pub os_partitions: OsPartitionInfo,
     pub disk_guid: InternedString,
     pub ephemeral_sessions: SyncMutex<Sessions>,
@@ -331,6 +332,7 @@ impl RpcContext {
 
         let seed = Arc::new(RpcContextSeed {
             is_closed: AtomicBool::new(false),
+            closed: watch::Sender::new(false),
             os_partitions: OsPartitionInfo::from_fstab().await?,
             disk_guid,
             ephemeral_sessions: SyncMutex::new(Sessions::new()),
@@ -385,8 +387,18 @@ impl RpcContext {
         self.crons.mutate(|c| std::mem::take(c));
         self.services.shutdown_all().await?;
         self.is_closed.store(true, Ordering::SeqCst);
+        self.closed.send_replace(true);
         tracing::info!("{}", t!("context.rpc.rpc-context-shutdown"));
         Ok(())
+    }
+
+    /// Resolves once graceful teardown (`shutdown`) has completed. Used by the
+    /// `wait` path of the server shutdown/restart RPC so a caller can block
+    /// until containers are stopped (it won't outlive the webserver teardown
+    /// that immediately follows).
+    pub async fn wait_closed(&self) {
+        let mut rx = self.0.closed.subscribe();
+        let _ = rx.wait_for(|closed| *closed).await;
     }
 
     pub fn add_cron<F: Future<Output = ()> + Send + 'static>(&self, fut: F) -> Guid {

--- a/core/src/shutdown.rs
+++ b/core/src/shutdown.rs
@@ -1,3 +1,7 @@
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
 use crate::PLATFORM;
 use crate::context::RpcContext;
 use crate::disk::main::export;
@@ -86,7 +90,35 @@ impl Shutdown {
     }
 }
 
-pub async fn shutdown(ctx: RpcContext) -> Result<(), Error> {
+#[derive(Debug, Clone, Deserialize, Serialize, Parser, TS)]
+#[group(skip)]
+#[ts(export)]
+#[serde(rename_all = "camelCase")]
+#[command(rename_all = "kebab-case")]
+pub struct ShutdownParams {
+    /// Block until graceful teardown completes (default over the CLI; the
+    /// frontend omits this and gets an immediate reply). Cleared with
+    /// `--nowait`. The wait can't outlive the webserver teardown that follows
+    /// container shutdown, so the connection drops once services are stopped.
+    #[arg(long = "nowait", action = clap::ArgAction::SetFalse, help = "help.arg.nowait")]
+    #[serde(default)]
+    wait: bool,
+}
+
+async fn begin_shutdown(ctx: &RpcContext, restart: bool, wait: bool) {
+    ctx.shutdown
+        .send(Some(Shutdown {
+            disk_guid: Some(ctx.disk_guid.clone()),
+            restart,
+        }))
+        .map_err(|_| eyre!("receiver dropped"))
+        .log_err();
+    if wait {
+        ctx.wait_closed().await;
+    }
+}
+
+pub async fn shutdown(ctx: RpcContext, ShutdownParams { wait }: ShutdownParams) -> Result<(), Error> {
     ctx.db
         .mutate(|db| {
             db.as_public_mut()
@@ -97,17 +129,11 @@ pub async fn shutdown(ctx: RpcContext) -> Result<(), Error> {
         })
         .await
         .result?;
-    ctx.shutdown
-        .send(Some(Shutdown {
-            disk_guid: Some(ctx.disk_guid.clone()),
-            restart: false,
-        }))
-        .map_err(|_| eyre!("receiver dropped"))
-        .log_err();
+    begin_shutdown(&ctx, false, wait).await;
     Ok(())
 }
 
-pub async fn restart(ctx: RpcContext) -> Result<(), Error> {
+pub async fn restart(ctx: RpcContext, ShutdownParams { wait }: ShutdownParams) -> Result<(), Error> {
     ctx.db
         .mutate(|db| {
             db.as_public_mut()
@@ -118,17 +144,11 @@ pub async fn restart(ctx: RpcContext) -> Result<(), Error> {
         })
         .await
         .result?;
-    ctx.shutdown
-        .send(Some(Shutdown {
-            disk_guid: Some(ctx.disk_guid.clone()),
-            restart: true,
-        }))
-        .map_err(|_| eyre!("receiver dropped"))
-        .log_err();
+    begin_shutdown(&ctx, true, wait).await;
     Ok(())
 }
 
 pub async fn rebuild(ctx: RpcContext) -> Result<(), Error> {
     tokio::fs::write(SYSTEM_REBUILD_PATH, b"").await?;
-    restart(ctx).await
+    restart(ctx, ShutdownParams { wait: false }).await
 }

--- a/core/startos-restart.service
+++ b/core/startos-restart.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=StartOS graceful restart
+# Reboot/kexec counterpart of startos-shutdown.service (see its comment).
+DefaultDependencies=no
+After=startd.service
+Before=reboot.target kexec.target
+Conflicts=reboot.target kexec.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+ExecStop=/usr/bin/start-cli server restart
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/core/startos-shutdown.service
+++ b/core/startos-shutdown.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=StartOS graceful shutdown
+# DefaultDependencies=no ties this unit to poweroff/halt specifically rather
+# than the generic shutdown.target, so it (and its ExecStop) fire only on a
+# power-off, not on a reboot. After=startd.service makes it stop before startd,
+# so startd is still up to run the graceful teardown its ExecStop requests.
+DefaultDependencies=no
+After=startd.service
+Before=poweroff.target halt.target
+Conflicts=poweroff.target halt.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+# start-cli waits for graceful teardown by default; authenticates locally via
+# /run/startos/rpc.authcookie. startd then re-issues the matching poweroff,
+# which is idempotent since systemd is already powering off.
+ExecStop=/usr/bin/start-cli server shutdown
+TimeoutStopSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/startos/postinst
+++ b/debian/startos/postinst
@@ -133,6 +133,8 @@ dns=systemd-resolved
 managed=true
 EOF
 $SYSTEMCTL enable startd.service
+$SYSTEMCTL enable startos-shutdown.service
+$SYSTEMCTL enable startos-restart.service
 $SYSTEMCTL enable systemd-resolved.service
 $SYSTEMCTL enable ssh.service
 $SYSTEMCTL enable systemd-oomd.service


### PR DESCRIPTION
## Summary

Makes externally-initiated shutdowns graceful, so StartOS service containers are torn down by `startd` before systemd proceeds — covering `qm shutdown`, ACPI, and **UPS/NUT-triggered `shutdown -h`** (the dependency for #3317). Closes #3235.

Previously only a UI / `start-cli server shutdown` initiated shutdown ran `startd`'s graceful teardown; a system-initiated shutdown let systemd stop everything around `startd`, terminating services abruptly (data-corruption risk for Lightning/Bitcoin workloads).

### Approach (revised per review)

`startd` already handles `SIGTERM` by running the same graceful teardown as a UI shutdown. The gap is purely *ordering*: systemd ordering is symmetric, so because `startd` starts **before** the things it manages, it is stopped **after** them — the opposite of what we need. Two small pre-shutdown barrier units invert that:

- **`core/startos-shutdown.service`** (poweroff/halt) and **`core/startos-restart.service`** (reboot/kexec). `DefaultDependencies=no` binds each to its *specific* target (not the generic `shutdown.target`), so each fires only on its own mode. Ordered `After=startd.service` (and `Before=`/`Conflicts=` its target), each unit's `ExecStop` calls `start-cli server shutdown` / `restart` — which now **waits** for graceful teardown — while `startd` is still up. `start-cli` authenticates locally via `/run/startos/rpc.authcookie`. `startd` then re-issues the matching final poweroff/reboot, which is idempotent since systemd is already on its way there.

- **`server shutdown` / `restart` gain a `wait`** (`core/src/shutdown.rs`): a `watch`-backed completion signal on `RpcContext` (`wait_closed()`, fired after `services.shutdown_all()`). Default **false** over the API (the frontend keeps its immediate reply — it already sends `{}`), default **true** on the CLI with `--nowait` to opt out.

### Files

- `core/src/shutdown.rs` — `ShutdownParams { wait }`, wait-on-teardown.
- `core/src/context/rpc.rs` — `closed` watch + `wait_closed()`.
- `core/startos-shutdown.service`, `core/startos-restart.service` — barrier units.
- `Makefile`, `debian/startos/postinst` — install + enable.
- `core/locales/i18n.yaml` — `help.arg.nowait` (×5 locales).

## Validation status

- **Not yet build- or runtime-verified.** TODO before merge: `cargo check`, `make ts-bindings` (generate `ShutdownParams.ts` + SDK rebuild), cross-layer typechecks, and a VM test of an external **poweroff** *and* **reboot** on beta-9 (diff teardown logs against a UI shutdown). Pushed for review per @dr-bonez.
