### PR TITLE
chore(rust): clear unused-import/mut/lifetime/visibility warnings

### DIFF
--- a/shared-libs/crates/exver/src/test.rs
+++ b/shared-libs/crates/exver/src/test.rs
@@ -265,5 +265,5 @@ fn caret() {
 #[cfg(feature = "serde")]
 #[test]
 fn deser() {
-    let v: ExtendedVersion = serde_yaml::from_str("---\n0.2.5:0\n").unwrap();
+    let _v: ExtendedVersion = serde_yaml::from_str("---\n0.2.5:0\n").unwrap();
 }

--- a/shared-libs/crates/jsonpath/src/ffi/mod.rs
+++ b/shared-libs/crates/jsonpath/src/ffi/mod.rs
@@ -30,14 +30,11 @@ pub extern "C" fn ffi_select(json_str: *const c_char, path: *const c_char) -> *c
 }
 
 #[no_mangle]
-#[allow(clippy::forget_copy)]
 pub extern "C" fn ffi_path_compile(path: *const c_char) -> *mut c_void {
     let path = to_str(path, INVALID_PATH);
     #[allow(deprecated)]
     let ref_node = Box::into_raw(Box::new(parser::Parser::compile(path).unwrap()));
-    let ptr = ref_node as *mut c_void;
-    std::mem::forget(ref_node);
-    ptr
+    ref_node as *mut c_void
 }
 
 #[no_mangle]

--- a/shared-libs/crates/jsonpath/src/lib.rs
+++ b/shared-libs/crates/jsonpath/src/lib.rs
@@ -289,7 +289,7 @@ pub fn selector<'a>(
 /// ```
 pub fn selector_as<'a, T: serde::de::DeserializeOwned>(
     json: &'a Value,
