### PR TITLE
fix(docs): de-nest StartOS backup tabs so the book builds clean

### DIFF
--- a/projects/start-os/docs/src/backup-create.md
+++ b/projects/start-os/docs/src/backup-create.md
@@ -347,68 +347,84 @@ A network folder backup sends your encrypted backup over the LAN to a shared fol
 
 1. Complete the form:
 
-   {{#tabs global="backup-target"}}
+{{#tabs global="backup-target"}}
 
-   {{#tab name="Mac"}}
-   1. **Hostname**: The hostname or IP address of your Mac (see the tip in the section above).
-   1. **Path**: The _name_ of your shared folder, _not_ the full directory path.
-   1. **Username**: Your Mac user who owns the shared folder.
-   1. **Password**: Your password for the above user.
-      {{#endtab}}
+{{#tab name="Mac"}}
 
-   {{#tab name="Windows"}}
-   1. **Hostname**: Your Windows computer name (shown after `\\` in the sharing dialog).
-   1. **Path**: The share name from the sharing dialog (e.g. `SharedFolder`), _not_ the full directory path.
-   1. **Username**: Your Windows user who owns the shared folder.
-   1. **Password**: Your password for the above user. You _cannot_ use a PIN.
+1. **Hostname**: The hostname or IP address of your Mac (see the tip in the section above).
+1. **Path**: The _name_ of your shared folder, _not_ the full directory path.
+1. **Username**: Your Mac user who owns the shared folder.
+1. **Password**: Your password for the above user.
 
-   > [!WARNING]
-   > Ensure you are not using a PIN and that Office365 accounts are not in use — try a regular local user instead. If you receive `mount error(115): Operation now in progress`, navigate to `Start > Settings > Network & Internet > Ethernet (or WiFi)` and select the "Private" profile.
-   > {{#endtab}}
+{{#endtab}}
 
-   {{#tab name="Ubuntu"}}
-   1. **Hostname**: The name of your Linux machine on the LAN.
-   1. **Path**: The share name from your Samba config (e.g. `start9-backup`), _not_ the full directory path.
-   1. **Username**: Your Linux username on the remote machine.
-   1. **Password**: The SMB password you created with `smbpasswd`.
-      {{#endtab}}
+{{#tab name="Windows"}}
 
-   {{#tab name="Mint"}}
-   1. **Hostname**: The name of your Linux machine on the LAN.
-   1. **Path**: The "Share Name" from the sharing dialog, _not_ the full directory path.
-   1. **Username**: Your Linux username on the remote machine.
-   1. **Password**: The SMB password you created with `smbpasswd`.
-      {{#endtab}}
+1. **Hostname**: Your Windows computer name (shown after `\\` in the sharing dialog).
+1. **Path**: The share name from the sharing dialog (e.g. `SharedFolder`), _not_ the full directory path.
+1. **Username**: Your Windows user who owns the shared folder.
+1. **Password**: Your password for the above user. You _cannot_ use a PIN.
 
-   {{#tab name="Other Linux"}}
-   1. **Hostname**: The name of your Linux machine on the LAN.
-   1. **Path**: The "Share Name" from your Samba config, _not_ the full directory path (e.g. `backup-share`).
-   1. **Username**: Your Linux username on the remote machine.
-   1. **Password**: The SMB password you created with `smbpasswd`.
-      {{#endtab}}
+> [!WARNING]
+> Ensure you are not using a PIN and that Office365 accounts are not in use — try a regular local user instead. If you receive `mount error(115): Operation now in progress`, navigate to `Start > Settings > Network & Internet > Ethernet (or WiFi)` and select the "Private" profile.
 
-   {{#tab name="Synology"}}
-   1. **Hostname**: The name of your Synology device on the LAN.
-   1. **Path**: The _name_ of your shared folder, _not_ the full directory path (e.g. `Backups`).
-   1. **Username**: Your Synology user who owns the shared folder.
-   1. **Password**: Your password for the above user.
-      {{#endtab}}
+{{#endtab}}
 
-   {{#tab name="TrueNAS SCALE"}}
-   1. **Hostname**: The name of your TrueNAS device on the LAN (e.g. `truenas.local`).
-   1. **Path**: The share name you chose when creating the SMB share, _not_ the full directory path.
-   1. **Username**: The TrueNAS user you created for backups.
-   1. **Password**: Your password for the above user.
-      {{#endtab}}
+{{#tab name="Ubuntu"}}
 
-   {{#tab name="TrueNAS CORE"}}
-   1. **Hostname**: The name of your TrueNAS device on the LAN (e.g. `truenas.local`).
-   1. **Path**: The share name you chose when creating the SMB share, _not_ the full directory path.
-   1. **Username**: The TrueNAS user you created for backups.
-   1. **Password**: Your password for the above user.
-      {{#endtab}}
+1. **Hostname**: The name of your Linux machine on the LAN.
+1. **Path**: The share name from your Samba config (e.g. `start9-backup`), _not_ the full directory path.
+1. **Username**: Your Linux username on the remote machine.
+1. **Password**: The SMB password you created with `smbpasswd`.
 
-   {{#endtabs}}
+{{#endtab}}
+
+{{#tab name="Mint"}}
+
+1. **Hostname**: The name of your Linux machine on the LAN.
+1. **Path**: The "Share Name" from the sharing dialog, _not_ the full directory path.
+1. **Username**: Your Linux username on the remote machine.
+1. **Password**: The SMB password you created with `smbpasswd`.
+
+{{#endtab}}
+
+{{#tab name="Other Linux"}}
+
+1. **Hostname**: The name of your Linux machine on the LAN.
+1. **Path**: The "Share Name" from your Samba config, _not_ the full directory path (e.g. `backup-share`).
+1. **Username**: Your Linux username on the remote machine.
+1. **Password**: The SMB password you created with `smbpasswd`.
+
+{{#endtab}}
+
+{{#tab name="Synology"}}
+
+1. **Hostname**: The name of your Synology device on the LAN.
+1. **Path**: The _name_ of your shared folder, _not_ the full directory path (e.g. `Backups`).
+1. **Username**: Your Synology user who owns the shared folder.
+1. **Password**: Your password for the above user.
+
+{{#endtab}}
+
+{{#tab name="TrueNAS SCALE"}}
+
+1. **Hostname**: The name of your TrueNAS device on the LAN (e.g. `truenas.local`).
+1. **Path**: The share name you chose when creating the SMB share, _not_ the full directory path.
+1. **Username**: The TrueNAS user you created for backups.
+1. **Password**: Your password for the above user.
+
+{{#endtab}}
+
+{{#tab name="TrueNAS CORE"}}
+
+1. **Hostname**: The name of your TrueNAS device on the LAN (e.g. `truenas.local`).
+1. **Path**: The share name you chose when creating the SMB share, _not_ the full directory path.
+1. **Username**: The TrueNAS user you created for backups.
+1. **Password**: Your password for the above user.
+
+{{#endtab}}
+
+{{#endtabs}}
 
 > [!WARNING]
 > If you receive `Filesystem I/O Error mount error(13): Permission denied`, ensure you have entered the correct values. The hostname can be particularly tricky.


### PR DESCRIPTION
Follow-up to #3358. That PR fixed the theme symlinks (the deploy blocker), but a second commit — this docs cleanup — was left out of the merge when the PR head desynced, so it never reached master. Re-landing it on its own.

## What

`backup-create.md`'s "Step 2. Connect from StartOS" nested its `{{#tabs}}` block inside the `1. Complete the form:` list item. The mdbook-tabs preprocessor emits `<div>` wrappers, and nested in a list item they straddle the item boundary, so every docs build logged:

```
WARN unclosed HTML tag `<div>` found in `backup-create.md` while exiting Item
WARN unexpected HTML end tag `</div>` found in `backup-create.md`
```

It blamed the file, not a line — the `yt-video` `<div>` was a red herring. De-nested the tabs to top level (matching "Step 1"), and normalized the tab markers to the surrounding blank-line style.

Non-fatal (the build still succeeded), but it cluttered every run.

## Verification

`projects/start-docs/build.sh` builds all four books with **zero warnings**, and both backup tab groups still render (2 groups, 16 panels, content intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)