### PR TITLE
chore(release): give the SDK npm release a GitHub release + OTP prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the layout and [CONTRIBUTING.md](CONT
 
 **A product's user docs and changelog ship with the code.** Any change that alters user-visible behavior **must** update that product's user-facing documentation book (its `docs/` directory — e.g. `projects/start-os/docs/`, `projects/start-tunnel/docs/`, `projects/start-sdk/docs/`) in the **same change**, and **must** add a `CHANGELOG.md` entry for that product (a version bump always pairs with its changelog). Don't land code and defer its docs or changelog to a follow-up.
 
+**Read [CONTRIBUTING.md](CONTRIBUTING.md) before making *any* code changes.** It carries the build/test/format workflow and the commit/PR conventions every change must follow — read it first, before you touch code. This is hierarchical like `AGENTS.md`: if a subdirectory you touch carries its own `CONTRIBUTING.md`, read that one too — and any further nested `CONTRIBUTING.md` on the way down to the files you're editing — before changing anything there.
+
 **Read down into what you touch.** When you work in a subdirectory, first read its `AGENTS.md` — and any further nested `AGENTS.md` on the way down to the files you're editing — before changing anything. Each scope's docs assume you've read the scopes above it, so a subdir's `AGENTS.md` adds only its own rules on top of this root.
 
 ## Layout

--- a/projects/start-sdk/AGENTS.md
+++ b/projects/start-sdk/AGENTS.md
@@ -24,7 +24,7 @@ The TypeScript SDK (`@start9labs/start-sdk`) for building StartOS service packag
 | `make check` | `tsc --noEmit` |
 | `make fmt` / `make check-fmt` | Prettier write / check on all `.ts` |
 | `make link` | build + `npm link` from `dist/` for local package testing |
-| `make publish` | build, then `npm publish` from `dist/` (`OTP=…` for 2FA) |
+| `make publish` | build, then `npm publish` from `dist/` (`OTP=…` for 2FA, else prompts) |
 
 Tests are jest + ts-jest, Node only (no browser). Test files use `.test.ts`. The ExVer parser is generated from `shared-libs/ts-modules/start-core/lib/exver/exver.pegjs` via Peggy (`make` runs this for you).
 

--- a/projects/start-sdk/Makefile
+++ b/projects/start-sdk/Makefile
@@ -58,8 +58,14 @@ package-lock.json: package.json $(START_CORE_DIST)/package.json
 node_modules: package-lock.json $(START_CORE_DIST)/package.json
 	npm ci
 
+# Prompt for the npm 2FA OTP here (after the build) so it can't expire; OTP=… skips.
 publish: bundle test check-fmt package.json README.md LICENSE CHANGELOG.md
-	cd dist && npm publish --access=public --tag=latest $(if $(OTP),--otp=$(OTP))
+	@otp='$(OTP)'; \
+	if [ -z "$$otp" ] && [ -t 0 ]; then \
+		printf 'npm one-time password (OTP): ' >&2; \
+		read -r otp; \
+	fi; \
+	cd dist && npm publish --access=public --tag=latest $${otp:+--otp=$$otp}
 
 link: bundle
 	cd dist && npm link

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -7,7 +7,7 @@
 # See usage() for the subcommands. The <project> is one of the monorepo's
 # releasable products; its version is read from that product's canonical
 # manifest (Cargo.toml for the Rust products, package.json for the SDK) and its
-# git tag / GitHub release is <project>_v<version>.
+# git tag / GitHub release is <project>/v<version>.
 
 set -euo pipefail
 
@@ -355,15 +355,16 @@ cmd_pre_check() {
             ;;
     esac
 
-    # gh + the Start9 signing key are needed by every os/cli/deb release
-    # (create-gh-release, upload, sign — and the apt Release signature for debs).
+    # gh is needed by every release to create the GitHub release (plus the asset
+    # upload, sign, and apt Release signature for os/cli/deb).
+    if gh auth status >/dev/null 2>&1; then
+        echo "  ✓ gh authenticated"
+    else
+        >&2 echo "  ✗ gh not authenticated (run: gh auth login)"
+        errors=1
+    fi
+    # os/cli/deb also sign their artifacts with the Start9 org key.
     if [ "$KIND" != npm ]; then
-        if gh auth status >/dev/null 2>&1; then
-            echo "  ✓ gh authenticated"
-        else
-            >&2 echo "  ✗ gh not authenticated (run: gh auth login)"
-            errors=1
-        fi
         if gpg --list-secret-keys "$START9_GPG_KEY" >/dev/null 2>&1; then
             echo "  ✓ Start9 signing key ${START9_GPG_KEY} present"
         else
@@ -470,8 +471,10 @@ cmd_tag() {
 }
 
 cmd_create_gh_release() {
-    require_kind os cli deb
-    enter_release_dir
+    require_kind os cli deb npm
+    # os/cli/deb reference their pulled artifacts in the notes; npm (the SDK)
+    # ships to npm and its notes are just the changelog, so it needs no release dir.
+    [ "$KIND" = npm ] || enter_release_dir
     local notes
     notes=$(release_notes)
     echo "Creating GitHub release ${TAG}..."
@@ -639,8 +642,8 @@ checksum_block() {
 }
 
 cmd_notes() {
-    require_kind os cli deb
-    enter_release_dir
+    require_kind os cli deb npm
+    [ "$KIND" = npm ] || enter_release_dir
     release_notes
 }
 
@@ -667,8 +670,11 @@ cmd_release() {
             cmd_sign
             ;;
         npm)
+            # create-gh-release before push: everything idempotent runs ahead of
+            # the one irreversible step (npm publish can't be re-run for a version).
             cmd_pre_check
             cmd_tag
+            cmd_create_gh_release
             cmd_push
             ;;
     esac
@@ -683,10 +689,10 @@ Projects:
   start-cli       per-triple binaries -> GitHub release; per-arch .deb -> apt + GitHub
   start-tunnel    per-arch .deb -> apt repo + GitHub release
   start-registry  per-arch .deb -> apt repo + GitHub release
-  start-sdk       npm package -> npm
+  start-sdk       npm package -> npm + GitHub release
 
 Version is read from the project's manifest (Cargo.toml, or package.json for
-start-sdk); the git tag / GitHub release is <project>_v<version>.
+start-sdk); the git tag / GitHub release is <project>/v<version>.
 
 Subcommands:
   pre-check          Verify the changelog documents this version and that the
@@ -695,9 +701,9 @@ Subcommands:
                      (os/cli/deb; set RUN_ID or you'll be prompted.)
   pull               Download the released assets from their official location
                      (registry / apt repo / GitHub release / npm).
-  tag                Create and push the <project>_v<version> git tag.
+  tag                Create and push the <project>/v<version> git tag.
   create-gh-release  Create (or update) the GitHub release with notes.
-                     (os/cli/deb.)
+                     (all projects.)
   push               Upload artifacts to their destination (S3 for os, GitHub
                      release + apt for cli/deb, npm publish for sdk). For os this
                      normally runs in CI; use it for a manual re-publish.
@@ -708,7 +714,7 @@ Subcommands:
                      available) and upload signatures.tar.gz. (os/cli/deb.)
   cosign             Add your personal GPG signature to an existing release's
                      signatures.tar.gz. (os/cli/deb; run 'pull' first.)
-  notes              Print the release notes to stdout. (os/cli/deb.)
+  notes              Print the release notes to stdout. (all projects.)
   release            Run the full applicable pipeline for the project.
 
 Environment variables:
@@ -721,7 +727,8 @@ Environment variables:
                            npm republish always fails)
   CLEAN                    Set to 1 to wipe and recreate the release directory
   GH_USER                  Override GitHub username (default: autodetected via gh)
