### PR TITLE
fix(install): keep the Updates-tab progress circle live through finalization

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -124,6 +124,14 @@ file tracks notable changes since the move to the monorepo.
   characters". SSIDs are passed to NetworkManager as-is, and SSIDs containing a colon
   are now parsed correctly when listing connections. The WiFi passphrase still
   requires ASCII, as mandated by WPA.
+- **Updates-tab progress circle vanishing during install finalization.** A
+  package update marked the overall install progress complete right after the
+  old version was uninstalled — before the new version's finalization/init
+  progress (added with package init progress reporting, #3323) had run — so the
+  Updates-tab loading circle snapped to full and then disappeared partway
+  through "installing/finalizing". Overall progress now completes only once the
+  package is fully installed, so the circle keeps tracking live finalization
+  progress until the update finishes.
 
 ### Removed
 

--- a/shared-libs/crates/start-core/src/service/service_map.rs
+++ b/shared-libs/crates/start-core/src/service/service_map.rs
@@ -356,7 +356,6 @@ impl ServiceMap {
                             )
                         };
                         let cleanup = service.uninstall(uninit, false, false).await?;
-                        progress.complete();
                         Some(cleanup)
                     } else {
                         None


### PR DESCRIPTION
## Problem

After the install progress sub-phases work (**#3323**, "package init progress reporting"), the Updates tab has a regression: partway through an update — around the "installing/finalizing" phase — the loading circle snaps to full and then disappears, well before the package is actually installed. It should stay visible and keep advancing until the update finishes.

## Root cause

In the **update-only** branch of `ServiceMap::install` (`shared-libs/crates/start-core/src/service/service_map.rs`), immediately after the old service is uninstalled, the code called:

```rust
let cleanup = service.uninstall(uninit, false, false).await?;
progress.complete();   // <-- premature
```

`progress.complete()` marks the shared `FullProgressTracker`'s **overall** progress `Complete(true)` — *before* `Service::install` runs the new version's finalization/init phase. Two things follow on the next sync tick:

1. The `sync_to_db` task breaks permanently (its loop exits as soon as `overall.is_complete()`), so no further progress reaches patch-db.
2. The live init sub-progress that **#3323** now streams into that finalization phase (via the `set-init-progress` effect) is written to the tracker but never synced.

The `installingProgress` pipe maps a complete `overall` to `100`, so the `<tui-progress-circle>` (rendered only under `@if (state === 'updating')`) jumps to full and freezes; it then vanishes entirely when `Service::install` flips the state to `Installed` and the row leaves the Updates list.

This line has existed since 2024 and was *cosmetically* harmless before #3323, because back then `finalization_progress` wasn't passed into `Service::new` — there was no live sub-progress to truncate. #3323 wired real init progress into that phase, turning the long-standing prematurity into a visible regression. Overall progress is already completed at the correct place — the end of `Service::install` (`service/mod.rs`, after the state flips to Installed).

## Fix

Remove the premature `progress.complete();`. The update path now behaves like the fresh-install path (which never had this call and already worked): overall progress completes only once init has run and the package is fully installed, so the circle tracks live finalization progress the whole way through.

- The `sync_to_db` task still terminates cleanly — once state is `Installed`, its deref returns `None` (no `installingInfo`), and `overall_progress.complete()` fires right after. No hang.
- `progress` stays owned/used (moved into `InstallProgressHandles`, cloned into the sync task), so no borrow fallout.
- Fresh-install and restore paths take the other branch and are unchanged.

## Testing

- `cargo check -p start-core` — clean (only pre-existing warnings).
- Rust-only, one-line change; no `#[ts(export)]` types, RPC surface, or platform APIs touched, so the darwin/musl CI matrix is unaffected and no ts-bindings rebuild is needed.
- **Not reproducible on the web mock** (it keeps `overall` a climbing value through finalization and never completes it early), so it needs manual confirmation on a real server: install a package, then update it, and watch the Updates-tab circle stay visible and keep advancing through "installing/finalizing" until the package reaches Installed.

CHANGELOG updated under `0.4.0-beta.10 → Fixed`.