### PR TITLE
chore(web): publish shared 0.3.16, correct shared/marketplace lib peerDependencies

### DIFF
--- a/web/projects/marketplace/package.json
+++ b/web/projects/marketplace/package.json
@@ -4,13 +4,18 @@
   "peerDependencies": {
     "@angular/common": ">=21.0.0",
     "@angular/core": ">=21.0.0",
-    "@start9labs/shared": ">=0.3.2",
+    "@angular/forms": ">=21.0.0",
+    "@angular/router": ">=21.0.0",
+    "@ng-web-apis/platform": ">=5.0.0",
+    "@start9labs/shared": ">=0.3.16",
+    "@start9labs/start-sdk": ">=1.5.3",
     "@taiga-ui/cdk": ">=5.0.0",
     "@taiga-ui/core": ">=5.0.0",
+    "@taiga-ui/dompurify": ">=5.0.0",
     "@taiga-ui/kit": ">=5.0.0",
     "@taiga-ui/layout": ">=5.0.0",
-    "@taiga-ui/dompurify": ">=5.0.0",
-    "fuse.js": "^6.4.6"
+    "fuse.js": "^6.4.6",
+    "rxjs": ">=7.0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/web/projects/shared/package.json
+++ b/web/projects/shared/package.json
@@ -1,17 +1,27 @@
 {
   "name": "@start9labs/shared",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "peerDependencies": {
-    "@angular/common": ">=13.2.0",
-    "@angular/core": ">=13.2.0",
-    "@angular/router": ">=13.2.0",
-    "@ng-web-apis/mutation-observer": ">=4.0.0",
-    "@ng-web-apis/resize-observer": ">=4.0.0",
-    "@taiga-ui/cdk": ">=4.0.0",
-    "@taiga-ui/core": ">=4.0.0",
-    "@taiga-ui/layout": ">=4.0.0",
-    "@tinkoff/ng-dompurify": ">=4.0.0",
-    "ansi-to-html": "^0.7.2"
+    "@angular/cdk": ">=21.0.0",
+    "@angular/common": ">=21.0.0",
+    "@angular/core": ">=21.0.0",
+    "@angular/forms": ">=21.0.0",
+    "@angular/platform-browser": ">=21.0.0",
+    "@angular/router": ">=21.0.0",
+    "@ng-web-apis/intersection-observer": ">=5.0.0",
+    "@ng-web-apis/mutation-observer": ">=5.0.0",
+    "@start9labs/start-sdk": ">=1.5.3",
+    "@taiga-ui/addon-mobile": ">=5.0.0",
+    "@taiga-ui/cdk": ">=5.0.0",
+    "@taiga-ui/core": ">=5.0.0",
+    "@taiga-ui/dompurify": ">=5.0.0",
+    "@taiga-ui/i18n": ">=5.0.0",
+    "@taiga-ui/kit": ">=5.0.0",
+    "@taiga-ui/polymorpheus": ">=5.0.0",
+    "ansi-to-html": "^0.7.2",
+    "base64-js": "^1.5.1",
+    "marked": "^4.0.0",
+    "rxjs": ">=7.0.0"
   },
   "exports": {
     "./assets/": "./assets/"


### PR DESCRIPTION
Publishes the StartOS web libraries to npm and brings their `peerDependencies` back in line with what the source actually imports.

**Published**
- `@start9labs/shared@0.3.16` (was `0.3.15`)
- `@start9labs/marketplace@0.3.36` (npm had `0.3.35`; repo was already at `0.3.36`, never published)

**shared peerDependencies** — corrected to match the Taiga 5 / Angular 21 codebase:
- Angular `>=13.2.0` → `>=21.0.0`; Taiga `>=4.0.0` → `>=5.0.0`; `@ng-web-apis/*` `>=4.0.0` → `>=5.0.0`
- dropped removed `@tinkoff/ng-dompurify` → `@taiga-ui/dompurify`; dropped unused `resize-observer` → `intersection-observer`
- added previously-undeclared-but-imported peers: `@angular/{cdk,forms,platform-browser}`, `@taiga-ui/{addon-mobile,i18n,kit,polymorpheus}`, `@start9labs/start-sdk`, `rxjs`, `base64-js`, `marked`

**marketplace peerDependencies** — added missing `@angular/{forms,router}`, `@ng-web-apis/platform`, `@start9labs/start-sdk`, `rxjs`; bumped `@start9labs/shared` floor `>=0.3.2` → `>=0.3.16` (the `0.3.36` lib is Taiga-5 code and needs the new shared).

`@start9labs/start-sdk` pinned `>=1.5.3` in both — used for the `T` types namespace (both libs) and the `ExtendedVersion`/`VersionRange` runtime exver API (shared). The 2.0 floor update will follow next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)