### PR TITLE
fix(net): bind DNS listeners with SO_REUSEPORT so the :53 wildcard coexists with per-address sockets

### DIFF
--- a/core/src/net/dns.rs
+++ b/core/src/net/dns.rs
@@ -34,7 +34,7 @@ use crate::context::{CliContext, RpcContext};
 use crate::db::model::Database;
 use crate::db::model::public::NetworkInterfaceInfo;
 use crate::net::gateway::NetworkInterfaceWatcher;
-use crate::net::utils::{bind_tokio_listener, ipv6_is_link_local};
+use crate::net::utils::{bind_tokio_listener_reuse_port, ipv6_is_link_local};
 use crate::prelude::*;
 use crate::util::future::NonDetachingJoinHandle;
 use crate::util::io::file_string_stream;
@@ -659,6 +659,9 @@ fn bind_reuse_udp(addr: SocketAddr, dual_stack: bool) -> Result<UdpSocket, Error
     socket
         .set_reuse_address(true)
         .with_kind(ErrorKind::Network)?;
+    socket
+        .set_reuse_port(true)
+        .with_kind(ErrorKind::Network)?;
     if matches!(addr, SocketAddr::V6(_)) {
         socket
             .set_only_v6(!dual_stack)
@@ -673,7 +676,7 @@ fn dns_server_on(resolver: Resolver, addr: SocketAddr) -> Result<Server<Resolver
     let dual_stack = matches!(addr, SocketAddr::V6(v6) if v6.ip().is_unspecified());
     let mut server = Server::new(resolver);
     server.register_listener(
-        bind_tokio_listener(addr).with_kind(ErrorKind::Network)?,
+        bind_tokio_listener_reuse_port(addr).with_kind(ErrorKind::Network)?,
         Duration::from_secs(30),
         DNS_RESPONSE_BUFFER_SIZE,
     );

--- a/core/src/net/utils.rs
+++ b/core/src/net/utils.rs
@@ -22,13 +22,22 @@ use crate::util::Invoke;
 // accept queue on the vhost proxy under burst load.
 const LISTEN_BACKLOG: i32 = 1024;
 
-fn build_listen_socket(addr: SocketAddr) -> std::io::Result<std::net::TcpListener> {
+fn build_listen_socket(
+    addr: SocketAddr,
+    reuse_port: bool,
+) -> std::io::Result<std::net::TcpListener> {
     let domain = match addr {
         SocketAddr::V4(_) => socket2::Domain::IPV4,
         SocketAddr::V6(_) => socket2::Domain::IPV6,
     };
     let socket = socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
     socket.set_reuse_address(true)?;
+    if reuse_port {
+        // SO_REUSEADDR alone does not let a dual-stack wildcard catch-all listener
+        // share a TCP port with the per-address specific listeners bound alongside
+        // it; that requires SO_REUSEPORT. Used by the DNS :53 binds (`dns_server_on`).
+        socket.set_reuse_port(true)?;
+    }
     socket.set_nonblocking(true)?;
     socket.bind(&addr.into())?;
     socket.listen(LISTEN_BACKLOG)?;
@@ -39,14 +48,23 @@ fn build_listen_socket(addr: SocketAddr) -> std::io::Result<std::net::TcpListene
 /// ([`LISTEN_BACKLOG`]) instead of mio's hardcoded 128. Use everywhere we'd
 /// otherwise reach for `mio::net::TcpListener::bind`.
 pub fn bind_mio_listener(addr: SocketAddr) -> std::io::Result<mio::net::TcpListener> {
-    Ok(mio::net::TcpListener::from_std(build_listen_socket(addr)?))
+    Ok(mio::net::TcpListener::from_std(build_listen_socket(addr, false)?))
 }
 
 /// Bind a `tokio::net::TcpListener` with an explicit listen backlog
 /// ([`LISTEN_BACKLOG`]) instead of tokio's hardcoded 128. Use everywhere we'd
 /// otherwise reach for `tokio::net::TcpListener::bind`.
 pub fn bind_tokio_listener(addr: SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
-    tokio::net::TcpListener::from_std(build_listen_socket(addr)?)
+    tokio::net::TcpListener::from_std(build_listen_socket(addr, false)?)
+}
+
+/// Like [`bind_tokio_listener`], but with SO_REUSEPORT so a wildcard catch-all
+/// listener can share a port with per-address specific listeners (the DNS :53
+/// binds in `dns_server_on`).
+pub fn bind_tokio_listener_reuse_port(
+    addr: SocketAddr,
+) -> std::io::Result<tokio::net::TcpListener> {
+    tokio::net::TcpListener::from_std(build_listen_socket(addr, true)?)
 }
 
 /// Detect silent peer death within ~2 min instead of the Linux default ~2h.


### PR DESCRIPTION
## Summary

The DNS server binds a dual-stack `[::]:53` wildcard catch-all alongside per-address sockets (loopback, the container bridge, and each gateway). `SO_REUSEADDR` alone does **not** let a wildcard listener share a TCP port with a specific-address listener — that requires `SO_REUSEPORT` — so the catch-all's **TCP** bind failed with `EADDRINUSE` and the wildcard was silently dropped, logging `failed to bind DNS on [::]:53: Address in use`. (UDP was unaffected; it coexists on `SO_REUSEADDR`.)

This adds `SO_REUSEPORT` to the DNS TCP and UDP binders, scoped via a new `bind_tokio_listener_reuse_port` so the `web_server`/vhost binders are unchanged. Routing is preserved — `SO_REUSEPORT` only permits the overlapping bind; the kernel still delivers to the most-specific address, so the per-gateway scope design is intact.

Verified on a beta.10 host: with `SO_REUSEADDR` the full `:53` topology (dual-stack `[::]` + IPv4 specifics + `[::1]`) fails the TCP wildcard bind; with `SO_REUSEPORT` the whole set binds cleanly (TCP and UDP). `cargo zigbuild --lib -p start-os` (release, musl) compiles green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
