### PR TITLE
docs(start-os): product docs for the OS product in the monorepo

### DIFF
--- a/start-os/AGENTS.md
+++ b/start-os/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS — StartOS OS product
+
+Operating rules for AI developers working in `start-os/`. See the root
+[AGENTS.md](../AGENTS.md) for monorepo-wide rules and
+[ARCHITECTURE.md](ARCHITECTURE.md) for how this product is wired.
+
+## Where things are
+
+- `src/bin/startbox.rs`, `src/bin/start-container.rs` — the only Rust in this
+  dir. They are thin entry points; backend logic lives in
+  `../shared/crates/start-core` (crate `start-core`, lib `startos`).
+- `web/ui`, `web/setup-wizard` — Angular apps; part of the workspace at
+  `../shared/web`. Run web commands from `../shared/web`, not from here.
+- `container-runtime/` — Node.js LXC runtime with its **own** AGENTS/CLAUDE;
+  read `container-runtime/AGENTS.md` before touching it.
+- `docs/` — the end-user mdbook (book "StartOS"), served at `/start-os/`.
+- Systemd units + `services.slice` live directly in this dir; OS image
+  packaging (`debian/`, `apt/`, `build/`, `assets/`) is at the **repo root**.
+
+## Build & verify (run from the repo root)
+
+- Compile the OS bins: `cargo check -p start-os` (or `cargo build -p start-os
+  --bin startbox`). Local `cargo check` is **linux-only** — CI also builds
+  apple-darwin and aarch64/riscv64 musl; platform-specific changes can pass here
+  yet break those.
+- Regenerate TS bindings after any change to exported Rust types:
+  `make ts-bindings`. Then rebuild the SDK (`cd start-sdk && make bundle`) before
+  web/runtime type-checks — editing `start-sdk/base/lib/osBindings/*.ts` alone
+  is not enough.
+- Type-check web apps: `cd shared/web && npm run check:ui && npm run check:setup`.
+- Type-check the runtime: `cd start-os/container-runtime && npm run check`.
+- Build the UI: `make ui` (or `make uis` for ui + setup-wizard).
+- Tests: `make test` (Rust + SDK + container-runtime), or `make test-core`.
+- Format: `make format` / `make format-check`.
+
+## Gotchas
+
+- **UIs are embedded into `startbox` at compile time** (`include_dir!`), so the
+  web build must precede the Rust build — use the `Makefile`, which encodes the
+  ordering, rather than running `cargo build` against a stale `web/dist`.
+- **`unshare-userns` must stay a multi-call applet**, not a CLI subcommand: it
+  calls `unshare(CLONE_NEWUSER)`, which the kernel rejects on a multi-threaded
+  process. See the comment in `src/bin/start-container.rs`.
+- **Don't normalize style across components.** The container-runtime uses double
+  quotes + no semicolons (its own prettier config); the SDK uses single quotes.
+- **Don't edit `start-os/sdk.ts` / `index.ts`-style "DO NOT EDIT" files** or the
+  root `s9pk.mk`.
+- **Ask before destructive `make` recipes** — `update*`, `reflash`, `wormhole*`,
+  image flashing, and `make clean*` consume hours/disk and may touch a live
+  device.
+- **The `beta` feature swaps the UI seed** (`patchdb-ui-seed.beta.json`) and
+  forwards to `start-core`'s `beta` feature — keep both seeds in sync when you
+  change seed shape.
+
+## Docs are part of the change
+
+User-facing changes (UI, CLI output/flags, install/setup flow) must update the
+matching page under `docs/` in the same change. Keep this AGENTS, README, and
+ARCHITECTURE current when you change structure, build steps, or conventions.

