### PR TITLE
feat: gate container-runtime RPC/action logging behind dev build flag

### DIFF
--- a/container-runtime/src/Adapters/RpcListener.ts
+++ b/container-runtime/src/Adapters/RpcListener.ts
@@ -106,6 +106,10 @@ const evalType = z.object({
   }),
 })
 
+const isDevBuild = (process.env.STARTOS_ENVIRONMENT ?? "")
+  .split("-")
+  .includes("dev")
+
 const jsonParse = (x: string) => JSON.parse(x)
 
 const handleRpc = (id: IdType, result: Promise<RpcResult>) =>
@@ -164,12 +168,13 @@ export class RpcListener {
       const logData =
         (location: string) =>
         <X>(x: X) => {
-          console.log({
-            location,
-            stringified: JSON.stringify(x),
-            type: typeof x,
-            id,
-          })
+          if (isDevBuild)
+            console.log({
+              location,
+              stringified: JSON.stringify(x),
+              type: typeof x,
+              id,
+            })
           return x
         }
       const mapError = (error: any): SocketResponse => ({

--- a/core/src/service/effects/subcontainer/sync.rs
+++ b/core/src/service/effects/subcontainer/sync.rs
@@ -824,6 +824,7 @@ pub fn pipe_wrap(
 
     let mut cmd = StdCommand::new(program);
     cmd.args(args);
+    cmd.env("STARTOS_ENVIRONMENT", crate::version::ENVIRONMENT.trim());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 

--- a/core/src/version/mod.rs
+++ b/core/src/version/mod.rs
@@ -691,6 +691,11 @@ pub const COMMIT_HASH: &str = include_str!(concat!(
     "/../build/env/GIT_HASH.txt"
 ));
 
+pub const ENVIRONMENT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../build/env/ENVIRONMENT.txt"
+));
+
 pub fn git_info() -> Result<InternedString, Error> {
     Ok(InternedString::intern(COMMIT_HASH))
 }


### PR DESCRIPTION
## What

The container-runtime's `RpcListener` logged **every** RPC's full input and response — including action `run`/`get-input` payloads, which can contain secrets — to the service logs on every call, unconditionally (`logData` in `RpcListener.ts`).

This gates that per-RPC logging behind the **dev build flag** (the cargo `dev` feature, derived from `ENVIRONMENT` at build time).

## How

The node container-runtime isn't built per-environment, so the flag is plumbed in at runtime:

1. **core** — add `version::ENVIRONMENT`, the build's `ENVIRONMENT` string embedded via `include_str!(build/env/ENVIRONMENT.txt)`, mirroring the existing `COMMIT_HASH`/`GIT_HASH.txt` pattern (both files are build-generated and gitignored).
2. **core** — `pipe_wrap` (the `start-container` subcommand that launches the node runtime per `container-runtime.service`) now sets `STARTOS_ENVIRONMENT` on the child process.
3. **container-runtime** — `logData` only emits when the build is a dev build (`STARTOS_ENVIRONMENT` split on `-` includes `dev`, matching how cargo features are derived from `ENVIRONMENT`).

Non-dev (production) builds no longer dump RPC/action payloads to logs.

## Testing

- `cargo check --lib` and `cargo check --lib --features dev` — both compile clean (the `startbox`/`tunnelbox` bin `include_dir!` failures are pre-existing, from web dist not built locally).
- container-runtime `npm run check` (tsc) passes.