### PR TITLE
fix(docs): repair theme symlinks + de-nest backup tabs so the docs site builds clean

### DIFF
--- a/projects/start-os/docs/theme
+++ b/projects/start-os/docs/theme
@@ -1,1 +1,1 @@
-../../docs/theme
+../../start-docs/theme

--- a/projects/start-sdk/docs/theme
+++ b/projects/start-sdk/docs/theme
@@ -1,1 +1,1 @@
-../../docs/theme
+../../start-docs/theme

--- a/projects/start-tunnel/docs/theme
+++ b/projects/start-tunnel/docs/theme
@@ -1,1 +1,1 @@
-../../docs/theme
+../../start-docs/theme


### PR DESCRIPTION
Two fixes so the docs site builds and deploys cleanly after the monorepo reorg (#3352). The first is the actual deploy blocker; the second is a long-standing non-fatal warning surfaced while verifying.

## 1. Theme symlinks — the deploy blocker

The reorg consolidated the shared mdBook theme into `projects/start-docs/theme/`, but left the `theme` symlinks in three book dirs pointing at the pre-reorg `../../docs/theme`, which now resolves to a nonexistent `projects/docs/theme`:

- `projects/start-os/docs/theme`
- `projects/start-tunnel/docs/theme`
- `projects/start-sdk/docs/theme`

mdBook aborted while copying `theme/youtube.css` (`No such file or directory`), so **Build and deploy docs** failed at *Build all books* before any deploy step ran — `docs.start9.com` still serves the pre-reorg build. `bitcoin-guides` was unaffected; its `../theme` symlink already pointed at the right place. Repointed the three at `../../start-docs/theme`.

## 2. Stray mdbook-tabs `<div>` warning

`backup-create.md`'s "Step 2" nested its `{{#tabs}}` block inside the `1. Complete the form:` list item. The tabs preprocessor emits `<div>` wrappers, and nested in a list item they straddle the item boundary, so every build logged `unclosed <div> ... while exiting Item` / `unexpected </div>` (it blamed the file, not a line — the yt-video `<div>` was a red herring). De-nested the tabs to top level, matching Step 1.

## Verification

Locally, `projects/start-docs/build.sh` builds all four books (start-os, start-tunnel, packaging, bitcoin-guides) with **zero warnings**, the theme assets land in each book's output, and both backup tab groups still render (16 panels, content intact).

Merging re-triggers the docs deploy — the changed paths are in the workflow's trigger globs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)