-  OTP                      npm one-time password (start-sdk publish)
+  OTP                      npm one-time password for start-sdk publish
+                           (prompted for at publish time if unset)
 
 Registries are scoped per project (only the OS promotes between registries):
   STARTOS_SOURCE_REGISTRY  registry the OS release pulls/promotes from (default: beta)
@@ -750,7 +757,7 @@ if [ -z "$VERSION" ]; then
     >&2 echo "Could not derive version for ${PROJECT}"
     exit 1
 fi
-TAG="${PROJECT}_v${VERSION}"
+TAG="${PROJECT}/v${VERSION}"
 
 case "$SUBCOMMAND" in
     pre-check) cmd_pre_check ;;


### PR DESCRIPTION
## What

Two independent changes bundled from local working state:

### Release tooling (`scripts/manage-release.sh`, SDK `Makefile`/`AGENTS.md`)
Bring the start-sdk (npm) release into parity with the os/cli/deb flows:

- **`create-gh-release` + `notes` now support `npm`.** The SDK release pipeline runs `create-gh-release` between `tag` and `push`, so every idempotent step precedes the one irreversible step (`npm publish` can't be re-run for a version). npm skips the release-dir requirement since its notes are just the changelog.
- **`gh` auth is now a pre-check for every project.** It was gated behind non-npm; npm now needs it to cut its GitHub release. GPG signing-key check stays os/cli/deb-only.
- **Release tag/release scheme: `<project>_v<version>` → `<project>/v<version>`** (comment, usage text, and the `TAG=` line).
- **Prompt for the npm OTP at publish time** (after the build, so it can't expire) when `OTP` is unset and stdin is a tty; `OTP=…` still skips. Usage/env-var docs and the SDK `AGENTS.md` publish row updated to match.

### Root docs (`AGENTS.md`)
Add a rule to read `CONTRIBUTING.md` before any code change, noting it's hierarchical like `AGENTS.md` (read nested `CONTRIBUTING.md`s on the way down too).

## Notes

Release-tooling only — no product/runtime code touched. Shell script, Makefile, and Markdown are outside the `make format` targets, so no formatting pass applies.