### PR TITLE
fix(ui): show a service's nested init-progress in the install card

### DIFF
--- a/web/projects/ui/src/app/routes/portal/routes/services/components/progress.component.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/services/components/progress.component.ts
@@ -6,9 +6,10 @@ import {
   LeafProgressPipe,
 } from '@start9labs/shared'
 import { T } from '@start9labs/start-sdk'
-import { TuiButton } from '@taiga-ui/core'
+import { TuiButton, TuiExpand } from '@taiga-ui/core'
 import { TuiNotificationMiddleService, TuiProgress } from '@taiga-ui/kit'
 import { InstallingProgressPipe } from 'src/app/routes/portal/routes/services/pipes/install-progress.pipe'
+import { InstallPhaseViewPipe } from 'src/app/routes/portal/routes/services/pipes/install-phase-view.pipe'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
 import { PackageDataEntry } from 'src/app/services/patch-db/data-model'
 import { getManifest } from 'src/app/utils/get-package-data'
@@ -33,10 +34,11 @@ import { getManifest } from 'src/app/utils/get-package-data'
       phase of pkg.stateInfo.installingInfo?.progress?.phases;
       track $index
     ) {
-      @let leaf = phase.progress | leafProgress;
+      @let view = phase.progress | installPhaseView;
+      @let leaf = view.progress | leafProgress;
       @let percent = leaf | installingProgress;
       <div>
-        {{ $any(phase.name) | i18n }}:
+        <b>{{ $any(phase.name) | i18n }}</b>
         @if (leaf === null) {
           <span>{{ 'waiting' | i18n }}</span>
         } @else if (leaf === true) {
@@ -46,6 +48,9 @@ import { getManifest } from 'src/app/utils/get-package-data'
         } @else {
           <span>{{ percent }}%</span>
         }
+        <tui-expand [expanded]="!!view.subtext">
+          <div class="subtext">{{ $any(view.subtext) | i18n }}</div>
+        </tui-expand>
         <progress
           tuiProgressBar
           size="m"
@@ -66,6 +71,15 @@ import { getManifest } from 'src/app/utils/get-package-data'
       padding: 0.25rem 0;
     }
 
