### PR TITLE
fix(net): run web-server connections in parallel + enable h2 adaptive window

### DIFF
--- a/core/src/net/http.rs
+++ b/core/src/net/http.rs
@@ -257,6 +257,7 @@ where
 {
     let (client, to) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
         .timer(TokioTimer::new())
+        .adaptive_window(true)
         .keep_alive_interval(Duration::from_secs(25))
         .keep_alive_timeout(Duration::from_secs(300))
         .handshake(TokioIo::new(to))
@@ -264,6 +265,7 @@ where
     let from = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
         .timer(TokioTimer::new())
         .enable_connect_protocol()
+        .adaptive_window(true)
         .keep_alive_interval(Duration::from_secs(25)) // Add this
         .keep_alive_timeout(Duration::from_secs(300))
         .serve_connection(

--- a/core/src/net/web_server.rs
+++ b/core/src/net/web_server.rs
@@ -405,9 +405,19 @@ where
                 Fut: Future + Send + 'static,
             {
                 fn execute(&self, fut: Fut) {
+                    // Run each connection (and hyper's per-stream futures) on its
+                    // own task instead of serializing them all on the runner's
+                    // single poll loop — h2's per-byte framing/flow-control work
+                    // otherwise caps single-stream upload throughput. The handle
+                    // stays in the runner wrapped in NonDetachingJoinHandle, which
+                    // aborts the task on drop, preserving shutdown-cancel.
                     self.queue.peek(|q| {
                         if let Some(q) = q {
-                            q.add_job(fut);
+                            q.add_job(NonDetachingJoinHandle::from(tokio::spawn(
+                                async move {
+                                    fut.await;
+                                },
+                            )));
                         } else {
                             tracing::warn!("job queued after shutdown");
                         }
@@ -456,6 +466,7 @@ where
                 .http2()
                 .timer(TokioTimer::new())
                 .enable_connect_protocol()
+                .adaptive_window(true)
                 .keep_alive_interval(Duration::from_secs(25))
                 .keep_alive_timeout(Duration::from_secs(300));
             let (queue, mut runner) = BackgroundJobQueue::new();
@@ -467,19 +478,22 @@ where
                     for _ in 0..5 {
                         if let Err(e) = async {
                             let (metadata, stream) = acceptor.accept().await?;
-                            queue.add_job(
-                                graceful.watch(
-                                    server
-                                        .serve_connection_with_upgrades(
-                                            TokioIo::new(stream),
-                                            SwappableRouter {
-                                                router: service.clone(),
-                                                metadata,
-                                            },
-                                        )
-                                        .into_owned(),
-                                ),
+                            let conn = graceful.watch(
+                                server
+                                    .serve_connection_with_upgrades(
+                                        TokioIo::new(stream),
+                                        SwappableRouter {
+                                            router: service.clone(),
+                                            metadata,
+                                        },
+                                    )
+                                    .into_owned(),
                             );
+                            queue.add_job(NonDetachingJoinHandle::from(tokio::spawn(
+                                async move {
+                                    let _ = conn.await;
+                                },
+                            )));
 
                             Ok::<_, Error>(())
                         }


### PR DESCRIPTION
## Problem

Large package **sideloads from the web UI stall/hang**, while `start-cli` sideload of the same file on the same network works fine.

## Root cause

The browser is forced onto **HTTP/2** (the OS interface advertises `h2` ALPN) and a **single h2 upload stream** is far slower than the CLI's HTTP/1.1.

The web server handed every connection — and every hyper-internal per-stream future (via the `QueueRunner` executor) — to a single `BackgroundJobRunner`: a `FuturesUnordered` polled by **one** task. So all connections plus h2's per-byte framing/flow-control/WINDOW_UPDATE work ran cooperatively on a single task. h2 is far more sensitive to this than h1 (much heavier per-byte work), so h2 single-stream throughput was capped while h1 sailed. Running each connection on its own task takes h2 from ~50–70 MB/s to h1 parity with the same window.

> An earlier revision blamed O_DIRECT disk-flush stalls — that was wrong; direct measurement showed the encrypted data drive does 906 MB/s O_DIRECT with ~2 ms/MiB and no stalls. The single-task runner is the cause.

## Fix

- In the web server, **spawn each job on its own task** and hand the handle to the existing `BackgroundJobRunner` wrapped in **`NonDetachingJoinHandle`** — connections run in parallel, the runner still tracks them, and the handle aborts the task on drop, so **shutdown-cancel semantics are preserved**. Scoped to the web server's two `add_job` sites (the executor + the connection-accept loop); **`BackgroundJobQueue::add_job` and its other callers (socks proxy, actor framework) are unchanged.**
- Enable hyper **`adaptive_window`** on the h2 builders (web server + vhost proxy) — no magic numbers; grows to BDP on higher-latency links.

## Validation (on-VM, 1 GiB single-stream upload)

| connection runner | h2 single-stream | h1 |
|---|---|---|
| single-task `BackgroundJobRunner` | ~40–70 MB/s | ~600–700 |
| **parallel (this PR)** | **~465–515 MB/s** | ~565–650 |

h2 single-stream reaches parity with HTTP/1.1. (Shared-host contention makes absolute numbers swing run-to-run — e.g. 41 vs 506 MB/s on the same binary — so the ceiling is the reliable signal.)

No docs change: internal net-stack only, no API surface change.
