### PR TITLE
ci(start-cli): reuse Build Binary artifact for the deb, fix arch selector

### DIFF
--- a/.github/workflows/start-cli.yaml
+++ b/.github/workflows/start-cli.yaml
@@ -78,10 +78,10 @@ jobs:
               "x86_64": ["x86_64-unknown-linux-musl"],
               "x86_64-apple": ["x86_64-apple-darwin"],
               "aarch64": ["aarch64-unknown-linux-musl"],
-              "x86_64-apple": ["aarch64-apple-darwin"],
+              "aarch64-apple": ["aarch64-apple-darwin"],
               "riscv64": ["riscv64gc-unknown-linux-musl"],
               "ALL": ["x86_64-unknown-linux-musl", "x86_64-apple-darwin", "aarch64-unknown-linux-musl", "aarch64-apple-darwin", "riscv64gc-unknown-linux-musl"]
-            }')[github.event.inputs.platform || 'ALL']
+            }')[github.event.inputs.arch || 'ALL']
           }}
     runs-on: ${{ fromJson('["ubuntu-latest", "ubuntu-24.04-32-cores"]')[github.event.inputs.runner == 'fast'] }}
     steps:
@@ -112,7 +112,11 @@ jobs:
 
   deb:
     name: Build Debian Package
-    if: github.event.pull_request.draft != true
+    needs: [compile]
+    # Skip apple-only arch selections — macOS targets have no .deb. The matrix
+    # selector below still resolves to a valid (unused) value so evaluation never
+    # errors; this `if` is what actually prevents the job from running.
+    if: ${{ github.event.pull_request.draft != true && !contains(github.event.inputs.arch, 'apple') }}
     strategy:
       fail-fast: true
       matrix:
@@ -123,7 +127,7 @@ jobs:
               "aarch64": ["aarch64"],
               "riscv64": ["riscv64"],
               "ALL": ["x86_64", "aarch64", "riscv64"]
-            }')[github.event.inputs.platform || 'ALL']
+            }')[contains(github.event.inputs.arch, 'apple') && 'ALL' || github.event.inputs.arch || 'ALL']
           }}
     runs-on: ${{ fromJson('["ubuntu-latest", "ubuntu-24.04-32-cores"]')[github.event.inputs.runner == 'fast'] }}
     steps:
@@ -132,10 +136,40 @@ jobs:
         run: sudo mount -t tmpfs tmpfs .
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
+          # cli debs never need the openwrt submodule (see Build Binary above).
+          submodules: false
       - uses: ./.github/actions/setup-build
         with:
           nodejs-version: ${{ env.NODEJS_VERSION }}
+
+      - name: Resolve musl target triple
+        id: triple
+        run: |
+          case "${{ matrix.arch }}" in
+            x86_64)  triple=x86_64-unknown-linux-musl ;;
+            aarch64) triple=aarch64-unknown-linux-musl ;;
+            riscv64) triple=riscv64gc-unknown-linux-musl ;;
+            *) echo "::error::unsupported arch ${{ matrix.arch }}"; exit 1 ;;
+          esac
+          echo "triple=$triple" >> "$GITHUB_OUTPUT"
+
+      - name: Download Build Binary
+        uses: actions/download-artifact@v8
+        with:
+          name: start-cli_${{ steps.triple.outputs.triple }}
+          path: target/${{ steps.triple.outputs.triple }}/release
+
+      - name: Stamp prebuilt binary as up-to-date
+        # Drop the compiled binary where `make cli-deb` expects it and mark it
+        # newer than its Make prerequisites (the generated env/git-hash stamp
+        # files + checked-out sources) so packaging skips a redundant recompile.
+        run: |
+          bin="target/${{ steps.triple.outputs.triple }}/release/start-cli"
+          chmod +x "$bin"
+          ./build/env/check-environment.sh >/dev/null
+          ./build/env/check-git-hash.sh >/dev/null
+          PLATFORM="${{ matrix.arch }}" ./build/env/check-platform.sh >/dev/null
+          touch "$bin"
 
       - name: Make
         run: make cli-deb


### PR DESCRIPTION
## Why

Two issues in `.github/workflows/start-cli.yaml`:

1. **The `Build Debian Package` job recompiled `start-cli` from scratch** instead of
   consuming the binary the `Build Binary` (`compile`) job already produced. The two
   jobs ran independently — no `needs:`, no artifact handoff — so every push built the
   same musl binaries twice.
2. **Both build matrices keyed off `github.event.inputs.platform`, which is not a real
   input** (the `workflow_dispatch` input is named `arch`). So the manual arch picker
   was a dead knob that always fell through to `ALL`. The `compile` matrix also had a
   duplicate `x86_64-apple` key that shadowed `aarch64-apple` and mismapped the darwin
   triple.

## What

- **`deb` now `needs: [compile]`**, downloads the matching `start-cli_<triple>` musl
  artifact into `target/<triple>/release/`, and stamps it newer than its Make
  prerequisites (the generated `ENVIRONMENT`/`GIT_HASH`/`PLATFORM` stamp files + the
  checked-out sources) so `make cli-deb` skips the redundant recompile and goes
  straight to `debian/build.sh`.
- Point both matrix selectors at `github.event.inputs.arch`.
- Fix the duplicate `x86_64-apple` matrix key → `aarch64-apple`.
- Skip apple-only arch selections in the `deb` job (macOS targets have no `.deb`); the
  matrix selector still resolves to a valid unused value so evaluation never errors.
- Drop the needless `submodules: recursive` from the `deb` checkout — cli debs never
  need the openwrt submodule.

## Verification

Simulated the reuse locally with a placeholder binary stamped at the expected path:

- `make -n cli-deb PLATFORM=x86_64` plans only `debian/build.sh` — **no `build-cli.sh`**.
- The nested `make install-cli` (run inside `debian/build.sh`) also skips the recompile.
- Confirmed the stamp files' mtimes stay stable across a re-parse (content unchanged →
  no rewrite), so the binary remains newest through both the outer and nested make runs.

No changelog/docs update needed — CI plumbing only, no user-visible behavior and no
build inputs changed (the `paths:` ↔ `build.mk` mirror is untouched).
