### PR TITLE
fix(web): commit brochure config.json so deploy build resolves it

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -30,4 +30,5 @@ npm-debug.log*
 /node_modules
 
 config.json
+!projects/brochure/config.json
 proxy.conf.json

--- a/web/projects/brochure/config.json
+++ b/web/projects/brochure/config.json
@@ -1,0 +1,6 @@
+{
+  "marketplace": {
+    "start9": "https://registry.start9.com/",
+    "community": "https://community-registry.start9.com/"
+  }
+}


### PR DESCRIPTION
## Problem

The **Deploy brochure (marketplace.start9.com)** workflow has been failing on `master` since the brochure landed:

```
✘ [ERROR] Could not resolve "../../../config.json"
    projects/brochure/src/app/components/registry.component.ts:76:47
    projects/brochure/src/app/services/marketplace.service.ts:12:39
```

([failed run](https://github.com/Start9Labs/start-os/actions/runs/27850550777))

## Root cause

The brochure reads its registry URLs from `web/projects/brochure/config.json` via `require('../../../config.json').marketplace`. That file was meant to be committed (per #3330's description: *"config.json (registry URLs) … lives at the project root"*), but `web/.gitignore` has a global `config.json` rule — intended for the **generated** root `web/config.json` — which also matched and silently ignored the brochure's file. It built locally (the file existed on the author's disk) but CI never had it, and the deploy workflow has no step that generates it.

## Fix

- Commit `web/projects/brochure/config.json` with the start9 + community registry URLs (copied verbatim from the original `Start9Labs/brochure-marketplace` repo).
- Add a `.gitignore` negation `!projects/brochure/config.json` so this source file is tracked, while the generated `web/config.json` stays ignored.

## Verification

Reproduced the deploy workflow's exact steps locally (build `sdk/baseDist`, build `patch-db/client`, `npm --prefix web ci`, `npm --prefix web run build:brochure`):

- **Before:** fails with the `Could not resolve` error above.
- **After:** `build:brochure` succeeds and `web/dist/raw/brochure/index.html` is produced.