### PR TITLE
chore(rust): resolve dead_code warnings

### DIFF
--- a/shared-libs/crates/jsonpath/src/paths/tokenizer.rs
+++ b/shared-libs/crates/jsonpath/src/paths/tokenizer.rs
@@ -223,7 +223,6 @@ impl<'a> Tokenizer<'a> {
 pub(super) struct TokenReader<'a> {
     tokenizer: Tokenizer<'a>,
     curr_pos: usize,
-    err: Option<TokenError>,
     peeked: Option<Result<Token, TokenError>>,
 }
 
@@ -232,7 +231,6 @@ impl<'a> TokenReader<'a> {
         TokenReader {
             tokenizer: Tokenizer::new(input),
             curr_pos: 0,
-            err: None,
             peeked: None,
         }
     }

--- a/shared-libs/crates/patch-db/core/src/model.rs
+++ b/shared-libs/crates/patch-db/core/src/model.rs
@@ -200,12 +200,14 @@ mod test {
     #[model = "Model<Self>"]
     // #[macro_debug]
     struct Foo {
+        #[allow(dead_code)]
         a: Bar,
     }
 
     #[derive(crate::HasModel)]
     #[model = "Model<Self>"]
     struct Bar {
+        #[allow(dead_code)]
         b: String,
     }
 

--- a/shared-libs/crates/start-core/src/backup/os.rs
+++ b/shared-libs/crates/start-core/src/backup/os.rs
@@ -67,6 +67,7 @@ struct OsBackupSerDe {
 #[derive(Deserialize)]
 #[serde(rename = "kebab-case")]
 struct OsBackupV0 {
+    #[allow(dead_code)] // parsed for format-validation; StartOS no longer restores the tor key
     tor_key: Base32<[u8; 64]>, // Base32 Encoded Ed25519 Expanded Secret Key
     root_ca_key: Pem<PKey<Private>>, // PEM Encoded OpenSSL Key
     root_ca_cert: Pem<X509>,   // PEM Encoded OpenSSL X509 Certificate

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -43,7 +43,7 @@ pub struct NetController {
     pub(super) dns_update: DnsUpdateController,
     pub(super) forward: InterfacePortForwardController,
     pub(crate) port_map: PortMapController,
-    pub(super) socks: SocksController,
+    pub(super) _socks: SocksController,
     pub(crate) callbacks: Arc<ServiceCallbacks>,
 }
 
@@ -120,7 +120,7 @@ impl NetController {
             ),
             port_map,
             net_iface,
-            socks,
+            _socks: socks,
             callbacks: Arc::new(ServiceCallbacks::default()),
         })
     }

--- a/shared-libs/crates/start-core/src/s9pk/merkle_archive/mod.rs
+++ b/shared-libs/crates/start-core/src/s9pk/merkle_archive/mod.rs
@@ -31,7 +31,12 @@ pub mod write_queue;
 
 #[derive(Debug, Clone)]
 enum Signer {
-    Signed(VerifyingKey, Signature, u64, InternedString),
+    Signed(
+        VerifyingKey,
+        Signature,
+        u64,
+        #[allow(dead_code)] InternedString,
+    ),
     Signer(SigningKey, InternedString),
 }
 

--- a/shared-libs/crates/start-core/src/tunnel/forward/igd.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/igd.rs
@@ -217,17 +217,10 @@ async fn control(
     handle_control(&ctx, peer, &headers, &body).await
 }
 
-pub(super) async fn apply_peer_forward(
-    ctx: &TunnelContext,
-    source: SocketAddrV4,
-    target: SocketAddrV4,
-) -> Result<(), u16> {
-    apply_peer_forward_range(ctx, source, target, 1, "UPnP").await
-}
-
-/// Like [`apply_peer_forward`] but forwards `count` contiguous ports (a PCP
-/// PORT_SET range). `protocol_label` is the DB label (e.g. "UPnP", "PCP"); the
-/// requesting device is already shown by the forward's target.
+/// Installs (or re-asserts) a forward of `count` contiguous ports (a PCP
+/// PORT_SET range) from `source` to `target`. `protocol_label` is the DB label
+/// (e.g. "UPnP", "PCP"); the requesting device is already shown by the forward's
+/// target.
 pub(super) async fn apply_peer_forward_range(
     ctx: &TunnelContext,
     source: SocketAddrV4,

--- a/shared-libs/crates/start-core/src/version/mod.rs
+++ b/shared-libs/crates/start-core/src/version/mod.rs
@@ -562,6 +562,9 @@ unsafe impl Send for DynVersion {}
 trait DynVersionT: RefUnwindSafe + Send + Sync {
     fn previous(&self) -> DynVersion;
     fn semver(&self) -> exver::Version;
+    // part of the DynVersionT surface; kept intentionally though not dynamically dispatched
+    #[allow(dead_code)]
+    fn compat(&self) -> &'static exver::VersionRange;
     fn pre_up(&self) -> BoxFuture<'static, Result<Box<dyn Any + UnwindSafe + Send>, Error>>;
     fn up(&self, db: &mut Value, input: Box<dyn Any + Send>) -> Result<Value, Error>;
     fn post_up<'a>(&self, ctx: &'a RpcContext, input: Value) -> BoxFuture<'a, Result<(), Error>>;
@@ -577,6 +580,9 @@ where
     }
     fn semver(&self) -> exver::Version {
         VersionT::semver(*self)
+    }
+    fn compat(&self) -> &'static exver::VersionRange {
+        VersionT::compat(*self)
     }
     fn pre_up(&self) -> BoxFuture<'static, Result<Box<dyn Any + UnwindSafe + Send>, Error>> {
         let v = *self;
