### PR TITLE
fix: wrap markdown code blocks in dialogs to prevent notification text overflow

### DIFF
--- a/shared-libs/ts-modules/shared/src/components/markdown.component.ts
+++ b/shared-libs/ts-modules/shared/src/components/markdown.component.ts
@@ -27,6 +27,12 @@ import { getErrorMessage } from '../services/error.service'
       }
     }
   `,
+  styles: `
+    :host ::ng-deep pre {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+  `,
   host: { class: 'g-subpage' },
   imports: [
     TuiNotification,


### PR DESCRIPTION
## Summary

Fixes #3377. Long service-log lines in the notification **View details** dialog ran off the right edge of the box instead of wrapping.

The service message is rendered through the shared `MarkdownComponent`. When the log portion is an indented (or fenced) block, `marked` emits a `<pre><code>` element, and `<pre>` defaults to `white-space: pre` — so long lines don't wrap and overflow the dialog horizontally (the surrounding paragraphs wrapped fine).

The fix scopes a `pre` rule to the markdown dialog so code blocks wrap within the box while preserving their line breaks:

```css
:host ::ng-deep pre {
  white-space: pre-wrap;
  overflow-wrap: anywhere;
}
```

This applies everywhere the shared markdown dialog is used (notification details, OS release notes, sideload notes, marketplace descriptions) — a modal that renders arbitrary service/markdown content shouldn't overflow horizontally in any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)