### PR TITLE
fix(web): isolate union variant memory per row to stop cross-row bleed

### DIFF
--- a/web/projects/ui/src/app/routes/portal/components/form/containers/union.component.ts
+++ b/web/projects/ui/src/app/routes/portal/components/form/containers/union.component.ts
@@ -52,9 +52,16 @@ import { FormGroupComponent } from './group.component'
 })
 export class FormUnionComponent implements OnChanges {
   @Input({ required: true })
-  spec!: IST.ValueSpecUnion & { others?: Record<string, any> }
+  spec!: IST.ValueSpecUnion
 
   selectSpec!: IST.ValueSpecSelect
+
+  // Per-instance memory of values entered in not-currently-selected variants,
+  // so switching away and back restores them. This MUST be instance state, not
+  // stashed on `spec`: a list renders every row with the SAME variant spec
+  // object, so writing to `spec.others` leaks one row's variant values into
+  // another row when you switch into that variant.
+  private readonly others: Record<string, any> = {}
 
   private readonly form = inject(FormGroupName)
   private readonly formService = inject(FormService)
@@ -63,16 +70,14 @@ export class FormUnionComponent implements OnChanges {
     return this.form.value.selection
   }
 
-  // OTHER?
   onUnion(union: string) {
-    this.spec.others = this.spec.others || {}
-    this.spec.others[this.union] = this.form.control.controls['value']?.value
+    this.others[this.union] = this.form.control.controls['value']?.value
     this.form.control.setControl(
       'value',
       this.formService.getFormGroup(
         union ? this.spec.variants[union]?.spec || {} : {},
         [],
-        this.spec.others[union],
+        this.others[union],
       ),
       { emitEvent: false },
     )


### PR DESCRIPTION
## Problem

When a `Value.union` / `Value.dynamicUnion` is used inside a `List.obj`,
switching one list row's union into a variant it did **not** originally hold
pre-fills that variant's fields with **another row's** value instead of the
variant's default. Saving then writes the wrong data to that row — silent data
bleed across list rows.

It reproduces regardless of the variant field's type (list, textarea, …) or
`minLength`. Fields placed directly on the list-item object (siblings of the
union, e.g. plain text/select controls) are unaffected.

### Minimal repro

A list of objects, each with a `source` union whose variant `a` holds a field:

```ts
InputSpec.of({
  items: Value.list(
    List.obj({ name: 'Items' }, {
      spec: InputSpec.of({
        source: Value.union({
          name: 'Source',
          default: 'a',
          variants: Variants.of({
            a: { name: 'A', spec: InputSpec.of({
              folders: Value.list(List.text({ name: 'Folders', default: [] }, { patterns: [] })),
            }) },
            b: { name: 'B', spec: InputSpec.of({}) },
          }),
        }),
      }),
    }),
  ),
})
```

Prefill two rows — row 1: `{selection:'a', value:{folders:['Photos','Documents']}}`,
row 2: `{selection:'b', value:{}}`. Open the form, switch **row 2** from B to A.

- **Expected:** row 2's `A → Folders` is empty.
- **Actual:** row 2's `A → Folders` shows `['Photos','Documents']` (row 1's value).

## Root cause

`FormUnionComponent` stored its cross-variant "others" memory (used to restore
values when you switch a variant away and back) on the **`spec` object**
(`this.spec.others`). But the list renderer passes the **same** variant spec
object to every row (`[spec]="$any(spec.spec)"` in `array.component.ts`), so
`spec.others` is shared across all rows — one row's variant values leak into
another's on switch.

## Fix

Store the "others" memory as **per-component-instance** state
(`private readonly others = {}`) instead of on the shared `spec`. Each row's
union now keeps its own variant memory. One-file change in
`web/projects/ui/src/app/routes/portal/components/form/containers/union.component.ts`.

## Testing

Surfaced in a real package (an external-libraries action with a per-row source
union); the minimal repro above reproduces it on `master`. The change is a
localized move of state from the shared spec to component-instance scope.
