### PR TITLE
fix(net): render host address list table instead of panicking

### DIFF
--- a/core/src/net/host/address.rs
+++ b/core/src/net/host/address.rs
@@ -153,7 +153,50 @@ pub fn address_api<C: Context, Kind: HostApiKind>()
                     }
 
                     let mut table = Table::new();
-                    todo!("find a good way to represent this");
+                    table.add_row(row![bc =>
+                        "ADDRESS",
+                        "VISIBILITY",
+                        "PUBLIC GATEWAY",
+                        "ACME PROVIDER",
+                        "PRIVATE GATEWAYS",
+                    ]);
+                    for addr in res.iter() {
+                        let visibility = match (&addr.public, &addr.private) {
+                            (Some(_), Some(_)) => "public, private",
+                            (Some(_), None) => "public",
+                            (None, Some(_)) => "private",
+                            (None, None) => "none",
+                        };
+                        let public_gateway = addr
+                            .public
+                            .as_ref()
+                            .map_or_else(|| "—".to_owned(), |p| p.gateway.to_string());
+                        let acme = addr
+                            .public
+                            .as_ref()
+                            .and_then(|p| p.acme.as_ref())
+                            .map_or_else(|| "—".to_owned(), |a| a.0.to_string());
+                        let private_gateways = addr
+                            .private
+                            .as_ref()
+                            .filter(|g| !g.is_empty())
+                            .map_or_else(
+                                || "—".to_owned(),
+                                |g| {
+                                    g.iter()
+                                        .map(|g| g.to_string())
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                },
+                            );
+                        table.add_row(row![
+                            addr.address,
+                            visibility,
+                            public_gateway,
+                            acme,
+                            private_gateways,
+                        ]);
+                    }
 
                     table.print_tty(false)?;
 


### PR DESCRIPTION
## Problem

`start-cli server host address list` (and the per-package host equivalent) panics:

```
core/src/net/host/address.rs:156: not yet implemented: find a good way to represent this
```

The custom TTY display fn for `list` had a `todo!()` where the table should be built. JSON output (`--format`) worked; the default human table aborted.

## Proposed representation

One row per `HostAddress`. Each address can be public (a gateway + optional ACME provider) and/or private (a set of gateways), so the columns are:

| Column | Source | Notes |
|--------|--------|-------|
| ADDRESS | `address` | the FQDN |
| VISIBILITY | `public`/`private` presence | `public`, `private`, `public, private`, or `none` |
| PUBLIC GATEWAY | `public.gateway` | gateway the domain is publicly exposed on, else `—` |
| ACME PROVIDER | `public.acme` | provider URL, else `—` (manual/none) |
| PRIVATE GATEWAYS | `private` | comma-joined gateway ids, else `—` |

Example:

```
+-------------+-----------------+----------------+-------------------------------+------------------+
| ADDRESS     | VISIBILITY      | PUBLIC GATEWAY | ACME PROVIDER                 | PRIVATE GATEWAYS |
+-------------+-----------------+----------------+-------------------------------+------------------+
| example.com | public, private | wan            | https://acme-v02.../directory | lan, vpn         |
| foo.local   | private         | —              | —                             | lan              |
+-------------+-----------------+----------------+-------------------------------+------------------+
```

This mirrors the `bc =>` header + per-row style already used by `binding list` next door. Open to dropping/renaming columns if you'd represent it differently — easy to adjust.

## Verification

`cargo check -p start-os --lib` passes. The change is confined to the display closure; `list_addresses` and the JSON (`--format`) path are untouched.