### PR TITLE
ci: move service-package CI actions off deprecated node 20 runtime

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -26,7 +26,7 @@ runs:
         toolchain: stable
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker
       uses: docker/setup-docker-action@v5

--- a/.github/actions/upload-each/action.yml
+++ b/.github/actions/upload-each/action.yml
@@ -17,5 +17,5 @@ inputs:
     required: false
     default: "warn"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,7 +237,7 @@ jobs:
         shell: bash
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.TAG || github.ref_name }}
           name: ${{ steps.version.outputs.version }}

--- a/.github/workflows/tagAndRelease.yml
+++ b/.github/workflows/tagAndRelease.yml
@@ -107,7 +107,7 @@ jobs:
         # delete the existing GitHub release here: if the downstream build
         # fails (e.g. transient infra issue), the previous release stays
         # intact and the registry's download URLs keep resolving. On a
-        # successful build, softprops/action-gh-release@v2 updates the
+        # successful build, softprops/action-gh-release@v3 updates the
         # release in place and replaces same-named assets.
         run: |
           TAG="${{ steps.extract.outputs.tag }}"


### PR DESCRIPTION
## Summary

GitHub is deprecating the Node 20 Actions runtime. The reusable service-package CI — the `workflow_call` workflows/actions that external `*-startos` repos consume — still pinned three actions on Node 20, surfacing deprecation annotations on every service build/release. This bumps them to the current Node 24 majors.

| Location | Action | Was | Now |
|---|---|---|---|
| `.github/actions/setup-build-env/action.yml` | `docker/setup-qemu-action` | `@v3` | `@v4` |
| `.github/workflows/release.yml` | `softprops/action-gh-release` | `@v2` | `@v3` |
| `.github/actions/upload-each/action.yml` | in-repo JS action | `using: node20` | `using: node24` |

Plus a stale version reference in a `tagAndRelease.yml` comment (`@v2` → `@v3`).

## Notes

- Both third-party bumps are **runtime-only major versions** — their v4.0.0 / v3.0.0 release notes state the only change is moving the runtime to Node 24; no input or behavior changes affect our usage.
- `upload-each`'s `dist/index.js` bundle is unchanged — Node 24 runs the existing node20-compiled bundle; only the `using:` declaration governs the runtime.
- The monorepo's **own** product CI (`.github/actions/setup-build`) was already on `@v4`; this only touches the service-package path (`setup-build-env`, used by `build.yml`/`release.yml`).
- No package-template or docs mirror needed: those copies are thin `uses:` wrappers and don't reference these action versions (per the AGENTS.md coupling rule, only the caller-facing surface — inputs/action names/file layout — mirrors; internal action versions don't).