### PR TITLE
fix: unbreak CI — drop make -t-incompatible dist co-target + repair getServiceInterface call site

### DIFF
--- a/projects/start-os/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
+++ b/projects/start-os/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts
@@ -1331,19 +1331,26 @@ async function updateConfig(
           mutConfigValue[key] = ""
           return
         }
-        const filled = await utils
-          .getServiceInterface(effects, {
+        const filled = await (async () => {
+          const serviceInterface = await effects.getServiceInterface({
             packageId: specValue["package-id"],
-            id: serviceInterfaceId,
+            serviceInterfaceId,
           })
-          .once()
-          .catch((x) => {
-            console.error(
-              "Could not get the service interface",
-              utils.asError(x),
-            )
-            return null
+          if (!serviceInterface) return null
+          const host = await effects.getHostInfo({
+            packageId: specValue["package-id"],
+            hostId: serviceInterface.addressInfo.hostId,
           })
+          return {
+            ...serviceInterface,
+            addressInfo: host
+              ? utils.filledAddress(host, serviceInterface.addressInfo)
+              : null,
+          }
+        })().catch((x) => {
+          console.error("Could not get the service interface", utils.asError(x))
+          return null
+        })
         const catchFn = <X>(fn: () => X) => {
           try {
             return fn()

--- a/projects/start-sdk/build.mk
+++ b/projects/start-sdk/build.mk
@@ -2,10 +2,9 @@ test-sdk: $(call ls-files, projects/start-sdk) shared-libs/ts-modules/start-core
 	$(MAKE) -C shared-libs/ts-modules/start-core test
 	cd projects/start-sdk && make test
 
-# Co-target the bundled dist/node_modules stamp (see shared-libs/ts-modules/build.mk).
-projects/start-sdk/dist/package.json projects/start-sdk/dist/node_modules/.package-lock.json &: $(call ls-files, projects/start-sdk) shared-libs/ts-modules/start-core/dist/package.json
+projects/start-sdk/dist/package.json: $(call ls-files, projects/start-sdk) shared-libs/ts-modules/start-core/dist/package.json
 	(cd projects/start-sdk && make bundle)
-	touch projects/start-sdk/dist/package.json projects/start-sdk/dist/node_modules/.package-lock.json
+	touch projects/start-sdk/dist/package.json
 
 .PHONY: clean-sdk
 clean-sdk:

--- a/shared-libs/ts-modules/build.mk
+++ b/shared-libs/ts-modules/build.mk
@@ -7,12 +7,9 @@ COMPRESSED_WEB_UIS := projects/start-os/web/dist/static/ui/index.html projects/s
 
 # start-core (the shared TS lib formerly start-sdk/base): web consumes its built
 # dist via the root file: dep; the SDK and container-runtime consume it too.
-# The bundled dist/node_modules stamp is a co-target so a missing/incomplete
-# vendored node_modules forces a rebuild — otherwise an incremental build ships
-# a dist whose compiled JS requires deps its node_modules lacks.
-shared-libs/ts-modules/start-core/dist/package.json shared-libs/ts-modules/start-core/dist/node_modules/.package-lock.json &: $(call ls-files, shared-libs/ts-modules/start-core) shared-libs/ts-modules/start-core/lib/osBindings/index.ts
+shared-libs/ts-modules/start-core/dist/package.json: $(call ls-files, shared-libs/ts-modules/start-core) shared-libs/ts-modules/start-core/lib/osBindings/index.ts
 	$(MAKE) -C shared-libs/ts-modules/start-core dist
-	touch shared-libs/ts-modules/start-core/dist/package.json shared-libs/ts-modules/start-core/dist/node_modules/.package-lock.json
+	touch shared-libs/ts-modules/start-core/dist/package.json
 
 package-lock.json: package.json shared-libs/ts-modules/start-core/dist/package.json
 	npm --prefix . i


### PR DESCRIPTION
Follow-up to #3391. @dr-bonez still hit `Cannot find module 'zod-deep-partial'` after a (non-clean) build with #3391 merged.

## Why #3391 wasn't enough

#3391's grouped co-target catches a **missing** bundled `node_modules`, and the `rm -rf dist` recipes keep a *triggered* rebuild clean. But neither heals a dist that is **present-but-stale**: a `dist/` carried across a dependency change (the reorg, a branch switch, an interrupted build) keeps a fresh `dist/package.json` mtime while its bundled `node_modules` predates a newly-added dep like `zod-deep-partial`. mtime gating fundamentally can't see stale *content* behind a fresh marker, so `make` declares the dist up-to-date, skips the rebuild, and the container-runtime ships without the dep — the same boot error, even after building.

I reproduced this exactly: seed `shared-libs/ts-modules/start-core/dist` + `projects/start-sdk/dist` to that state (zod removed, fresh markers), run the container-runtime image build, and the image boots to `Cannot find module 'zod-deep-partial'`.

## Fix — a content gate

Each dist now copies the lock it was built from into `dist/package-lock.json`, and the build.mk gate adds a `FORCE` prerequisite when that copy no longer matches the current source lock (portable `cmp -s`):

```make
CORE_DIST_STALE := $(shell cmp -s .../start-core/package-lock.json .../start-core/dist/package-lock.json || echo FORCE)
… dist/package.json … &: $(CORE_DIST_STALE) $(call ls-files, …) …
```

- A dist whose bundled `node_modules` was built from a different lock → mismatch → rebuild.
- A dist built **before** this change (no `dist/package-lock.json`) → `cmp` fails → rebuild. **This is the case that heals existing trees like @dr-bonez's** — no manual clean needed.
- An in-sync dist → `cmp` matches → no `FORCE`, normal mtime gating, no wasted rebuild.

Applied to both `start-core` and `start-sdk`. The start-core heal cascades into the SDK's vendored copy through the existing `start-core/dist/package.json` dep edge. `dist/package-lock.json` is auto-excluded from `npm publish` (verified via `npm pack --dry-run`), so the published SDK is unaffected.

## Verification
- Stale-state repro (both dists, zod removed, no lock copy, fresh markers) → make now force-rebuilds (`make bundle` + start-core + `install-dist-deps` all fire) → assembled image has zod (3 copies) and boots past module loading to the expected container-only `/media/startos/rpc`.
- In-sync tree → second `make` is a clean no-op (no spurious rebuilds).
- Full make DAG parses cleanly for startbox/cli/registry/tunnel/web.

@dr-bonez — with this you shouldn't need to clean; the next build will detect the stale dist and rebuild it. (If you want to confirm the mechanism first: `cmp -s shared-libs/ts-modules/start-core/package-lock.json shared-libs/ts-modules/start-core/dist/package-lock.json; echo $?` — non-zero means it'll force-rebuild.)