### PR TITLE
chore(libs): mark shared/marketplace as internal, not published

### DIFF
--- a/web/projects/marketplace/package.json
+++ b/web/projects/marketplace/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@start9labs/marketplace",
-  "version": "0.3.36",
+  "version": "0.0.0",
+  "description": "Internal, source-consumed StartOS marketplace UI library — apps resolve it via tsconfig paths, not the ng-packagr build. Private and unpublished; the ng-packagr target exists only for optional npm extraction.",
   "private": true,
   "peerDependencies": {
     "@angular/common": ">=22.0.0",
@@ -8,7 +9,7 @@
     "@angular/forms": ">=22.0.0",
     "@angular/router": ">=22.0.0",
     "@ng-web-apis/platform": ">=5.0.0",
-    "@start9labs/shared": ">=0.3.16",
+    "@start9labs/shared": "*",
     "@start9labs/start-sdk": ">=1.5.3",
     "@taiga-ui/cdk": ">=5.0.0",
     "@taiga-ui/core": ">=5.0.0",

--- a/web/projects/shared/package.json
+++ b/web/projects/shared/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@start9labs/shared",
-  "version": "0.3.16",
+  "version": "0.0.0",
+  "description": "Internal, source-consumed StartOS library — apps resolve it via tsconfig paths, not the ng-packagr build. Private and unpublished; the ng-packagr target exists only for optional npm extraction.",
   "private": true,
   "peerDependencies": {
     "@angular/cdk": ">=22.0.0",


### PR DESCRIPTION
## Summary

Stacked on #3340 (targets `marketplace-unify`, not `master`).

Light cleanup of the `shared` and `marketplace` library projects — keep them as conventional, extract-ready Angular libraries, but drop the metadata that makes them look like a live npm publish pipeline:

- Reset `version` from the frozen `0.3.x` (leftovers from when these were published to npm for the standalone brochure) to `0.0.0`.
- Relax marketplace's internal `@start9labs/shared` peer range to `*` (it was `>=0.3.16`, now self-contradictory).
- Add a one-line `description` documenting that they are internal and source-consumed (apps resolve them via tsconfig paths, not the ng-packagr output), with the ng-packagr target kept only for optional extraction.

Metadata only — no code, import, or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
