### PR TITLE
Custom registries by domain + remove "Plugin:" interface label

### DIFF
--- a/web/projects/brochure/src/app/services/marketplace.service.ts
+++ b/web/projects/brochure/src/app/services/marketplace.service.ts
@@ -7,7 +7,13 @@ import {
   StoreDataWithUrl,
   StoreIdentity,
 } from '@start9labs/marketplace'
-import { defaultRegistries, Exver, i18nPipe, sameUrl } from '@start9labs/shared'
+import {
+  defaultRegistries,
+  Exver,
+  i18nPipe,
+  registryUrl,
+  sameUrl,
+} from '@start9labs/shared'
 import { T } from '@start9labs/start-sdk'
 import {
   BehaviorSubject,
@@ -117,7 +123,7 @@ export class MarketplaceService extends AbstractMarketplaceService {
   }
 
   async add(rawUrl: string): Promise<string> {
-    const url = new URL(rawUrl).origin + '/'
+    const url = registryUrl(rawUrl)
 
     if (
       (await firstValueFrom(this.registries$)).some(r => sameUrl(r.url, url))

--- a/web/projects/marketplace/src/components/registry-select.component.ts
+++ b/web/projects/marketplace/src/components/registry-select.component.ts
@@ -224,9 +224,9 @@ export class MarketplaceRegistrySelectComponent {
         .openPrompt<string>({
           label: 'Add Custom Registry',
           data: {
-            message: 'A fully-qualified URL of the custom registry',
+            message: 'The domain or URL of the custom registry',
             label: 'URL',
-            placeholder: 'e.g. https://example.org',
+            placeholder: 'e.g. registry.example.com',
             buttonText: 'Save',
           },
         })

--- a/web/projects/shared/src/i18n/dictionaries/de.ts
+++ b/web/projects/shared/src/i18n/dictionaries/de.ts
@@ -157,7 +157,7 @@ export default {
   162: 'Register wird überprüft',
   163: 'Möchten Sie dieses Register wirklich löschen?',
   164: 'Benutzerdefiniertes Register hinzufügen',
-  165: 'Vollständige URL des benutzerdefinierten Registers',
+  165: 'Die Domain oder URL des benutzerdefinierten Registers',
   166: 'Muss eine gültige URL sein',
   167: 'installiert von',
   168: 'manuell installiert',

--- a/web/projects/shared/src/i18n/dictionaries/en.ts
+++ b/web/projects/shared/src/i18n/dictionaries/en.ts
@@ -156,7 +156,7 @@ export const ENGLISH: Record<string, number> = {
   'Validating registry': 162,
   'Are you sure you want to delete this registry?': 163,
   'Add Custom Registry': 164,
-  'A fully-qualified URL of the custom registry': 165,
+  'The domain or URL of the custom registry': 165,
   'Must be a valid URL': 166,
   'installed from': 167,
   'sideloaded': 168, // as in, the application was installed by sideloading

--- a/web/projects/shared/src/i18n/dictionaries/es.ts
+++ b/web/projects/shared/src/i18n/dictionaries/es.ts
@@ -157,7 +157,7 @@ export default {
   162: 'Validando registro',
   163: '¿Estás seguro de que deseas eliminar este registro?',
   164: 'Agregar registro personalizado',
-  165: 'Una URL completamente calificada del registro personalizado',
+  165: 'El dominio o la URL del registro personalizado',
   166: 'Debe ser una URL válida',
   167: 'instalado desde',
   168: 'instalado manualmente',

--- a/web/projects/shared/src/i18n/dictionaries/fr.ts
+++ b/web/projects/shared/src/i18n/dictionaries/fr.ts
@@ -157,7 +157,7 @@ export default {
   162: 'Validation de la bibliothèque',
   163: 'Voulez-vous vraiment supprimer cette bibliothèque ?',
   164: 'Ajouter une bibliothèque personnalisée',
-  165: 'Une URL complète de la bibliothèque personnalisée',
+  165: 'Le domaine ou l’URL de la bibliothèque personnalisée',
   166: 'Doit être une URL valide',
   167: 'installé depuis',
   168: 'installé manuellement',

--- a/web/projects/shared/src/i18n/dictionaries/pl.ts
+++ b/web/projects/shared/src/i18n/dictionaries/pl.ts
@@ -157,7 +157,7 @@ export default {
   162: 'Weryfikowanie katalogu',
   163: 'Czy na pewno chcesz usunąć ten katalog?',
   164: 'Dodaj niestandardowy katalog',
-  165: 'Pełny adres URL niestandardowego katalogu',
+  165: 'Domena lub adres URL niestandardowego katalogu',
   166: 'Musi być poprawnym adresem URL',
   167: 'zainstalowano z',
   168: 'zainstalowano ręcznie',

--- a/web/projects/shared/src/util/misc.util.ts
+++ b/web/projects/shared/src/util/misc.util.ts
@@ -54,6 +54,15 @@ export function toUrl(text: string | null | undefined): string {
   }
 }
 
+export function registryUrl(input: string): string {
+  const trimmed = input.trim()
+  const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)
+  // Domain-only input is allowed: default to https, but http for .onion hosts.
+  const url = new URL(hasScheme ? trimmed : `https://${trimmed}`)
+  if (!hasScheme && url.hostname.endsWith('.onion')) url.protocol = 'http:'
+  return url.origin + '/'
+}
+
 export type WithId<T> = T & { id: string }
 
 export type OptionalProperty<T, K extends keyof T> = Omit<T, K> &

--- a/web/projects/ui/src/app/routes/portal/components/interfaces/addresses/plugin/plugin.component.ts
+++ b/web/projects/ui/src/app/routes/portal/components/interfaces/addresses/plugin/plugin.component.ts
@@ -20,7 +20,7 @@ import { PluginItemComponent } from './item.component'
           <img [src]="pkgInfo.icon" alt="" />
         </span>
       }
-      {{ 'Plugin' | i18n }}: {{ pluginGroup().pluginName }}
+      {{ pluginGroup().pluginName }}
       @if (pluginGroup().tableAction; as action) {
         <button
           tuiButton

--- a/web/projects/ui/src/app/services/marketplace.service.ts
+++ b/web/projects/ui/src/app/services/marketplace.service.ts
@@ -7,7 +7,13 @@ import {
   StoreDataWithUrl,
   StoreIdentity,
 } from '@start9labs/marketplace'
-import { defaultRegistries, Exver, i18nPipe, sameUrl } from '@start9labs/shared'
+import {
+  defaultRegistries,
+  Exver,
+  i18nPipe,
+  registryUrl,
+  sameUrl,
+} from '@start9labs/shared'
 import { T } from '@start9labs/start-sdk'
 import { PatchDB } from 'patch-db-client'
 import {
@@ -272,7 +278,7 @@ export class MarketplaceService extends AbstractMarketplaceService {
   }
 
   async add(rawUrl: string): Promise<string> {
-    const url = new URL(rawUrl).origin + '/'
+    const url = registryUrl(rawUrl)
     const existing = await firstValueFrom(this.registries$)
 
     if (existing.some(r => sameUrl(r.url, url))) {


### PR DESCRIPTION
Two small, independent web changes.

## Add custom registries by domain

Custom registries can now be added by domain alone — no `http(s)://` required.

- New shared `registryUrl()` normalizer in `shared/util/misc.util.ts`, used by both the OS UI and brochure `add()` flows in place of the duplicated `new URL(rawUrl).origin + '/'`.
- When no scheme is given, default to **https**, except **`.onion`** hosts which default to **http**. An explicit `http://`/`https://` is respected. Input is trimmed and reduced to origin + `/`, and the helper stays idempotent for already-normalized URLs (the "save current registry" path).
- Updated the add-registry dialog copy (message + placeholder) and the registry-message string (id 165) across all five dictionaries.

## Remove "Plugin:" label

On the service-interface view, the plugin address-group header (`interfaces/addresses/plugin/plugin.component.ts`) now shows just the plugin name instead of `Plugin: <name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