@@ -611,6 +617,9 @@ impl DynVersionT for DynVersion {
     }
     fn semver(&self) -> exver::Version {
         self.0.semver()
+    }
+    fn compat(&self) -> &'static exver::VersionRange {
+        self.0.compat()
     }
     fn pre_up(&self) -> BoxFuture<'static, Result<Box<dyn Any + UnwindSafe + Send>, Error>> {
         self.0.pre_up()

--- a/shared-libs/crates/start-core/src/version/mod.rs
+++ b/shared-libs/crates/start-core/src/version/mod.rs
@@ -562,7 +562,6 @@ unsafe impl Send for DynVersion {}
 trait DynVersionT: RefUnwindSafe + Send + Sync {
     fn previous(&self) -> DynVersion;
     fn semver(&self) -> exver::Version;
-    fn compat(&self) -> &'static exver::VersionRange;
     fn pre_up(&self) -> BoxFuture<'static, Result<Box<dyn Any + UnwindSafe + Send>, Error>>;
     fn up(&self, db: &mut Value, input: Box<dyn Any + Send>) -> Result<Value, Error>;
     fn post_up<'a>(&self, ctx: &'a RpcContext, input: Value) -> BoxFuture<'a, Result<(), Error>>;
@@ -578,9 +577,6 @@ where
     }
     fn semver(&self) -> exver::Version {
         VersionT::semver(*self)
-    }
-    fn compat(&self) -> &'static exver::VersionRange {
-        VersionT::compat(*self)
     }
     fn pre_up(&self) -> BoxFuture<'static, Result<Box<dyn Any + UnwindSafe + Send>, Error>> {
         let v = *self;
@@ -616,9 +612,6 @@ impl DynVersionT for DynVersion {
     fn semver(&self) -> exver::Version {
         self.0.semver()
     }
-    fn compat(&self) -> &'static exver::VersionRange {
-        self.0.compat()
-    }
     fn pre_up(&self) -> BoxFuture<'static, Result<Box<dyn Any + UnwindSafe + Send>, Error>> {
         self.0.pre_up()
     }
@@ -637,7 +630,7 @@ impl DynVersionT for DynVersion {
 }
 
 #[derive(Debug, Clone)]
-struct LTWrapper<T>(T, exver::Version);
+struct LTWrapper<T>(T, #[allow(dead_code)] exver::Version);
 impl<T> serde::Serialize for LTWrapper<T>
 where
     T: VersionT,

--- a/shared-libs/crates/yasi/src/ts_rs.rs
+++ b/shared-libs/crates/yasi/src/ts_rs.rs
@@ -28,6 +28,7 @@ mod test {
 
     #[derive(TS)]
     struct HasString {
+        #[allow(dead_code)]
         s: InternedString,
     }
 


### PR DESCRIPTION
Second of three PRs on the Rust workspace warnings. Covers the 10 `dead_code` warnings, handled **per item** rather than with a blanket `#[allow]` — `_`-prefix or removal where it's meaningful, scoped `#[allow(dead_code)]` only where the value is genuinely retained but can't be renamed/removed without changing behavior.

`cargo check --workspace --all-targets` dead_code: **10 → 0**, no new warnings.

### Removed (genuinely unused)
- **`igd::apply_peer_forward`** — a thin `count = 1` wrapper superseded by `apply_peer_forward_range`; no callers. Removed, and de-linked the doc comment that referenced it.
- **`DynVersionT::compat`** — the dynamic-dispatch accessor is never called; the static `VersionT::compat` (still present) covers every use site (`db/model/public`, `registry/device_info`, the version dump). Removed from the trait and both impls.
- **`jsonpath TokenReader::err`** — vestigial vendored field, only ever set to `None`, never read.

### Renamed (RAII)
- **`net_controller::socks` → `_socks`** — holds the live SOCKS5 server thread (`NonDetachingJoinHandle`); never read by design, the `_` signals it's held for its `Drop`. Dropping it would kill the SOCKS server.

### Kept with scoped `#[allow(dead_code)]`
These can't be `_`-prefixed (serde field-name binding / macro-generated accessors / positional tuple fields) or are read only under `#[cfg(test)]`:
- `backup::OsBackupV0::tor_key` — parsed for legacy-format validation; StartOS no longer restores the tor key.
- `merkle_archive::Signer::Signed` context field — retained signing-context provenance, not re-read during verify.
- `version::LTWrapper` second field — read only in a `#[cfg(test)]` path.
- patch-db `Foo`/`Bar` and yasi `HasString` test fields — drive `HasModel`/`TS` derives.

@drbonez — flagging two for your call in particular: removing **`DynVersionT::compat`** (in case it was staged for future compat-gating rather than being truly dead), and keeping vs. dropping the unused **`Signer::Signed` context field**. Happy to flip either.