### PR TITLE
refactor(shared): drop unused base64-js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "@taiga-ui/layout": "5.11.0",
         "@taiga-ui/polymorpheus": "5.0.1",
         "ansi-to-html": "^0.7.2",
-        "base64-js": "^1.5.1",
         "buffer": "^6.0.3",
         "cbor": "npm:@jprochazk/cbor@^0.4.9",
         "cbor-web": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "@taiga-ui/layout": "5.11.0",
     "@taiga-ui/polymorpheus": "5.0.1",
     "ansi-to-html": "^0.7.2",
-    "base64-js": "^1.5.1",
     "buffer": "^6.0.3",
     "cbor": "npm:@jprochazk/cbor@^0.4.9",
     "cbor-web": "^8.1.0",

--- a/shared-libs/ts-modules/shared/package.json
+++ b/shared-libs/ts-modules/shared/package.json
@@ -21,7 +21,6 @@
     "@taiga-ui/kit": ">=5.0.0",
     "@taiga-ui/polymorpheus": ">=5.0.0",
     "ansi-to-html": "^0.7.2",
-    "base64-js": "^1.5.1",
     "marked": "^4.0.0",
     "rxjs": ">=7.0.0"
   },

--- a/shared-libs/ts-modules/shared/src/public-api.ts
+++ b/shared-libs/ts-modules/shared/src/public-api.ts
@@ -43,7 +43,6 @@ export * from './types/workspace-config'
 
 export * from './tokens/relative-url'
 
-export * from './util/base-64'
 export * from './util/convert-ansi'
 export * from './util/format-progress'
 export * from './util/get-new-entries'

--- a/shared-libs/ts-modules/shared/src/util/base-64.ts
+++ b/shared-libs/ts-modules/shared/src/util/base-64.ts
@@ -1,9 +1,0 @@
-import * as Base64 from 'base64-js'
-
-export function encodeBase64(text: string) {
-  return Base64.fromByteArray(new TextEncoder().encode(text))
-}
-
-export function decodeBase64(encoded: string) {
-  return new TextDecoder().decode(Base64.toByteArray(encoded))
-}


### PR DESCRIPTION
## What

Removes the `base64-js` dependency and the `encodeBase64`/`decodeBase64` helpers it backed in `@start9labs/shared`.

## Why

`encodeBase64`/`decodeBase64` (`shared-libs/ts-modules/shared/src/util/base-64.ts`) had **no callers anywhere in the monorepo** — only a `public-api.ts` re-export — yet `base64-js` is CommonJS, so it showed up as a tree-shaking *optimization bailout* in every web build that pulls in `@start9labs/shared` (brochure, ui, setup-wizard, start-tunnel):

```
▲ [WARNING] Module 'base64-js' used by '.../util/base-64.ts' is not ESM
```

Since nothing used the helpers, the cleanest fix is removal (rather than rewriting them onto native `btoa`/`atob`). The `base64-js` bailout warning is now gone from web builds.

## Safety

- Verified zero references to `encodeBase64`/`decodeBase64` or a direct `base64-js` import across the whole tree before removing.
- `buffer` (used by `@start9labs/start-core`) keeps its **own transitive** `base64-js` for its `Buffer` polyfill — `node_modules/base64-js` stays in the lock, so nothing breaks.
- `package-lock.json` change is a single line: dropping `base64-js` from the root `dependencies`, mirroring `package.json`. Everything else in the lock is untouched, so `npm ci` stays in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)