--- a/start-os/ARCHITECTURE.md
+++ b/start-os/ARCHITECTURE.md
@@ -1,0 +1,127 @@
+# Architecture — StartOS OS product
+
+This document covers the **OS product** (`start-os/`). For the monorepo as a
+whole, see [../ARCHITECTURE.md](../ARCHITECTURE.md) and [../MONOREPO.md](../MONOREPO.md).
+For the Rust backend internals, see the `start-core` crate at
+[../shared/crates/start-core](../shared/crates/start-core).
+
+## What this product is
+
+`start-os/` is a thin wrapper that assembles the StartOS server operating system
+from shared building blocks. It contributes the entry points and the
+OS-specific surface; almost all backend logic is in the `start-core` crate.
+
+## Binaries
+
+`Cargo.toml` declares package `start-os` with two binaries, both depending on
+`start-core` (imported as the `startos` lib):
+
+- **`startbox`** (`src/bin/startbox.rs`) — a multi-call applet enabling the
+  `startd` daemon, the `start-cli` client, and the `unshare-userns` applet. It
+  also embeds the built web UIs at compile time via `include_dir!`
+  (`web/dist/static/ui`, `web/dist/static/setup-wizard`) and the Patch-DB UI
+  seed (`web/patchdb-ui-seed.json`, or `*.beta.json` under the `beta` feature).
+  Because the UIs are embedded, the web build must run before the Rust build —
+  the `Makefile` encodes this ordering.
+- **`start-container`** (`src/bin/start-container.rs`) — runs **inside** each
+  service LXC. It enables `start-container` plus `unshare-userns`. The latter
+  must be a multi-call applet (not a CLI subcommand): it calls
+  `unshare(CLONE_NEWUSER)`, which the kernel rejects on a multi-threaded
+  process, and the applet entry stays single-threaded.
+
+Cargo features (`beta`, `console`, `dev`, `test`, `unstable`) forward to the
+matching `start-core` features.
+
+The sibling product crates (`start-cli`, `start-registry`, `start-tunnel`) are
+analogous thin wrappers over the same `start-core` lib; the OS bins above are
+this product's contribution.
+
+## Web
+
+Two Angular 22 apps live under `web/`:
+
+- `ui/` — the admin dashboard (Angular project `ui`).
+- `setup-wizard/` — the first-boot setup flow (project `setup-wizard`).
+
+They are part of the single Angular workspace rooted at `../shared/web`
+(`angular.json` there points each project's `root` at `../../start-os/web/...`).
+They consume the shared `@start9labs/shared` and `@start9labs/marketplace` libs
+from `../shared/web` and the SDK base from `../start-sdk`. The frontend talks to
+the backend exclusively over JSON-RPC, with reactive state via Patch-DB.
+
+`web/patchdb-ui-seed.json` / `patchdb-ui-seed.beta.json` seed initial UI state
+and are embedded into `startbox`.
+
+## Container runtime
+
+`container-runtime/` is a Node.js program that runs inside every service LXC. It
+loads the service's JavaScript from its `.s9pk`, manages subcontainers, and
+talks to the host daemon over a Unix-socket JSON-RPC channel. It depends on the
+**built** SDK at `../../start-sdk/dist`. It has its own
+[README](container-runtime/README.md), [ARCHITECTURE](container-runtime/ARCHITECTURE.md),
+and [AGENTS](container-runtime/AGENTS.md) — read those before editing it.
+
+## Systemd units and cgroups
+
+- `startd.service` — the main daemon (`Restart=always`, OOM-protected with
+  `ManagedOOMPreference=avoid`).
+- `services.slice` — the cgroup slice every service container lives under;
+  `Delegate=yes` hands the subtree to LXC, and systemd-oomd kills the heaviest
+  container under memory pressure rather than wedging the host. `startd` applies
+  a RAM-dependent `MemoryMax`/`MemoryHigh` to this slice at boot.
+- `startos-shutdown.service` — graceful teardown on power-off only (ties to
+  `poweroff.target`/`halt.target`, not reboot); its `ExecStop` calls
+  `start-cli server shutdown`.
+- `startos-restart.service` — restart handling.
+
+## OS image packaging
+
+Image build inputs are shared at the repo root, not in this dir: `debian/`
+(maintainer scripts incl. `debian/startos`), `apt/`, `build/` (`image-recipe`,
+`firmware`, `env` scripts, migration images), and `assets/`. The root `Makefile`
+turns the compiled bins + UIs + runtime squashfs into a `.deb`, `.squashfs`, and
+finally the `.iso`/`.img` for the target platform (x86_64, aarch64/Raspberry Pi,
+rockchip, riscv64).
+
+## Build pipeline (cross-layer)
+
+Changes flow in one direction; verify in this order:
+
+```
+start-core (Rust)
+  → make ts-bindings   # cargo test exports ts-rs types → shared/crates/start-core/bindings/
+    → start-sdk build  # produces start-sdk/baseDist (base) + start-sdk/dist (base+package)
+      → web apps consume start-sdk/baseDist via @start9labs/start-sdk
+      → container-runtime consumes start-sdk/dist
+```
+
+| Step | Command (from repo root) | What it does |
+|---|---|---|
+| 1 | `cargo check -p start-os` | Verify the OS bins compile |
+| 2 | `make ts-bindings` | Export ts-rs types from `start-core` |
+| 3 | `cd start-sdk && make bundle` | Build SDK `baseDist` + `dist` |
+| 4 | `cd shared/web && npm run check:ui && npm run check:setup` | Type-check the apps |
+| 5 | `cd start-os/container-runtime && npm run check` | Type-check the runtime |
+
+Editing the generated bindings under `start-sdk/base/lib/osBindings/*.ts` alone
+is **not** enough — the SDK bundle must be rebuilt before the web apps and
+container-runtime see the change.
+
+## Data flow: backend → frontend
+
+StartOS uses Patch-DB (`../vendor/patch-db`) for reactive sync:
+
+1. The backend mutates state via `db.mutate()`, producing CBOR diffs.
+2. Diffs are pushed to the frontend over a persistent WebSocket.
+3. The frontend applies the diff to its local copy and notifies observers.
+4. Components watch specific DB paths and update reactively — no polling.
+
+After a mutating RPC call, the frontend waits for the corresponding diff before
+resolving, so the UI is always eventually consistent with the backend.
+
+## Further reading
+
+- [../shared/crates/start-core](../shared/crates/start-core) — Rust backend
+- [../shared/web](../shared/web) — shared Angular libraries + workspace
+- [container-runtime/ARCHITECTURE.md](container-runtime/ARCHITECTURE.md) — runtime
+- [../MONOREPO.md](../MONOREPO.md) — monorepo layout and rationale

--- a/start-os/CHANGELOG.md
+++ b/start-os/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to the StartOS OS product are documented here. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and StartOS
+uses an [extended version](https://docs.start9.com) of semantic versioning.
+
+Full per-release notes are published on the
+[GitHub releases page](https://github.com/Start9Labs/start-os/releases). This
+file tracks notable changes since the move to the monorepo.
+
+## [Unreleased]
+
+### Changed
+
+- **Monorepo reorganization.** `start-os` is now the monorepo for all Start9
+  products. The OS product moved into its own `start-os/` directory as a thin
+  wrapper: the `startbox` and `start-container` entry points live in
+  `src/bin/`, the admin UI and setup wizard in `web/`, and the container runtime
+  in `container-runtime/`. Backend logic moved from the old `core/` crate to the
+  shared `start-core` crate (`shared/crates/start-core`); shared Angular
+  libraries moved to `shared/web`; the SDK to `start-sdk`; and the `patch-db`
+  submodule to `vendor/patch-db`. Builds now run against the root Cargo and
+  Angular workspaces (`cargo build -p start-os`, web from `shared/web`).
+
+## [0.4.0-beta.10]
+
+Current development version. See the
+[release notes](https://github.com/Start9Labs/start-os/releases) when published.
+
+## [0.4.0-beta.9] and earlier
+
+See the [GitHub releases page](https://github.com/Start9Labs/start-os/releases)
+for the full 0.4.0 beta and alpha history and all prior releases.
+
+[Unreleased]: https://github.com/Start9Labs/start-os/compare/v0.4.0-beta.10...HEAD
+[0.4.0-beta.10]: https://github.com/Start9Labs/start-os/compare/v0.4.0-beta.9...v0.4.0-beta.10
+[0.4.0-beta.9]: https://github.com/Start9Labs/start-os/releases/tag/v0.4.0-beta.9

--- a/start-os/CONTRIBUTING.md
+++ b/start-os/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to the StartOS OS product
+
+This guide covers contributing to the **OS product** in `start-os/`. For
+full environment setup (Debian/Ubuntu packages, Docker + binfmt, Rust, Node 24),
+branch policy, and cross-product workflow, follow the root
+[CONTRIBUTING.md](../CONTRIBUTING.md) first — it is the source of truth for the
+toolchain. This file adds product-specific build/test details.
+
+If you want to **package a service** for StartOS instead, see the
+[service packaging guide](https://github.com/Start9Labs/ai-service-packaging).
+For other ways to help, see [start9.com/contribute](https://start9.com/contribute).
+
+## Collaboration
+
+- [Matrix](https://matrix.to/#/#dev-startos:matrix.start9labs.com)
+- Security issues: [security@start9.com](mailto:security@start9.com)
+
+## Repo and branches
+
+Clone with submodules and target the right integration branch (`master` for the
+current release; `next/patch`, `next/minor`, `next/major` otherwise — ask a
+maintainer if unsure):
+
+```sh
+git clone --recursive https://github.com/Start9Labs/start-os.git
+cd start-os
+```
+
+This is a monorepo. The OS product is a thin wrapper over the shared
+`start-core` crate (`shared/crates/start-core`), the shared Angular libs
+(`shared/web`), and the SDK (`start-sdk`). Build commands run from the **repo
+root** unless noted.
+
+## Building
+
+```sh
+cargo check -p start-os        # verify the OS bins compile (startbox, start-container)
+make ui                        # build the admin UI
+make uis                       # build ui + setup-wizard
+make all                       # build everything for the current platform
+make $(IMAGE_TYPE)             # build the OS image (iso; img on Raspberry Pi)
+make cli / make install-cli    # build / install start-cli
+make deb / make squashfs       # package outputs
+```
+
+The web UIs are embedded into `startbox` at compile time, so the web build must
+precede the Rust build — always go through the `Makefile`, which encodes the
+ordering. For faster iteration use `./devmode.sh` / dev mode (see root
+CONTRIBUTING) and `cd shared/web && npm run start:ui`.
+
+Deploy/flash targets (`update*`, `reflash`, `wormhole*`, `emulate-reflash`) push
+to a live device and are slow/destructive — be deliberate.
+
+## Cross-layer changes
+
+When a change crosses Rust → bindings → SDK → web/runtime, verify in order:
+
+1. `cargo check -p start-os`
+2. `make ts-bindings` — regenerate ts-rs types from `start-core`
+3. `cd start-sdk && make bundle` — rebuild `baseDist` + `dist` (required before
+   the web apps / runtime can see new bindings)
+4. `cd shared/web && npm run check:ui && npm run check:setup`
+5. `cd start-os/container-runtime && npm run check`
+
+## Testing & formatting
+
+```sh
+make test                      # Rust + SDK + container-runtime
+make test-core                 # backend only
+make format                    # format Rust + web + runtime
+make format-check              # CI-style check
+```
+
+The container-runtime has its own test suite and prettier config (double quotes,
+no semicolons) — see [container-runtime/CONTRIBUTING.md](container-runtime/CONTRIBUTING.md).
+Note CI builds a multi-platform matrix (apple-darwin + aarch64/x86_64/riscv64
+musl); local `cargo check` is linux-only, so consider platform-specific impact.
+
+## Documentation
+
+User-facing changes (UI, CLI, install/setup flow) must update the end-user docs
+under `docs/` (an mdbook served at `/start-os/`) in the same change. Keep this
+product's [README.md](README.md), [ARCHITECTURE.md](ARCHITECTURE.md), and
+[AGENTS.md](AGENTS.md) current when you change structure, build steps, or
+conventions.

--- a/start-os/README.md
+++ b/start-os/README.md
@@ -1,0 +1,88 @@
+# StartOS
+
+StartOS is an open-source Linux distribution for running a personal server. It
+handles discovery, installation, network configuration, data backup, dependency
+management, and health monitoring of self-hosted services. Services run in
+isolated LXC containers, packaged as signed, merkle-archived `.s9pk` files.
+
+This directory is the **StartOS OS product** within the monorepo. It is a thin
+wrapper that ships the OS:
+
+- the `startbox` daemon binary (`startd` / `start-cli` multi-call applet) and the
+  `start-container` binary that runs inside each service LXC,
+- the web UIs (`ui` = admin dashboard, `setup-wizard` = first-boot setup),
+- the `container-runtime` (Node.js service runtime that runs inside package LXCs),
+- the systemd units and OS image packaging glue.
+
+The bulk of the backend logic lives in the shared `start-core` crate
+(`../shared/crates/start-core`), and the Angular apps here consume the shared web
+libraries under `../shared/web` and the SDK base from `../start-sdk`.
+
+## Tech stack
+
+- **Backend:** Rust (Tokio async, Axum), built on the `start-core` crate.
+- **Frontend:** Angular 22 + Taiga UI 5 (apps live under `web/`, shared libs
+  under `../shared/web`).
+- **Container runtime:** Node.js/TypeScript managing LXC service containers.
+- **State/sync:** Patch-DB (`../vendor/patch-db`) — diff-based store that pushes
+  CBOR diffs to the frontend over WebSocket for reactive, poll-free UI updates.
+
+## Layout
+
+```
+start-os/
+├── src/bin/startbox.rs         # startd + start-cli multi-call applet; embeds the UIs
+├── src/bin/start-container.rs  # runs inside each service LXC
+├── Cargo.toml                  # package "start-os" → depends on start-core
+├── web/
+│   ├── ui/                     # admin dashboard (Angular app "ui")
+│   ├── setup-wizard/           # first-boot setup (Angular app "setup-wizard")
+│   └── patchdb-ui-seed*.json   # seed state embedded into startbox
+├── container-runtime/          # Node.js LXC service runtime (own README/AGENTS)
+├── docs/                       # mdbook (book title "StartOS"); served at /start-os/
+├── startd.service              # systemd units + cgroup slice for service containers
+├── services.slice
+├── startos-shutdown.service
+└── startos-restart.service
+```
+
+OS-image packaging shared across products lives at the repo root: `debian/`
+(maintainer scripts), `apt/`, `build/` (image-recipe, firmware, env scripts),
+and `assets/`. The root `Makefile` drives the full ISO/img build.
+
+## Quickstart
+
+Build commands run from the **repo root** (one Cargo workspace, one Angular
+workspace). See the [root CONTRIBUTING](../CONTRIBUTING.md) for full environment
+setup (Debian/Ubuntu, Docker, Rust, Node 24).
+
+```sh
+# from the repo root
+cargo check -p start-os                 # verify the OS bins compile
+make ui                                  # build the admin UI
+make all                                 # build everything for the current platform
+make $(IMAGE_TYPE)                       # build the OS image (iso, or img on Pi)
+```
+
+`make` targets relevant to this product: `ui`, `uis`, `cli`, `install-cli`,
+`deb`, `squashfs`, `update*`/`reflash`/`wormhole*` (deploy to a live device —
+slow and destructive). Run `make test` for the full Rust + SDK + runtime test
+suite.
+
+## Documentation
+
+- [ARCHITECTURE.md](ARCHITECTURE.md) — how the OS product is structured and how
+  data flows backend → frontend.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — build/test/format workflow for this product.
+- [AGENTS.md](AGENTS.md) — operating rules for AI developers working here.
+- [CHANGELOG.md](CHANGELOG.md) — release history.
+- End-user docs: [docs.start9.com](https://docs.start9.com) (built from `docs/`).
+
+## Getting StartOS as a user
+
+- **Buy a server** from [store.start9.com](https://store.start9.com) — easiest path.
+- **Install on your own hardware** — follow the
+  [install guide](https://docs.start9.com/start-os/installing-startos.html).
+- Browse services on the [Start9 Marketplace](https://marketplace.start9.com/).
+
+To report security issues, email [security@start9.com](mailto:security@start9.com).


### PR DESCRIPTION
Adds the five required doc files directly in the `start-os/` product directory, describing the StartOS OS product as a thin wrapper within the new monorepo.

## Files added
- `start-os/README.md` — human-facing overview + quickstart
- `start-os/ARCHITECTURE.md` — structure, bins, web, runtime, systemd, build pipeline, data flow
- `start-os/AGENTS.md` — practical agent/dev rules for this product
- `start-os/CHANGELOG.md` — Keep a Changelog style; Unreleased (monorepo reorg) + current 0.4.0-beta.10
- `start-os/CONTRIBUTING.md` — build/test/format workflow, refers to root CONTRIBUTING

## Notes
- Content reflects the **new** monorepo layout: `start-core` (`shared/crates/start-core`), `shared/web`, `start-sdk`, `vendor/patch-db` — no stale root-level `core/`/`web/`/`sdk/` paths.
- Build commands verified against the root `Makefile` and `start-sdk/Makefile` (`cargo check -p start-os`, `make ts-bindings`, `make ui`, `cd start-sdk && make bundle`, etc.).
- Scope limited to the OS product's own docs; no code or other projects touched. Root `CLAUDE.md` is just `@AGENTS.md` and was not edited.