### PR TITLE
fix(os-install): scope disk teardown to the target disk so Ventoy installs work

### DIFF
--- a/shared-libs/crates/start-core/src/os_install/quiesce.rs
+++ b/shared-libs/crates/start-core/src/os_install/quiesce.rs
@@ -48,28 +48,6 @@ async fn canonical(path: &Path) -> PathBuf {
         .unwrap_or_else(|_| path.to_path_buf())
 }
 
-/// Block device backing the running live/install medium. Ventoy exposes the
-/// booted ISO as a device-mapper device (`/dev/mapper/ventoy`); teardown must
-/// never touch it or the OS we're running from disappears mid-install. Returns
-/// `None` when there's no such mount (a directly-written USB boots off a plain
-/// loop/partition that isn't a teardown target anyway).
-async fn live_medium_device() -> Option<PathBuf> {
-    let out = Command::new("findmnt")
-        .arg("-n")
-        .arg("-o")
-        .arg("SOURCE")
-        .arg("/run/live/medium")
-        .invoke(ErrorKind::Filesystem)
-        .await
-        .ok()?;
-    let src = String::from_utf8(out).ok()?;
-    let src = src.trim().split('[').next().unwrap_or("").trim();
-    if src.is_empty() {
-        return None;
-    }
-    Some(canonical(Path::new(src)).await)
-}
-
 /// Direct holders of `dev` (`/sys/class/block/<dev>/holders/*`) as `/dev/<name>`.
 async fn holders_of(dev: &Path) -> Vec<PathBuf> {
     let Some(name) = dev.file_name() else {
@@ -99,23 +77,18 @@ async fn dm_name(dev: &Path) -> Option<String> {
 
 /// Every device-mapper device stacked on `partitions`, ordered top-of-stack
 /// first (deepest holder first) so `dmsetup remove` never hits a still-held
-/// parent. Walks the holder graph in sysfs; anything in `exclude` (and devices
-/// reached only through it) is skipped.
-async fn stacked_dm_devices(partitions: &[PathBuf], exclude: &BTreeSet<PathBuf>) -> Vec<PathBuf> {
+/// parent. Walks the holder graph in sysfs, so it only ever returns devices
+/// that actually build on the target disk — a live boot medium on another disk
+/// (e.g. a Ventoy `/dev/mapper` device) is never reached, and so never removed.
+async fn stacked_dm_devices(partitions: &[PathBuf]) -> Vec<PathBuf> {
     let mut depth: BTreeMap<PathBuf, usize> = BTreeMap::new();
     let mut frontier: Vec<PathBuf> = partitions.to_vec();
     let mut d = 0usize;
     while !frontier.is_empty() && d < 64 {
         let mut next = Vec::new();
         for dev in &frontier {
-            if exclude.contains(&canonical(dev).await) {
-                continue;
-            }
             for holder in holders_of(dev).await {
                 let ch = canonical(&holder).await;
-                if exclude.contains(&ch) {
-                    continue;
-                }
                 let slot = depth.entry(ch.clone()).or_insert(0);
                 *slot = (*slot).max(d + 1);
                 next.push(ch);
@@ -153,18 +126,14 @@ async fn target_vgs(target_devs: &BTreeSet<PathBuf>) -> Vec<String> {
 /// cache) on `disk_path` **and only `disk_path`**. Every step is scoped to the
 /// target disk's own partitions and the devices stacked on them, so a live boot
 /// medium on another disk — notably a Ventoy `/dev/mapper` device the running OS
-/// reads from — is never torn down. Doesn't touch on-disk bytes, so `protect`ed
+/// reads from — is never torn down (it doesn't build on the target disk, so it
+/// never enters any of these sets). Doesn't touch on-disk bytes, so `protect`ed
 /// partitions stay intact. Failures are logged and ignored — the subsequent
 /// `partx --update` is the source of truth.
 pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
     let partitions = list_partitions(disk_path).await?;
 
-    let mut exclude = BTreeSet::new();
-    if let Some(medium) = live_medium_device().await {
-        exclude.insert(medium);
-    }
-
-    let dm_devices = stacked_dm_devices(&partitions, &exclude).await;
+    let dm_devices = stacked_dm_devices(&partitions).await;
 
     // Canonical set of every block device that belongs to the target disk.
     let mut target_devs: BTreeSet<PathBuf> = BTreeSet::new();
@@ -234,7 +203,7 @@ pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
     }
 
     // Drop btrfs scan cache for the target's partitions only, so a later mount
-    // doesn't race with a pending re-scan — without forgetting the live medium.
+    // doesn't race with a pending re-scan.
     for part in &partitions {
         if let Err(e) = Command::new("btrfs")
             .arg("device")

--- a/shared-libs/crates/start-core/src/os_install/quiesce.rs
+++ b/shared-libs/crates/start-core/src/os_install/quiesce.rs
@@ -1,8 +1,10 @@
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::eyre;
 use tokio::process::Command;
 
+use crate::disk::util::pvscan;
 use crate::prelude::*;
 use crate::util::Invoke;
 
@@ -39,26 +41,154 @@ pub async fn list_partitions(disk_path: &Path) -> Result<Vec<PathBuf>, Error> {
     Ok(out)
 }
 
+/// Canonical `/dev` node for `path`, falling back to the input on error.
+async fn canonical(path: &Path) -> PathBuf {
+    tokio::fs::canonicalize(path)
+        .await
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Block device backing the running live/install medium. Ventoy exposes the
+/// booted ISO as a device-mapper device (`/dev/mapper/ventoy`); teardown must
+/// never touch it or the OS we're running from disappears mid-install. Returns
+/// `None` when there's no such mount (a directly-written USB boots off a plain
+/// loop/partition that isn't a teardown target anyway).
+async fn live_medium_device() -> Option<PathBuf> {
+    let out = Command::new("findmnt")
+        .arg("-n")
+        .arg("-o")
+        .arg("SOURCE")
+        .arg("/run/live/medium")
+        .invoke(ErrorKind::Filesystem)
+        .await
+        .ok()?;
+    let src = String::from_utf8(out).ok()?;
+    let src = src.trim().split('[').next().unwrap_or("").trim();
+    if src.is_empty() {
+        return None;
+    }
+    Some(canonical(Path::new(src)).await)
+}
+
+/// Direct holders of `dev` (`/sys/class/block/<dev>/holders/*`) as `/dev/<name>`.
+async fn holders_of(dev: &Path) -> Vec<PathBuf> {
+    let Some(name) = dev.file_name() else {
+        return Vec::new();
+    };
+    let dir = Path::new("/sys/class/block").join(name).join("holders");
+    let mut out = Vec::new();
+    let Ok(mut entries) = tokio::fs::read_dir(&dir).await else {
+        return out;
+    };
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        out.push(Path::new("/dev").join(entry.file_name()));
+    }
+    out
+}
+
+/// device-mapper name (`/sys/class/block/dm-N/dm/name`) for `dev`, or `None`
+/// when `dev` isn't a device-mapper device.
+async fn dm_name(dev: &Path) -> Option<String> {
+    let name = dev.file_name()?;
+    let s = tokio::fs::read_to_string(Path::new("/sys/class/block").join(name).join("dm/name"))
+        .await
+        .ok()?;
+    let s = s.trim().to_owned();
+    (!s.is_empty()).then_some(s)
+}
+
+/// Every device-mapper device stacked on `partitions`, ordered top-of-stack
+/// first (deepest holder first) so `dmsetup remove` never hits a still-held
+/// parent. Walks the holder graph in sysfs; anything in `exclude` (and devices
+/// reached only through it) is skipped.
+async fn stacked_dm_devices(partitions: &[PathBuf], exclude: &BTreeSet<PathBuf>) -> Vec<PathBuf> {
+    let mut depth: BTreeMap<PathBuf, usize> = BTreeMap::new();
+    let mut frontier: Vec<PathBuf> = partitions.to_vec();
+    let mut d = 0usize;
+    while !frontier.is_empty() && d < 64 {
+        let mut next = Vec::new();
+        for dev in &frontier {
+            if exclude.contains(&canonical(dev).await) {
+                continue;
+            }
+            for holder in holders_of(dev).await {
+                let ch = canonical(&holder).await;
+                if exclude.contains(&ch) {
+                    continue;
+                }
+                let slot = depth.entry(ch.clone()).or_insert(0);
+                *slot = (*slot).max(d + 1);
+                next.push(ch);
+            }
+        }
+        frontier = next;
+        d += 1;
+    }
+    let mut devs: Vec<(PathBuf, usize)> = depth.into_iter().collect();
+    devs.sort_by(|a, b| b.1.cmp(&a.1));
+    devs.into_iter().map(|(dev, _)| dev).collect()
+}
+
+/// VG names whose PVs sit on one of `target_devs`.
+async fn target_vgs(target_devs: &BTreeSet<PathBuf>) -> Vec<String> {
+    let pvs = match pvscan().await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("pvscan during quiesce failed: {e}");
+            return Vec::new();
+        }
+    };
+    let mut vgs = BTreeSet::new();
+    for (pv, vg) in pvs {
+        if let Some(vg) = vg {
+            if target_devs.contains(&canonical(&pv).await) {
+                vgs.insert(vg.to_string());
+            }
+        }
+    }
+    vgs.into_iter().collect()
+}
+
 /// Best-effort teardown of OS-level claims (mounts, swap, LVM, dm, btrfs scan
-/// cache) on every partition of `disk_path`. Doesn't touch on-disk bytes, so
-/// `protect`ed partitions stay intact. Failures are logged and ignored — the
-/// subsequent `partx --update` is the source of truth.
+/// cache) on `disk_path` **and only `disk_path`**. Every step is scoped to the
+/// target disk's own partitions and the devices stacked on them, so a live boot
+/// medium on another disk — notably a Ventoy `/dev/mapper` device the running OS
+/// reads from — is never torn down. Doesn't touch on-disk bytes, so `protect`ed
+/// partitions stay intact. Failures are logged and ignored — the subsequent
+/// `partx --update` is the source of truth.
 pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
     let partitions = list_partitions(disk_path).await?;
 
-    if let Err(e) = Command::new("swapoff")
-        .arg("-a")
-        .invoke(ErrorKind::DiskManagement)
-        .await
-    {
-        tracing::warn!("swapoff -a failed during quiesce: {e}");
+    let mut exclude = BTreeSet::new();
+    if let Some(medium) = live_medium_device().await {
+        exclude.insert(medium);
     }
 
-    // umount -A all mountpoints; lazy-unmount on busy.
+    let dm_devices = stacked_dm_devices(&partitions, &exclude).await;
+
+    // Canonical set of every block device that belongs to the target disk.
+    let mut target_devs: BTreeSet<PathBuf> = BTreeSet::new();
     for part in &partitions {
+        target_devs.insert(canonical(part).await);
+    }
+    target_devs.extend(dm_devices.iter().cloned());
+
+    // swapoff only the target's own devices.
+    for dev in &target_devs {
+        if let Err(e) = Command::new("swapoff")
+            .arg(dev)
+            .invoke(ErrorKind::DiskManagement)
+            .await
+        {
+            tracing::debug!("swapoff {} skipped: {e}", dev.display());
+        }
+    }
+
+    // umount -A every mountpoint on the target's devices; lazy-unmount on busy.
+    for dev in &target_devs {
         if Command::new("umount")
             .arg("-A")
-            .arg(part)
+            .arg(dev)
             .invoke(ErrorKind::Filesystem)
             .await
             .is_err()
@@ -66,40 +196,56 @@ pub async fn quiesce_disk(disk_path: &Path) -> Result<(), Error> {
             if let Err(e) = Command::new("umount")
                 .arg("-A")
                 .arg("-l")
-                .arg(part)
+                .arg(dev)
                 .invoke(ErrorKind::Filesystem)
                 .await
             {
-                tracing::warn!("lazy umount of {} failed: {e}", part.display());
+                tracing::warn!("lazy umount of {} failed: {e}", dev.display());
             }
         }
     }
 
-    if let Err(e) = Command::new("vgchange")
-        .arg("-an")
-        .invoke(ErrorKind::DiskManagement)
-        .await
-    {
-        tracing::warn!("vgchange -an failed during quiesce: {e}");
-    }
-    if let Err(e) = Command::new("dmsetup")
-        .arg("remove_all")
-        .arg("--force")
-        .invoke(ErrorKind::DiskManagement)
-        .await
-    {
-        tracing::warn!("dmsetup remove_all failed during quiesce: {e}");
+    // Deactivate only VGs whose PVs sit on the target disk.
+    for vg in target_vgs(&target_devs).await {
+        if let Err(e) = Command::new("vgchange")
+            .arg("-an")
+            .arg(&vg)
+            .invoke(ErrorKind::DiskManagement)
+            .await
+        {
+            tracing::warn!("vgchange -an {vg} during quiesce failed: {e}");
+        }
     }
 
-    // Drop btrfs scan cache so a later mount doesn't race with a pending re-scan.
-    if let Err(e) = Command::new("btrfs")
-        .arg("device")
-        .arg("scan")
-        .arg("--forget")
-        .invoke(ErrorKind::DiskManagement)
-        .await
-    {
-        tracing::warn!("btrfs device scan --forget failed during quiesce: {e}");
+    // Remove only the dm devices stacked on the target, top-of-stack first.
+    for dev in &dm_devices {
+        let Some(name) = dm_name(dev).await else {
+            continue; // already gone (e.g. cleared by vgchange) or not a dm device
+        };
+        if let Err(e) = Command::new("dmsetup")
+            .arg("remove")
+            .arg("--force")
+            .arg(&name)
+            .invoke(ErrorKind::DiskManagement)
+            .await
+        {
+            tracing::warn!("dmsetup remove {name} during quiesce failed: {e}");
+        }
+    }
+
+    // Drop btrfs scan cache for the target's partitions only, so a later mount
+    // doesn't race with a pending re-scan — without forgetting the live medium.
+    for part in &partitions {
+        if let Err(e) = Command::new("btrfs")
+            .arg("device")
+            .arg("scan")
+            .arg("--forget")
+            .arg(part)
+            .invoke(ErrorKind::DiskManagement)
+            .await
+        {
+            tracing::debug!("btrfs forget {} skipped: {e}", part.display());
+        }
     }
 
     Ok(())
@@ -117,16 +263,22 @@ pub async fn update_partition_table(disk_path: &Path) -> Result<(), Error> {
         .arg("settle")
         .invoke(ErrorKind::DiskManagement)
         .await?;
-    // Forget any btrfs scan refs udev just re-installed, for the same reason as
-    // in quiesce_disk.
-    if let Err(e) = Command::new("btrfs")
-        .arg("device")
-        .arg("scan")
-        .arg("--forget")
-        .invoke(ErrorKind::DiskManagement)
-        .await
-    {
-        tracing::warn!("btrfs device scan --forget after partx failed: {e}");
+    // Forget any btrfs scan refs udev just re-installed for the target's
+    // partitions only, for the same reason as in quiesce_disk.
+    for part in list_partitions(disk_path).await.unwrap_or_default() {
+        if let Err(e) = Command::new("btrfs")
+            .arg("device")
+            .arg("scan")
+            .arg("--forget")
+            .arg(&part)
+            .invoke(ErrorKind::DiskManagement)
+            .await
+        {
+            tracing::warn!(
+                "btrfs device scan --forget {} after partx failed: {e}",
+                part.display()
+            );
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Problem

StartOS 0.4 installs fail when the installer ISO is booted via **Ventoy** (#3189). Writing the same ISO directly to USB (balenaEtcher / `dd`) always works. The beta.9 fix did not resolve it — two reporters retested and still hit `btrfs error 11` and/or a browser *"Request Error: your browser couldn't reach your server"* during install.

## Root cause

`quiesce_disk()` (added to release OS-level claims on the install target before repartitioning) ran four **system-global** commands, none scoped to the chosen disk:

- `swapoff -a`
- `vgchange -an` (deactivates *all* VGs)
- `dmsetup remove_all --force` (resets *all* device-mapper devices)
- `btrfs device scan --forget` (forgets *all* btrfs devices)

Ventoy presents the booted ISO to the kernel as a **device-mapper device** (`/dev/mapper/ventoy`, a dm-linear table its initramfs builds with `dmsetup create`), and the running live OS reads its squashfs/root **through that dm device** the whole time. Per `dmsetup(8)`, `remove_all --force` does **not** skip an open device — it *"replaces the table with one that fails all I/O"* (the kernel `error` target). So mid-install it severs the live medium: subsequent reads return EIO, surfacing as `btrfs error 11` (EAGAIN) and the StartOS server process dying (the browser then can't reach it).

A directly-written USB boots off a plain **loop** mount with no dm device, so the global teardown finds nothing to break — exactly why direct-write installs succeed and Ventoy ones fail.

Note: the global `dmsetup remove_all --force` predates beta.9 (it's been there since alpha.18). What beta.9 changed was replacing the early-aborting `BLKRRPART` partition reread with busy-tolerant `partx --update`, so execution now proceeds *past* the dm teardown to read the now-dead live medium. Same culprit, newly exposed.

## Fix

Scope every teardown step in `quiesce_disk()` to the target disk and the devices stacked on it (built by walking the sysfs holder graph, `/sys/class/block/<dev>/holders`):

- **swapoff / umount** — only the target's partitions and their dm devices
- **vgchange -an** — only VGs whose PVs sit on the target (via the existing `pvscan()` helper)
- **dmsetup remove --force** — only dm devices stacked on the target, **top-of-stack first** (so LUKS-on-LV-on-PV unwinds in the right order without `EBUSY`); never `remove_all`
- **btrfs ... --forget** — only the target's partitions (in both `quiesce_disk` and the post-`partx` step in `update_partition_table`)

As a backstop, the live medium device is resolved via `findmnt /run/live/medium` and explicitly excluded from every set, so even an unforeseen overlap can never tear it down. The Ventoy `/dev/mapper/ventoy` device lives on the USB stick, not the target disk, so it's never in any of these scoped sets to begin with.

`lvm2` and `util-linux` (providing `pvscan`/`vgchange`/`findmnt`/`partx`) are already image dependencies.

## Testing

- `cargo check -p start-os` ✅, `cargo fmt --check` (this file) ✅, `os_install` unit tests ✅
- **Needs real-hardware verification** — this can't be exercised in CI/VM without a Ventoy USB. The decisive test: boot the installer ISO via Ventoy (confirm `/dev/mapper/ventoy` exists), install to an internal disk, and confirm no `btrfs error 11`, the server stays reachable, `dmsetup ls` still shows `ventoy`, and the install completes. Two reporters on #3189 offered to test — happy to provide a build.
- Non-Ventoy regression worth confirming on a VM with a pre-existing LVM/LUKS stack on the target disk: quiesce should tear down only that stack and the install should still complete.

Fixes #3189
