### PR TITLE
fix(wifi): allow non-ascii characters in wifi ssids (#3365)

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -83,7 +83,8 @@ file tracks notable changes since the move to the monorepo.
 - **Allow non-ASCII characters in WiFi SSIDs (#3365).** Adding, connecting to, or
   removing a WiFi network whose SSID contains non-ASCII characters (e.g. an accented
   letter or a typographic apostrophe) no longer fails with "SSID may not have special
-  characters". SSIDs are passed to NetworkManager as-is; the WiFi passphrase still
+  characters". SSIDs are passed to NetworkManager as-is, and SSIDs containing a colon
+  are now parsed correctly when listing connections. The WiFi passphrase still
   requires ASCII, as mandated by WPA.
 
 ### Removed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -8,23 +8,6 @@ Full per-release notes are published on the
 [GitHub releases page](https://github.com/Start9Labs/start-technologies/releases). This
 file tracks notable changes since the move to the monorepo.
 
-## [Unreleased]
-
-### Changed
-
-- **Migrated `startos-backup-fs` into the monorepo** as the `start-os/backup-fs`
-  workspace member (from the former `Start9Labs/start-fs` repo); it is no longer
-  built as an external `cargo install --git` dependency.
-- **Monorepo reorganization.** `start-os` is now the monorepo for all Start9
-  products. The OS product moved into its own `start-os/` directory as a thin
-  wrapper: the `startbox` and `start-container` entry points live in
-  `src/bin/`, the admin UI and setup wizard in `web/`, and the container runtime
-  in `container-runtime/`. Backend logic moved from the old `core/` crate to the
-  shared `start-core` crate (`shared-libs/crates/start-core`); shared Angular
-  libraries moved to `shared-libs/ts-modules`; the SDK to `start-sdk`; and the `patch-db`
-  submodule to `shared-libs/crates/patch-db`. Builds now run against the root Cargo and
-  Angular workspaces (`cargo build -p start-os`, web from `shared-libs/ts-modules`).
-
 ## [0.4.0-beta.10]
 
 ### Added
@@ -54,6 +37,18 @@ file tracks notable changes since the move to the monorepo.
 
 ### Changed
 
+- **Migrated `startos-backup-fs` into the monorepo** as the `start-os/backup-fs`
+  workspace member (from the former `Start9Labs/start-fs` repo); it is no longer
+  built as an external `cargo install --git` dependency.
+- **Monorepo reorganization.** `start-os` is now the monorepo for all Start9
+  products. The OS product moved into its own `start-os/` directory as a thin
+  wrapper: the `startbox` and `start-container` entry points live in
+  `src/bin/`, the admin UI and setup wizard in `web/`, and the container runtime
+  in `container-runtime/`. Backend logic moved from the old `core/` crate to the
+  shared `start-core` crate (`shared-libs/crates/start-core`); shared Angular
+  libraries moved to `shared-libs/ts-modules`; the SDK to `start-sdk`; and the `patch-db`
+  submodule to `shared-libs/crates/patch-db`. Builds now run against the root Cargo and
+  Angular workspaces (`cargo build -p start-os`, web from `shared-libs/ts-modules`).
 - **Firewall migrated from iptables to native nftables (5b9cf7313).** Every StartOS-managed rule now lives in a single `table ip startos` with stable comment tags for handle-based, idempotent teardown (per-forward DNAT/hairpin/masquerade, the FORWARD `policy drop`, lxcbr0 container-egress accept, and the mangle policy-routing marks). lxc-net and wg-quick keep their own iptables-nft rules in separate tables. The `nftables` package is added to dependencies.
 - **Manifest capability flags split (#3271, #3275).** The misleading `nestedRuntime` flag is replaced by two independent capabilities: `userspaceFilesystems` (mounts `/dev/fuse` for fuse-overlayfs storage) and `virtualNetworking` (mounts `/dev/net/tun` for VPN / WireGuard / tun workloads). Both are device grants only — the service LXC already retains `CAP_NET_ADMIN` within its user namespace via the standard `userns.conf` include, so no capability machinery is needed (an earlier `lxc.cap.drop` snippet that was wrongly framed as "re-granting `CAP_NET_ADMIN`" — and actually dropped five caps that were otherwise kept — was removed). Hard rename — packages using `nestedRuntime` must republish.
 - **Service-container memory isolation (#3304).** Every service container is placed in a `services.slice` opted into systemd-oomd PSI monitoring, capped at total RAM minus a fixed 1 GiB host reservation; `system.slice`/`user.slice` get `MemoryMin` floors. A burst of concurrent installs can no longer overcommit RAM and wedge the host.
@@ -85,6 +80,11 @@ file tracks notable changes since the move to the monorepo.
 - **The redundant "Plugin:" prefix is dropped from interface plugin labels (#3349)** — the plugin address group already sits within a plugin section.
 - **Login and CA-wizard UX cleanup (e86dcc242).** The login button uses an inline loading state that holds until navigation completes (replacing the global overlay loader) and is correctly centered; the CA wizard gets a solid card background, drops the redundant "Bookmark this page" step, and moves the "repeat on every device" caveat into a notification.
 - **`fedimintd` → `fedimint-guardian`** package-ID rename is handled across all four `0.3.5.1`→`0.4.0` migration paths (2a806d8b8).
+- **Allow non-ASCII characters in WiFi SSIDs (#3365).** Adding, connecting to, or
+  removing a WiFi network whose SSID contains non-ASCII characters (e.g. an accented
+  letter or a typographic apostrophe) no longer fails with "SSID may not have special
+  characters". SSIDs are passed to NetworkManager as-is; the WiFi passphrase still
+  requires ASCII, as mandated by WPA.
 
 ### Removed
 

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -1545,13 +1545,6 @@ net.tunnel.timeout-waiting-for-remove:
   pl_PL: "upłynął limit czasu oczekiwania na usunięcie bramy %{gateway} z bazy danych"
 
 # net/wifi.rs
-net.wifi.ssid-no-special-characters:
-  en_US: "SSID may not have special characters"
-  de_DE: "SSID darf keine Sonderzeichen enthalten"
-  es_ES: "El SSID no puede tener caracteres especiales"
-  fr_FR: "Le SSID ne peut pas contenir de caractères spéciaux"
-  pl_PL: "SSID nie może zawierać znaków specjalnych"
-
 net.wifi.password-no-special-characters:
   en_US: "WiFi Password may not have special characters"
   de_DE: "WiFi-Passwort darf keine Sonderzeichen enthalten"

--- a/shared-libs/crates/start-core/src/net/wifi.rs
+++ b/shared-libs/crates/start-core/src/net/wifi.rs
@@ -652,6 +652,25 @@ pub struct WifiInfoLow {
 
 #[derive(Clone, Debug)]
 pub struct Psk(String);
+
+/// Split a line of `nmcli -t`/`-g` terse output into fields, honoring nmcli's
+/// backslash escaping (`\:` is a literal colon, `\\` a literal backslash) so an
+/// SSID containing `:` stays one field instead of being split apart.
+fn split_nmcli_terse_line(line: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut field = String::new();
+    let mut chars = line.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => field.push(chars.next().unwrap_or('\\')),
+            ':' => fields.push(std::mem::take(&mut field)),
+            _ => field.push(c),
+        }
+    }
+    fields.push(field);
+    fields
+}
+
 impl WpaCli {
     pub fn new(interface: GatewayId) -> Self {
         WpaCli { interface }
@@ -790,21 +809,17 @@ impl WpaCli {
             .invoke(ErrorKind::Wifi)
             .await?;
         let r = String::from_utf8(r)?;
-        tracing::info!("JCWM: all the networks: {:?}", r);
         Ok(r.lines()
             .filter_map(|l| {
-                let mut cs = l.split(':');
-                let name = Ssid(cs.next()?.to_owned());
-                let uuid = NetworkId(cs.next()?.to_owned());
-                let connection_type = cs.next()?;
-                let device = cs.next();
+                let mut fields = split_nmcli_terse_line(l).into_iter();
+                let name = Ssid(fields.next()?);
+                let uuid = NetworkId(fields.next()?);
+                let connection_type = fields.next()?;
+                let device = fields.next();
                 if !connection_type.contains("wireless") {
                     return None;
                 }
-                let info = WifiInfoLow {
-                    ssid: name,
-                    device: device.map(|x| x.to_owned()),
-                };
+                let info = WifiInfoLow { ssid: name, device };
                 Some((uuid, info))
             })
             .collect::<BTreeMap<NetworkId, WifiInfoLow>>())
@@ -823,9 +838,10 @@ impl WpaCli {
         Ok(String::from_utf8(r)?
             .lines()
             .filter_map(|l| {
-                let mut values = l.split(':');
-                let ssid = Ssid(values.next()?.to_owned());
-                let signal = SignalStrength::new(std::str::FromStr::from_str(values.next()?).ok());
+                let mut values = split_nmcli_terse_line(l).into_iter();
+                let ssid = Ssid(values.next()?);
+                let signal =
+                    SignalStrength::new(std::str::FromStr::from_str(values.next()?.as_str()).ok());
                 let security: Vec<String> =
                     values.next()?.split(' ').map(|x| x.to_owned()).collect();
                 Some((
@@ -1113,4 +1129,32 @@ pub async fn synchronize_network_manager<P: AsRef<Path>>(
             .await?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_nmcli_terse_line;
+
+    #[test]
+    fn terse_line_unescapes_colon_and_backslash() {
+        // nmcli `-t` escapes `:` as `\:` and `\` as `\\` within a field.
+        let line = r"my\:wifi\\x:61f7f9e2:802-11-wireless:";
+        assert_eq!(
+            split_nmcli_terse_line(line),
+            vec![
+                "my:wifi\\x".to_owned(),
+                "61f7f9e2".to_owned(),
+                "802-11-wireless".to_owned(),
+                String::new(),
+            ],
+        );
+    }
+
+    #[test]
+    fn terse_line_plain_fields() {
+        assert_eq!(
+            split_nmcli_terse_line("café:90:WPA2 WPA3"),
+            vec!["café".to_owned(), "90".to_owned(), "WPA2 WPA3".to_owned()],
+        );
+    }
 }

--- a/shared-libs/crates/start-core/src/net/wifi.rs
+++ b/shared-libs/crates/start-core/src/net/wifi.rs
@@ -232,12 +232,6 @@ pub async fn add(
     WifiAddParams { ssid, password }: WifiAddParams,
 ) -> Result<(), Error> {
     let mut wpa_supplicant = ctx.write_wifi_manager().await?;
-    if !ssid.is_ascii() {
-        return Err(Error::new(
-            color_eyre::eyre::eyre!("{}", t!("net.wifi.ssid-no-special-characters")),
-            ErrorKind::Wifi,
-        ));
-    }
     let ssid = Ssid(ssid);
     if !password.is_ascii() {
         return Err(Error::new(
@@ -295,12 +289,6 @@ pub async fn connect(
     WifiSsidParams { ssid }: WifiSsidParams,
 ) -> Result<(), Error> {
     let mut wpa_supplicant = ctx.write_wifi_manager().await?;
-    if !ssid.is_ascii() {
-        return Err(Error::new(
-            color_eyre::eyre::eyre!("{}", t!("net.wifi.ssid-no-special-characters")),
-            ErrorKind::Wifi,
-        ));
-    }
     if let Err(err) = async {
         let current = wpa_supplicant.get_current_network().await?;
         let connected = wpa_supplicant
@@ -360,12 +348,6 @@ pub async fn connect(
 #[instrument(skip_all)]
 pub async fn remove(ctx: RpcContext, WifiSsidParams { ssid }: WifiSsidParams) -> Result<(), Error> {
     let mut wpa_supplicant = ctx.write_wifi_manager().await?;
-    if !ssid.is_ascii() {
-        return Err(Error::new(
-            color_eyre::eyre::eyre!("{}", t!("net.wifi.ssid-no-special-characters")),
-            ErrorKind::Wifi,
-        ));
-    }
     let current = wpa_supplicant.get_current_network().await?;
     let ssid = Ssid(ssid);
     let is_current_being_removed = matches!(current, Some(current) if current == ssid);


### PR DESCRIPTION
Closes #3365.

## Summary

Adding, connecting to, or removing a WiFi network whose SSID contains a non-ASCII character (e.g. an accented letter or a typographic apostrophe `'`) failed with **"WiFi Internal Error SSID may not have special characters"**.

The cause is an `if !ssid.is_ascii()` guard at all three WiFi RPC entry points (`add`, `connect`, `remove`) in `net/wifi.rs`. 802.11 defines an SSID as 0–32 arbitrary octets — non-ASCII is valid, and plenty of real networks use it. This guard is unchanged from 0.3.5.1, so the restriction is live in 0.4.0.

This drops the SSID guard at all three sites. The SSID is handed to NetworkManager (`nmcli`) as a direct argv argument — a Rust `String` is always valid UTF-8 and NetworkManager handles UTF-8 SSIDs natively — so there's no quoting/shell hazard.

The **passphrase** `is_ascii()` check is intentionally kept: WPA-PSK passphrases must be 8–63 printable ASCII characters per 802.11i.

The now-unused `net.wifi.ssid-no-special-characters` i18n key is removed from all five locales.

## Notes

- A plain straight apostrophe (`'`, ASCII) was already accepted; the reporter's error implies a non-ASCII character (most likely a typographic `'` auto-substituted by their device).
- Changelog entry added under `0.4.0-beta.10` (StartOS).