+    b {
+      color: var(--tui-text-primary);
+    }
+
+    .subtext {
+      padding: 0;
+      font-size: 0.875rem;
+    }
+
     span {
       float: right;
       text-transform: capitalize;
@@ -78,7 +92,9 @@ import { getManifest } from 'src/app/utils/get-package-data'
   host: { class: 'g-card' },
   imports: [
     TuiProgress,
+    TuiExpand,
     InstallingProgressPipe,
+    InstallPhaseViewPipe,
     LeafProgressPipe,
     i18nPipe,
     TuiButton,

--- a/web/projects/ui/src/app/routes/portal/routes/services/pipes/install-phase-view.pipe.ts
+++ b/web/projects/ui/src/app/routes/portal/routes/services/pipes/install-phase-view.pipe.ts
@@ -1,0 +1,35 @@
+import { Pipe, PipeTransform } from '@angular/core'
+import { T } from '@start9labs/start-sdk'
+
+export interface InstallPhaseView {
+  // Progress driving the row's status + bar. When the phase nests a service's
+  // setInitProgress, this is the furthest-along sub-phase's progress (so the bar
+  // "reloads" for each sub-phase); otherwise the phase's own progress.
+  progress: T.Progress
+  // The furthest-along sub-phase's name, shown as subtext — null when the phase
+  // has no nested sub-phases or none has started yet.
+  subtext: string | null
+}
+
+@Pipe({ name: 'installPhaseView' })
+export class InstallPhaseViewPipe implements PipeTransform {
+  transform(progress: T.Progress): InstallPhaseView {
+    if (
+      progress !== null &&
+      typeof progress === 'object' &&
+      'overall' in progress
+    ) {
+      // The last sub-phase that has started: the running one while installing,
+      // and the final one once they're all done — so the subtext stays put
+      // through completion instead of dropping off and shrinking the card.
+      const started = progress.phases.filter(p => p.progress !== null)
+      const current = started[started.length - 1]
+
+      return current
+        ? { progress: current.progress, subtext: current.name }
+        : { progress, subtext: null }
+    }
+
+    return { progress, subtext: null }
+  }
+}

--- a/web/projects/ui/src/app/services/api/embassy-mock-api.service.ts
+++ b/web/projects/ui/src/app/services/api/embassy-mock-api.service.ts
@@ -81,6 +81,21 @@ const PROGRESS: T.FullProgress = {
   ],
 }
 
+// A service's own install-time progress (setInitProgress). The host nests this
+// inside the install's finalization ("Installing") phase as a FullProgress — but
+// only once finalization begins; until then that phase is null (waiting), so the
+// sub-phases must not appear before the download/validation phases finish.
+// installProgress injects this then. An indeterminate sub-phase (like HA's
+// "Generating Home Assistant configuration", a value-less animated bar) plus a
+// determinate one exercise both render branches of the install card's sub-phases.
+const INIT_PROGRESS: T.FullProgress = {
+  overall: { done: 0, total: 8, units: 'steps' },
+  phases: [
+    { name: 'Generating configuration', progress: false },
+    { name: 'Migrating data', progress: { done: 0, total: 8, units: 'steps' } },
+  ],
+}
+
 @Injectable()
 export class MockApiService extends ApiService {
   readonly mockWsSource$ = new Subject<Revision>()
@@ -1799,11 +1814,38 @@ export class MockApiService extends ApiService {
     id: string,
     finalManifest?: T.Manifest,
   ): Promise<void> {
-    // Cast to any: same reasoning as initProgress above.
+    // Cast to any: the finalization phase becomes a nested FullProgress at
+    // runtime (a service's setInitProgress, injected by installInitProgress).
     const progress: any = JSON.parse(JSON.stringify(PROGRESS))
 
     for (let [i, phase] of progress.phases.entries() as [number, any][]) {
-      if (!phase.progress || phase.progress === true || !phase.progress.total) {
+      // The last phase is finalization ("Installing"): the service reports its
+      // own progress via setInitProgress, which the host nests here — but only
+      // now, once download/validation are done. Inject it then, and animate it.
+      if (i === progress.phases.length - 1) {
+        await this.installInitProgress(id, i)
+
+        if (
+          progress.overall &&
+          typeof progress.overall === 'object' &&
+          progress.overall.total
+        ) {
+          progress.overall.done +=
+            progress.overall.total / progress.phases.length
+
+          this.mockRevision([
+            {
+              op: PatchOp.REPLACE,
+              path: `/packageData/${id}/stateInfo/installingInfo/progress/overall/done`,
+              value: progress.overall.done,
+            },
+          ])
+        }
+      } else if (
+        !phase.progress ||
+        phase.progress === true ||
+        !phase.progress.total
+      ) {
         await pauseFor(2000)
 
         const patches: Operation<any>[] = [
@@ -1902,6 +1944,81 @@ export class MockApiService extends ApiService {
       },
     ]
     this.mockRevision(patch2)
+  }
+
+  // Drives a service's nested init progress at the install's finalization
+  // ("Installing") phase. Injects INIT_PROGRESS in place of the not-started
+  // (null) phase — every sub-phase starting "waiting" — then starts each in
+  // turn: an indeterminate sub-phase sits "in progress" for a beat, a
+  // determinate one climbs its percentage, and both — and the nested overall —
+  // complete. Mirrors the host: the sub-phases appear only now, not earlier.
+  private async installInitProgress(
+    id: string,
+    parentIdx: number,
+  ): Promise<void> {
+    const base = `/packageData/${id}/stateInfo/installingInfo/progress/phases/${parentIdx}/progress`
+    const init: any = JSON.parse(JSON.stringify(INIT_PROGRESS))
+
+    this.mockRevision([
+      {
+        op: PatchOp.REPLACE,
+        path: base,
+        value: {
+          overall: init.overall,
+          phases: init.phases.map((p: any) => ({ ...p, progress: null })),
+        },
+      },
+    ])
+
+    for (let [j, sub] of init.phases.entries() as [number, any][]) {
+      // start this sub-phase (it has been showing "waiting")
+      this.mockRevision([
+        {
+          op: PatchOp.REPLACE,
+          path: `${base}/phases/${j}/progress`,
+          value: sub.progress,
+        },
+      ])
+
+      if (
+        sub.progress &&
+        typeof sub.progress === 'object' &&
+        sub.progress.total
+      ) {
+        const step = sub.progress.total / 4
+
+        while (sub.progress.done < sub.progress.total) {
+          await pauseFor(600)
+          sub.progress.done += step
+          this.mockRevision([
+            {
+              op: PatchOp.REPLACE,
+              path: `${base}/phases/${j}/progress/done`,
+              value: sub.progress.done,
+            },
+          ])
+        }
+      } else {
+        // indeterminate (false) — let the value-less bar animate before completing
+        await pauseFor(3000)
+      }
+
+      this.mockRevision([
+        {
+          op: PatchOp.REPLACE,
+          path: `${base}/phases/${j}/progress`,
+          value: true,
+        },
+      ])
+    }
+
+    this.mockRevision([
+      {
+        op: PatchOp.REPLACE,
+        path: `${base}/overall`,
+        value: true,
+      },
+    ])
   }
 
   private async updateOSProgress() {


### PR DESCRIPTION
## Summary

A package reports install-time progress via `setInitProgress` (a `FullProgressTracker` with named sub-phases). The host folds it into the install's finalization phase as `Progress::Nested(FullProgress)` carrying the service's named sub-phases, and that reaches the UI intact (`InstallingInfo { progress: FullProgress }`).

But `ServiceInstallProgressComponent` piped each phase through `leafProgress`, which **walks `overall` down to a scalar and discards the nested `phases[]`**. So the service's sub-phase names (e.g. `Generating Home Assistant configuration`) were **never displayed**, and an indeterminate sub-phase collapsed to `0%` — a **frozen install bar**. With nothing rendered, the init-progress feature had no visible effect — a real bug.

This renders each top-level install phase as a **stable row** (bold heading, no colon). When a phase nests sub-phases, `InstallPhaseViewPipe` surfaces the **furthest-along** sub-phase as `tuiExpand`-animated subtext and drives the row's status + bar from it (so the bar "reloads" for each sub-phase). The finalization row never splits, disappears, or shrinks — it holds as `Installing → <sub-phase> → complete`, with the subtext staying put through completion.

Sub-phases only exist once the service's init container runs (during finalization), so the finalization phase is `null` (waiting) until then — the UI reflects that faithfully.

Includes a mock fixture (`embassy-mock-api.service.ts`) that injects a nested init-progress at finalization (an indeterminate + a determinate sub-phase) so the behavior is exercisable in the mock UI. `check:shared` / `check:ui` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
