### PR TITLE
fix(web): brochure queries registries directly, not via host-proxy RPC

### DIFF
--- a/web/projects/brochure/src/app/services/live-api.service.ts
+++ b/web/projects/brochure/src/app/services/live-api.service.ts
@@ -85,14 +85,8 @@ export class LiveApiService extends ApiService {
     registryUrl: string,
     options: RPCOptions,
   ): Promise<T> {
-    return this.rpcRequest(
-      {
-        ...options,
-        method: `registry.${options.method}`,
-        params: { registry: registryUrl, ...options.params },
-      },
-      registryUrl,
-    )
+    // Hit the registry's RPC directly; the registry.* namespace + registry param is the StartOS host-proxy convention, absent on this static site.
+    return this.rpcRequest(options, `${new URL('rpc/v0', registryUrl)}`)
   }
 
   private async rpcRequest<T>(


### PR DESCRIPTION
## Problem

The brochure deployed to **marketplace.start9.com** but loads **no content** (no registry info, no package list).

## Root cause

The brochure's `LiveApiService` was speaking the **StartOS host-proxy** RPC dialect rather than talking to the registry directly. For every registry call it:

1. prepended `registry.` to the method (`info` → `registry.info`),
2. wrapped params in `{ registry: <url>, … }`, and
3. POSTed to the **bare** registry URL (`https://registry.start9.com/`).

That dialect is what a StartOS *server* exposes when it proxies registry calls on a client's behalf. `registry.start9.com` has no such proxy, so the deployed site's requests fail:

```
POST https://registry.start9.com/         → 405 Method Not Allowed   (bare URL isn't the RPC endpoint)
POST .../rpc/v0  {"method":"registry.info"} → -32601 Method not found  (registry.* is unknown directly)
```

…while the registry's own RPC works fine:

```
POST https://registry.start9.com/rpc/v0  {"method":"info"}        → 200
POST https://registry.start9.com/rpc/v0  {"method":"package.get"} → 200
```

(This dialect mismatch was inherited verbatim from the standalone `brochure-marketplace` repo; it only surfaced now that the app is actually deployed and pointed at the live registry.)

## Fix

`registryRequest` now POSTs to the registry's own endpoint — `${new URL('rpc/v0', registryUrl)}` — with the registry's **bare** methods (`info`, `package.get`) and unwrapped params. One-line change in `projects/brochure/src/app/services/live-api.service.ts`.

## Verification

- `npm --prefix web run build:brochure` + `check:brochure` pass; the rebuilt bundle now targets `<registry>/rpc/v0` with bare methods (no `registry.` prefix).
- Confirmed live against **both** registries (`registry.start9.com`, `community-registry.start9.com`): direct `info`/`package.get` return 200, and the CORS preflight from `Origin: https://marketplace.start9.com` returns `Access-Control-Allow-Origin` + `Access-Control-Allow-Credentials: true` — so the browser calls will succeed.

## Known remaining gap (separate, pre-existing)

Package **detail** pages fetch `LICENSE.md`/`instructions.md` via `getStaticProxy`, which still hits the host-only `/s9pk/proxy/…` path. On the static site that resolves to the SPA `index.html` (HTTP 200, `text/html`) rather than the file — the registry doesn't expose an `/s9pk/proxy` equivalent. The homepage/listing (the reported breakage) is fixed by this PR; the static-file proxy needs a server-side component and is out of scope here. Happy to follow up on it.