### PR TITLE
[chore]: Remove the URL mapping in old versions

### DIFF
--- a/core/src/registry/os/version/mod.rs
+++ b/core/src/registry/os/version/mod.rs
@@ -219,31 +219,6 @@ pub async fn get_version(
             })
             .collect::<Result<_, _>>()?,
     )?;
-
-    // TODO: remove
-    if device_info.map_or(false, |d| {
-        "0.4.0-alpha.17"
-            .parse::<Version>()
-            .map_or(false, |v| d.os.version <= v)
-    }) {
-        for (_, v) in res
-            .as_object_mut()
-            .into_iter()
-            .map(|v| v.iter_mut())
-            .flatten()
-        {
-            for asset_ty in ["iso", "squashfs", "img"] {
-                for (_, v) in v[asset_ty]
-                    .as_object_mut()
-                    .into_iter()
-                    .map(|v| v.iter_mut())
-                    .flatten()
-                {
-                    v["url"] = v["urls"][0].clone();
-                }
-            }
-        }
-    }
     Ok(res)
 }
 


### PR DESCRIPTION
According to `emver-rs`:

> This module was designed to address the problem of releasing updates to StartOS Packages where the upstream project was either unaware of or apathetic towards supporting their application on the StartOS platform.

Looks like that anything before or equal to `0.4.0-alpha.17` will always transpose  `v["urls"][0]` into `v["url"]` according to `|v| d.os.version <= v`. In other words, a migration mitigation.

Now that the current version is `0.4.0-beta.10` it doesn't seem that any machine is using a version older than `0.4.0-alpha.17`, therefore, the removal of the `TODO` and its associated code.

Feel free to indicate if there is an misunderstanding .