### PR TITLE
fix(container-runtime): build image node_modules with --install-links

### DIFF
--- a/projects/start-os/container-runtime/install-dist-deps.sh
+++ b/projects/start-os/container-runtime/install-dist-deps.sh
@@ -5,6 +5,6 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 set -e
 
 cat ./package.json | sed 's/file:\.\([.\/]\)/file:..\/.\1/g' > ./dist/package.json
-cat ./package-lock.json | sed 's/"\.\([.\/]\)/"..\/.\1/g' > ./dist/package-lock.json
 
-npm --prefix dist ci --omit=dev
+# --install-links materializes the file: deps' transitive tree (e.g. zod-deep-partial) as real files, not symlinks
+npm --prefix dist install --install-links --omit=dev


### PR DESCRIPTION
## Problem

Non-clean (incremental) builds ship a container image whose `node_modules` is missing `zod-deep-partial` (and, in principle, any other non-bundled transitive runtime dep of the `@start9labs/*` packages). Services fail at startup because `@start9labs/start-core`'s `zExport.js` does `require("zod-deep-partial")` and it isn't there.

## Why it only broke on subsequent builds

`install-dist-deps.sh` builds the image's `node_modules`. It used `npm ci`, which only recreated the `@start9labs/*` `file:` deps as **symlinks** and installed none of their transitive tree. The image's copy of those deps came indirectly: `update-image.sh` rsyncs `dist/` with `--copy-unsafe-links`, following the `@start9labs/start-core` symlink into `start-core/dist/node_modules` — which is itself a `cp -a` snapshot of `start-core/node_modules`.

What lives in `start-core/node_modules` is decided by npm **hoisting**:

- **Clean checkout** — `zod-deep-partial` sits nested in `start-core/node_modules`, gets snapshotted into `dist`, and rides the symlink into the image. Works.
- **Incremental build** — the shared repo-root `node_modules` already has `zod-deep-partial@1.4.4`, which satisfies start-core's `^1.4.4`, so npm **dedupes it up to the root** and drops the nested copy. The snapshot — and the image — lose it.

Tell-tale: `zod` survives (start-core pins `4.4.3` vs root `4.4.2`, a conflict that forces a nested copy) while `zod-deep-partial` does not.

## Fix

Use `npm install --install-links`, which packs the `file:` deps and installs their **full transitive tree as real files**, so `dist/node_modules` is self-contained regardless of hoisting state and no longer relies on `--copy-unsafe-links` chasing a fragile snapshot. The now-vestigial `dist/package-lock.json` seed line is dropped (`npm install` regenerates a correct one).

## Verification

Ran the updated script against a real `dist/`:

- `zod-deep-partial` and `zod` are now real dirs in `dist/node_modules`; `@start9labs/*` are real dirs, not symlinks.
- **Zero** out-of-tree symlinks remain in `dist/node_modules`.
- Both the top-level and SDK-bundled `start-core` resolve `zod-deep-partial` in the image layout.
- All three Makefile-declared outputs (`dist/package.json`, `dist/package-lock.json`, `dist/node_modules/.package-lock.json`) are still produced.