### PR TITLE
chore(os-install): use util::io::canonicalize in quiesce helper

### DIFF
--- a/shared-libs/crates/start-core/src/os_install/quiesce.rs
+++ b/shared-libs/crates/start-core/src/os_install/quiesce.rs
@@ -41,9 +41,10 @@ pub async fn list_partitions(disk_path: &Path) -> Result<Vec<PathBuf>, Error> {
     Ok(out)
 }
 
-/// Canonical `/dev` node for `path`, falling back to the input on error.
+/// Canonical `/dev` node for `path`, falling back to the input on error so it
+/// stays usable as a set key even for an unresolvable device.
 async fn canonical(path: &Path) -> PathBuf {
-    tokio::fs::canonicalize(path)
+    crate::util::io::canonicalize(path, false)
         .await
         .unwrap_or_else(|_| path.to_path_buf())
 }


### PR DESCRIPTION
Post-merge review follow-up on #3351 (@dr-bonez: "pretty sure we already have a util for canonicalization").

The `canonical` helper in `os_install/quiesce.rs` hand-rolled `tokio::fs::canonicalize`. This swaps it for the existing `crate::util::io::canonicalize(path, false)`:

- For the existing `/dev` nodes we canonicalize (to dedup device paths in the holder-graph walk), `tokio::fs::canonicalize` succeeds, so the result is identical.
- On a NotFound tail it resolves the first existing ancestor and re-joins the name instead of returning the raw input — strictly better, and never hit for live device nodes.
- The thin wrapper keeps the infallible fall-back-to-input behavior (`unwrap_or_else(|_| path.to_path_buf())`) so it's still usable as a `BTreeSet` key.

`cargo check -p start-core`, `os_install` tests, and rustfmt all clean.