### PR TITLE
feat: show inherited WAN IP in StartTunnel subnet and device tables

### DIFF
--- a/projects/start-tunnel/web/src/app/routes/home/components/wan.ts
+++ b/projects/start-tunnel/web/src/app/routes/home/components/wan.ts
@@ -60,8 +60,14 @@ export function toWanItems(options: readonly string[]): readonly WanItem[] {
 
 export const matchWan = (a: WanItem, b: WanItem) => a.ip === b.ip
 
-// `defaultLabel` names what the null/default option inherits from, e.g.
-// "Use System Default" (subnet) or "Use Subnet Default" (device).
-export function wanLabel(ip: string | null, defaultLabel: string): string {
-  return ip ?? defaultLabel
+// `defaultLabel` names what the null/default option inherits from — "System
+// default" (subnet) or "Subnet default" (device). When that default resolves to
+// a known address, show it parenthetically, e.g. "System default (1.2.3.4)".
+export function wanLabel(
+  ip: string | null,
+  defaultLabel: string,
+  inheritedIp: string | null = null,
+): string {
+  if (ip) return ip
+  return inheritedIp ? `${defaultLabel} (${inheritedIp})` : defaultLabel
 }

--- a/projects/start-tunnel/web/src/app/routes/home/routes/devices/add.ts
+++ b/projects/start-tunnel/web/src/app/routes/home/routes/devices/add.ts
@@ -212,8 +212,18 @@ export class DevicesAdd {
   protected readonly stringify = ({ range, name }: MappedSubnet) =>
     range ? `${name} (${range})` : ''
   protected readonly stringifyWan = ({ ip }: WanItem) =>
-    wanLabel(ip, 'Use Subnet Default')
+    wanLabel(ip, 'Subnet default', this.subnetWanIp())
   protected readonly matchWan = matchWan
+
+  // The address the device inherits on "Subnet default": the selected subnet's
+  // own WAN override, or the system default when the subnet has none.
+  private subnetWanIp(): string | null {
+    const range = this.form.controls.subnet.value?.range
+    return (
+      this.context.data.subnets().find(s => s.range === range)?.wanIp ??
+      this.context.data.defaultWan
+    )
+  }
 
   protected onSubnet(subnet: MappedSubnet) {
     this.form.controls.ip.clearValidators()

--- a/projects/start-tunnel/web/src/app/routes/home/routes/devices/index.ts
+++ b/projects/start-tunnel/web/src/app/routes/home/routes/devices/index.ts
@@ -53,7 +53,7 @@ import { MappedDevice } from './utils'
             <th>LAN IP</th>
             <th>DNS Injection</th>
             <th>Auto Port Forward</th>
-            <th>WAN</th>
+            <th>WAN IP</th>
             <th></th>
           </tr>
         </thead>
@@ -97,7 +97,7 @@ import { MappedDevice } from './utils'
                   />
                 </tui-loader>
               </td>
-              <td>{{ wanLabel(device.wanIp, 'Use Subnet Default') }}</td>
+              <td>{{ device.wan }}</td>
               <td [style.padding-inline-end.rem]="0.625">
                 <button
                   tuiIconButton
@@ -172,7 +172,7 @@ import { MappedDevice } from './utils'
             <th>Name</th>
             <th>Subnet</th>
             <th>LAN IP</th>
-            <th>WAN</th>
+            <th>WAN IP</th>
             <th></th>
           </tr>
         </thead>
@@ -182,7 +182,7 @@ import { MappedDevice } from './utils'
               <td>{{ device.name }}</td>
               <td>{{ device.subnet.name }}</td>
               <td>{{ device.ip }}</td>
-              <td>{{ wanLabel(device.wanIp, 'Use Subnet Default') }}</td>
+              <td>{{ device.wan }}</td>
               <td [style.padding-inline-end.rem]="0.625">
                 <button
                   tuiIconButton
@@ -270,8 +270,6 @@ export default class Devices {
   private readonly errorService = inject(ErrorService)
   private readonly patch = inject<PatchDB<TunnelData>>(PatchDB)
 
-  protected readonly wanLabel = wanLabel
-
   protected readonly togglingDns = signal<string | null>(null)
   protected readonly togglingPf = signal<string | null>(null)
 
@@ -288,18 +286,21 @@ export default class Devices {
   protected readonly subnets = toSignal(
     this.patch.watch$('wg', 'subnets').pipe(
       map(subnets =>
-        Object.entries(subnets).map(([range, { name, clients }]) => ({
+        Object.entries(subnets).map(([range, { name, clients, wanIp }]) => ({
           range,
           name,
           clients,
+          wanIp,
         })),
       ),
     ),
     { initialValue: null },
   )
 
-  protected readonly devices = computed(() =>
-    this.subnets()?.flatMap(subnet =>
+  protected readonly devices = computed(() => {
+    const defaultWan = this.defaultWan()
+
+    return this.subnets()?.flatMap(subnet =>
       Object.entries(subnet.clients).map(
         ([
           ip,
@@ -315,10 +316,11 @@ export default class Devices {
           allowDnsInjection,
           allowAutoPortForward,
           wanIp,
+          wan: wanLabel(wanIp, 'Subnet default', subnet.wanIp ?? defaultWan),
         }),
       ),
-    ),
-  )
+    )
+  })
 
   protected readonly servers = computed(() =>
     this.devices()?.filter(d => d.kind === 'server'),

--- a/projects/start-tunnel/web/src/app/routes/home/routes/devices/utils.ts
+++ b/projects/start-tunnel/web/src/app/routes/home/routes/devices/utils.ts
@@ -20,6 +20,7 @@ export interface MappedSubnet {
   readonly range: string
   readonly name: string
   readonly clients: T.Tunnel.WgSubnetClients
+  readonly wanIp: string | null
 }
 
 export interface DeviceData {

--- a/projects/start-tunnel/web/src/app/routes/home/routes/subnets/add.ts
+++ b/projects/start-tunnel/web/src/app/routes/home/routes/subnets/add.ts
@@ -219,7 +219,7 @@ export class SubnetsAdd {
   protected readonly modeLabel = (m: T.Tunnel.DnsMode) => MODE_LABEL[m]
   protected readonly matchWan = matchWan
   protected readonly stringifyWan = ({ ip }: WanItem) =>
-    wanLabel(ip, 'Use System Default')
+    wanLabel(ip, 'System default', this.context.data.defaultWan)
   protected readonly stringifyDevice = ({ ip, name }: MappedDevice) =>
     ip ? `${name} (${ip})` : ''
 

--- a/projects/start-tunnel/web/src/app/routes/home/routes/subnets/index.ts
+++ b/projects/start-tunnel/web/src/app/routes/home/routes/subnets/index.ts
@@ -44,7 +44,7 @@ import { SUBNETS_ADD } from './add'
             <th>Name</th>
             <th>IP Range</th>
             <th>DNS</th>
-            <th>WAN</th>
+            <th>WAN IP</th>
             <th></th>
           </tr>
         </thead>
@@ -54,7 +54,9 @@ import { SUBNETS_ADD } from './add'
               <td>{{ subnet.name }}</td>
               <td>{{ subnet.range }}</td>
               <td>{{ subnet.dnsLabel }}</td>
-              <td>{{ wanLabel(subnet.wanIp, 'Use System Default') }}</td>
+              <td>
+                {{ wanLabel(subnet.wanIp, 'System default', defaultWan()) }}
+              </td>
               <td [style.padding-inline-end.rem]="0.625">
                 <button
                   tuiIconButton


### PR DESCRIPTION
## Summary

Clarifies the WAN column in StartTunnel's Subnets and Devices (Servers/Clients) tables.

- Renames the `WAN` column to **WAN IP** in the subnet table and both device tables.
- When a row inherits its egress address instead of overriding it, the cell now shows what it resolves to rather than a bare "use default":
  - subnets → `System default (<ip>)` (the detected system default WAN)
  - devices → `Subnet default (<ip>)` — the device's subnet WAN override, falling back to the system default when the subnet has none
- The same labels appear in the Add/Edit dialogs' **WAN IP** selects.
- Falls back gracefully to plain `System default` / `Subnet default` when no address is known (e.g. no gateway detected yet).

## Implementation notes

- `wanLabel(ip, defaultLabel, inheritedIp?)` gained the optional `inheritedIp` arg; it appends `(<ip>)` when known.
- Device labels are precomputed as a `wan` field on the mapped row (reading `defaultWan()` in the `devices` computed so it stays reactive), matching the existing `dnsLabel` precompute pattern — this also avoids an Angular-template vs. prettier trailing-comma conflict on a multi-line call.
- `MappedSubnet` now carries `wanIp` so the device form can resolve its subnet's effective WAN.

No `docs/` change: the WAN field isn't documented in `subnets.md`/`devices.md`. No `CHANGELOG.md` entry added — this refines the (not-yet-logged) per-subnet/device WAN-IP feature; happy to add an `[Unreleased]` note if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)