-) -> impl FnMut(&'a str) -> Result<Vec<T>, JsonPathError> + '_ {
+) -> impl FnMut(&'a str) -> Result<Vec<T>, JsonPathError> + 'a {
     let mut selector = JsonSelector::default();
     let _ = selector.value(json);
     move |path: &str| {
@@ -622,7 +622,7 @@ impl<'a> PathCompiled<'a> {
     /// Compile a path expression and return a compiled instance.
     ///
     /// If parsing the path fails, it will return an error.
-    pub fn compile(path: &str) -> Result<PathCompiled, JsonPathError> {
+    pub fn compile(path: &str) -> Result<PathCompiled<'_>, JsonPathError> {
         let parser = PathParser::compile(path).map_err(|e| JsonPathError::from(&e))?;
         Ok(PathCompiled {
             parser: Rc::new(parser),

--- a/shared-libs/crates/jsonpath/src/paths/mod.rs
+++ b/shared-libs/crates/jsonpath/src/paths/mod.rs
@@ -1,4 +1,3 @@
-pub use self::parser_node_visitor::ParserNodeVisitor;
 pub use self::parser_token_handler::ParserTokenHandler;
 pub use self::path_parser::PathParser;
 pub use self::str_reader::StrRange;

--- a/shared-libs/crates/jsonpath/src/paths/path_parser.rs
+++ b/shared-libs/crates/jsonpath/src/paths/path_parser.rs
@@ -618,7 +618,6 @@ pub struct ParserNode {
 
 #[cfg(test)]
 mod path_parser_tests {
-    use imbl_value::imbl::vector;
     use paths::path_parser::PathParser;
     use paths::str_reader::StrRange;
     use paths::tokens::{FilterToken, ParseToken};

--- a/shared-libs/crates/jsonpath/src/paths/tokenizer.rs
+++ b/shared-libs/crates/jsonpath/src/paths/tokenizer.rs
@@ -288,7 +288,6 @@ impl<'a> TokenReader<'a> {
 
 #[cfg(test)]
 mod tokenizer_tests {
-    use imbl_value::imbl::vector;
     use paths::str_reader::StrRange;
     use paths::tokenizer::{TokenError, TokenReader};
     use paths::tokens::Token;

--- a/shared-libs/crates/jsonpath/src/selector/utils.rs
+++ b/shared-libs/crates/jsonpath/src/selector/utils.rs
@@ -37,7 +37,7 @@ impl<'a: 'b, 'b> PathKey<'a> {
     }
 }
 
-pub fn to_path_str(key: &str) -> PathKey {
+pub fn to_path_str(key: &str) -> PathKey<'_> {
     let mut path_key = PathKey {
         key,
         special_key: None,

--- a/shared-libs/crates/patch-db/core/src/model.rs
+++ b/shared-libs/crates/patch-db/core/src/model.rs
@@ -210,7 +210,7 @@ mod test {
     }
 
     fn mutate_fn(v: &mut Model<Foo>) {
-        let mut a = v.as_a_mut();
+        let a = v.as_a_mut();
         a.as_b_mut().ser(&"NotThis".into()).unwrap();
         a.as_b_mut().ser(&"Replaced".into()).unwrap();
     }

--- a/shared-libs/crates/start-core/src/db/model/public.rs
+++ b/shared-libs/crates/start-core/src/db/model/public.rs
@@ -32,7 +32,7 @@ use crate::util::cpupower::Governor;
 use crate::util::lshw::LshwDevice;
 use crate::util::serde::MaybeUtf8String;
 use crate::version::{Current, VersionT};
-use crate::{ARCH, GatewayId, PLATFORM, PackageId};
+use crate::{GatewayId, PLATFORM};
 
 pub static DB_UI_SEED_CELL: OnceLock<&'static str> = OnceLock::new();
 

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -1089,7 +1089,7 @@ impl ConnRegistry {
     }
 }
 
-struct ConnRegHandle {
+pub struct ConnRegHandle {
     id: u64,
     registry: Weak<ConnRegistry>,
 }
@@ -1151,7 +1151,7 @@ impl Default for AlpnInfo {
 }
 
 #[derive(Debug, Clone)]
-struct TargetEntry {
+pub struct TargetEntry {
     rc: Weak<()>,
     ctx: ProxyContext,
 }

--- a/shared-libs/crates/start-core/src/net/web_server.rs
+++ b/shared-libs/crates/start-core/src/net/web_server.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use axum::Router;
 use futures::future::Either;
-use futures::{FutureExt, TryFutureExt};
+use futures::FutureExt;
 use http::Extensions;
 use hyper_util::rt::{TokioIo, TokioTimer};
 use tokio::net::TcpListener;

--- a/shared-libs/crates/start-core/src/registry/os/version/mod.rs
+++ b/shared-libs/crates/start-core/src/registry/os/version/mod.rs
@@ -198,7 +198,7 @@ pub async fn get_version(
         }
     }
     let target = target.unwrap_or(VersionRange::Any);
-    let mut res = to_value::<BTreeMap<Version, OsVersionInfo>>(
+    let res = to_value::<BTreeMap<Version, OsVersionInfo>>(
         &ctx.db
             .peek()
             .await

--- a/shared-libs/crates/start-core/src/service/mod.rs
+++ b/shared-libs/crates/start-core/src/service/mod.rs
@@ -684,7 +684,7 @@ impl Service {
         if let Some(mut finalization_progress) = service.seed.init_phase.replace(None) {
             finalization_progress.complete();
         }
-        if let Some(mut overall_progress) = overall_progress {
+        if let Some(overall_progress) = overall_progress {
             overall_progress.complete();
             tokio::task::yield_now().await;
         }

--- a/shared-libs/crates/start-core/src/service/service_map.rs
+++ b/shared-libs/crates/start-core/src/service/service_map.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -30,7 +29,7 @@ use crate::s9pk::merkle_archive::source::FileSource;
 use crate::service::rpc::{ExitParams, InitKind};
 use crate::service::{LoadDisposition, Service, ServiceRef, get_data_version};
 use crate::sign::commitment::merkle_archive::MerkleArchiveCommitment;
-use crate::status::{DesiredStatus, StatusInfo};
+use crate::status::StatusInfo;
 use crate::util::future::NonDetachingJoinHandle;
 use crate::util::serde::{Base32, Pem};
 use crate::util::sync::SyncMutex;

--- a/shared-libs/crates/start-core/src/setup.rs
+++ b/shared-libs/crates/start-core/src/setup.rs
@@ -11,7 +11,6 @@ use rpc_toolkit::{Context, Empty, HandlerArgs, HandlerExt, ParentHandler, from_f
 
 use crate::context::CliContext;
 use itertools::Itertools;
-use rpc_toolkit::CallRemote;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -20,7 +19,7 @@ use tracing::instrument;
 use ts_rs::TS;
 
 use crate::account::AccountInfo;
-use crate::auth::{PasswordType, write_shadow};
+use crate::auth::write_shadow;
 use crate::backup::restore::recover_full_server;
 use crate::backup::target::BackupTargetFS;
 use crate::bins::set_locale;
@@ -159,7 +158,7 @@ pub fn disk<C: Context>() -> ParentHandler<C> {
 
 const LIVE_MEDIUM_PATH: &str = "/run/live/medium";
 
-pub async fn list_disks(ctx: SetupContext) -> Result<Vec<DiskInfo>, Error> {
+pub async fn list_disks(_ctx: SetupContext) -> Result<Vec<DiskInfo>, Error> {
     let mut disks = crate::disk::util::list(
         &crate::disk::OsPartitionInfo::from_fstab()
             .await

--- a/shared-libs/crates/start-core/src/sign/mod.rs
+++ b/shared-libs/crates/start-core/src/sign/mod.rs
@@ -90,6 +90,7 @@ impl SignatureScheme for AnyScheme {
             (Self::Ed25519(s), AnySigningKey::Ed25519(key), AnyDigest::Sha512(digest)) => {
                 Ok(AnySignature::Ed25519(s.sign(key, digest, context)?))
             }
+            #[allow(unreachable_patterns)]
             _ => Err(Error::new(
                 eyre!("mismatched signature algorithm"),
                 ErrorKind::InvalidSignature,
@@ -110,6 +111,7 @@ impl SignatureScheme for AnyScheme {
                 AnyDigest::Sha512(digest),
                 AnySignature::Ed25519(signature),
             ) => s.verify(key, digest, context, signature),
+            #[allow(unreachable_patterns)]
             _ => Err(Error::new(
                 eyre!("mismatched signature algorithm"),
                 ErrorKind::InvalidSignature,

--- a/shared-libs/crates/start-core/src/tunnel/update.rs
+++ b/shared-libs/crates/start-core/src/tunnel/update.rs
@@ -1,6 +1,5 @@
 use std::process::Stdio;
 
-use rpc_toolkit::Empty;
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::instrument;

--- a/shared-libs/crates/start-core/src/util/sync.rs
+++ b/shared-libs/crates/start-core/src/util/sync.rs
@@ -8,8 +8,6 @@ use std::task::{Poll, Waker};
 use futures::Stream;
 use futures::stream::BoxStream;
 
-use crate::prelude::*;
-
 #[cfg(feature = "unstable")]
 lazy_static::lazy_static! {
     static ref ID_CTR: AtomicUsize = AtomicUsize::new(0);


### PR DESCRIPTION
First of three PRs addressing the Rust compiler warnings across the monorepo workspace. This one covers the **unambiguous** warnings — each had a single reasonable resolution and none signal incomplete work.

`cargo check --workspace --all-targets` warnings dropped **88 → 61** (remaining: 10 `dead_code`, 51 `deprecated`/generic-array — each in its own PR per discussion).

### What changed (no behavior change)
- **`unused_imports` ×11** — removed across start-core (`db/model/public`, `net/web_server`, `service/service_map`, `setup`, `tunnel/update`, `util/sync`) and the vendored jsonpath crate.
- **`unused_mut` ×3** — dropped redundant `mut` (patch-db test, registry version listing, service finalization).
- **`mismatched_lifetime_syntaxes` ×3** (jsonpath) — made elided/named lifetimes consistent per rustc's suggestion (`+ 'a`, `PathCompiled<'_>`, `PathKey<'_>`).
- **`unused_variables` ×2** — `_`-prefixed required-by-signature params (`list_disks` ctx, an exver deser test binding).
- **`private_interfaces` ×5** (net/vhost) — made `ConnRegHandle`/`TargetEntry` `pub` so the public `ProxyContext::track`/`track_with` and `GetVHostAcmeProvider` no longer expose more-private types.
- **`unreachable_patterns` ×2** (sign) — `#[allow(unreachable_patterns)]` on the catch-all arms; they're deliberate forward-compat for the `#[non_exhaustive]` signature enums, currently single-variant (Ed25519).
- **`forgetting_copy_types` ×1** (jsonpath FFI) — removed a no-op `mem::forget` on a `*mut` raw pointer (`Box::into_raw` already leaks; the forget did nothing), plus its now-moot `#[allow(clippy::forget_copy)]`.

### Verification
- `cargo check --workspace --all-targets` — clean, zero new warnings.
- `cargo check -p start-core --features unstable` — confirms removing the `crate::prelude::*` glob in `util/sync.rs` doesn't break the feature-gated path.

Follow-ups: dead_code cleanup (separate PR), generic-array 1.x migration (separate PR).