### PR TITLE
fix(auth): re-sync unix password on reset-password so SSH tracks the …

### DIFF
--- a/shared-libs/crates/start-core/src/auth.rs
+++ b/shared-libs/crates/start-core/src/auth.rs
@@ -505,7 +505,9 @@ pub async fn reset_password_impl(
         account.set_password(&new_password)?;
         Ok(account.clone())
     })?;
-    ctx.db.mutate(|d| account.save(d)).await.result
+    ctx.db.mutate(|d| account.save(d)).await.result?;
+    write_shadow(&new_password).await?;
+    Ok(())
 }
 
 #[instrument(skip_all)]


### PR DESCRIPTION
…current password

reset_password_impl updated only the account (argon2) hash used for web-UI login, never the start9/kiosk unix password in /etc/shadow. write_shadow runs at setup and as a one-time login migration (both gated on the overlay shadow file being absent), so after any password change via the UI the SSH and local console password silently stayed at the original setup password.

Call write_shadow with the new password after persisting the account, mirroring the setup flow, so a reset keeps the unix password (start9 + kiosk) in sync.