### PR TITLE
Fix 3293 secure bridge

### DIFF
--- a/projects/start-sdk/docs/package-template/README.md
+++ b/projects/start-sdk/docs/package-template/README.md
@@ -27,6 +27,7 @@ image tags anywhere — the manifest is the source of truth.
 ## Network Access and Interfaces
 
 <!-- TODO -->
+> **Service-to-Service:** To connect to this service from another StartOS package, use the SDK's host bridge API (see the [Networking Guide](https://docs.start9.com/packaging/networking)).
 
 ## Actions (StartOS UI)
 

--- a/projects/start-sdk/docs/src/SUMMARY.md
+++ b/projects/start-sdk/docs/src/SUMMARY.md
@@ -52,6 +52,7 @@
 
 ## Networking
 
+- [Service-to-Service Networking](networking.md)
 - [Expose a Web UI](recipe-web-ui.md)
 - [Expose Multiple Interfaces](recipe-multi-interface.md)
 - [Expose an API-Only Interface](recipe-api-interface.md)

--- a/projects/start-sdk/docs/src/networking.md
+++ b/projects/start-sdk/docs/src/networking.md
@@ -1,0 +1,35 @@
+# Networking
+
+StartOS provides a secure, host-mediated networking environment. Services do not connect to each other directly by IP or overlay network. Instead, all inter-service communication routes through the host's internal bridge network.
+
+## The Host Bridge Model
+
+Services on StartOS are strictly isolated. Direct container-to-container communication is disabled by the firewall. To communicate with another service, your service must use the **Host Bridge Address** over plain HTTP.
+
+When a service connects to the host bridge, the StartOS `net_controller` intercepts the traffic and routes it to the target container, providing an enforceable boundary.
+
+### Connecting to a Dependency
+
+To connect to a dependency, you construct a URL using the host's bridge IP address and the dependency's LAN-domain port.
+
+Because the bridge network is intrinsically secure (traffic never leaves the host), service-to-service communication happens over **plain HTTP**, bypassing any TLS wrapping the service might provide for external clients.
+
+### Using the SDK
+
+The StartOS SDK provides a helper to automatically construct the correct service-to-service base URL for a dependency's interface.
+
+```typescript
+import { sdk } from './sdk'
+
+// Within an action, init, or main lifecycle hook:
+const url = await sdk.getServiceBridgeUrl(effects, 8080)
+// url will be e.g. "http://10.0.3.1:8080"
+```
+
+> **Note**: Do not hardcode `10.0.3.1` in your scripts. Always obtain the bridge IP from the SDK at runtime, as the bridge subnet is subject to change in future network topologies.
+
+## Deprecation of `.startos`
+
+In older versions of StartOS (0.3.x), services used `.startos` DNS overlay names (e.g., `http://bitcoind.startos:8332`) to communicate. This model suffered from DNS caching issues and is being removed. 
+
+> **Important**: Never use `.startos` domains for new packages. If you are migrating an older package, replace all `.startos` base URLs with the bridge URL obtained from the SDK.

--- a/projects/start-sdk/lib/StartSdk.ts
+++ b/projects/start-sdk/lib/StartSdk.ts
@@ -173,6 +173,21 @@ export class StartSdk<Manifest extends T.SDKManifest> {
         effects.getServicePortForward(...args),
       clearBindings: (effects, ...args) => effects.clearBindings(...args),
       getOsIp: (effects, ...args) => effects.getOsIp(...args),
+      /**
+       * Constructs the service-to-service base URL for a given interface over the secure host bridge.
+       * Uses the target service's LAN-domain port (the port shown for its .local or LAN address).
+       * 
+       * Note: Because the bridge network never leaves the host, this communication happens securely 
+       * over plain HTTP, bypassing TLS overhead.
+       * 
+       * @param effects - The effects context
+       * @param port - The LAN-domain port of the target service
+       * @returns The base URL string (e.g. `http://10.0.3.1:8080`)
+       */
+      getServiceBridgeUrl: async (effects: T.Effects, port: number): Promise<string> => {
+        const ip = await effects.getOsIp()
+        return `http://${ip}:${port}`
+      },
       getSslKey: (effects, ...args) => effects.getSslKey(...args),
       shutdown: (effects, ...args) => effects.shutdown(...args),
       getDependencies: (effects, ...args) => effects.getDependencies(...args),

--- a/shared-libs/crates/start-core/src/net/dns.rs
+++ b/shared-libs/crates/start-core/src/net/dns.rs
@@ -455,6 +455,10 @@ impl Resolver {
                 }
             }
             if STARTOS.zone_of(name) || EMBASSY.zone_of(name) {
+                tracing::warn!(
+                    "The .startos DNS suffix is deprecated and will be removed in a future release. \
+                    Please migrate to the SDK host bridge API (getServiceBridgeUrl) for service-to-service communication."
+                );
                 let Ok(pkg) = name
                     .iter()
                     .rev()

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -625,6 +625,27 @@ impl NetServiceData {
                     }
                 }
             }
+
+            // Expose the service on the host bridge at its LAN-domain port.
+            // The bridge network (lxcbr0) is intrinsically secure, so this explicitly
+            // bypasses the TLS proxy and forwards plain HTTP directly to the container.
+            let lan_domain_port = bind.net.assigned_ssl_port.or(bind.net.assigned_port);
+            if let Some(lan_port) = lan_domain_port {
+                let forward_entry = forwards.entry(lan_port).or_insert_with(|| {
+                    (
+                        SocketAddrV4::new(self.ip, *port),
+                        1, // port count
+                        ForwardRequirements {
+                            public_gateways: BTreeSet::new(),
+                            private_ips: BTreeSet::new(),
+                            secure: true,
+                        },
+                    )
+                });
+                
+                // Whitelist the host bridge IP as a valid private IP source for this forward
+                forward_entry.2.private_ips.insert(IpAddr::V4(Ipv4Addr::from(crate::HOST_IP)));
+            }
         }
 
         // Port-range bindings: forward each enabled range the same way as a
@@ -732,6 +753,27 @@ impl NetServiceData {
                         }
                     }
                 }
+            }
+
+            // Expose the service on the host bridge at its LAN-domain port.
+            // The bridge network (lxcbr0) is intrinsically secure, so this explicitly
+            // bypasses the TLS proxy and forwards plain HTTP directly to the container.
+            let lan_domain_port = bind.net.assigned_ssl_port.or(bind.net.assigned_port);
+            if let Some(lan_port) = lan_domain_port {
+                let forward_entry = forwards.entry(lan_port).or_insert_with(|| {
+                    (
+                        SocketAddrV4::new(self.ip, *port),
+                        1, // port count
+                        ForwardRequirements {
+                            public_gateways: BTreeSet::new(),
+                            private_ips: BTreeSet::new(),
+                            secure: true,
+                        },
+                    )
+                });
+                
+                // Whitelist the host bridge IP as a valid private IP source for this forward
+                forward_entry.2.private_ips.insert(IpAddr::V4(Ipv4Addr::from(crate::HOST_IP)));
             }
         }
         // Withdraw redirect maps that no longer apply (443 unexposed, or 80 became

--- a/shared-libs/crates/start-core/src/net/socks.rs
+++ b/shared-libs/crates/start-core/src/net/socks.rs
@@ -21,7 +21,12 @@ pub const DEFAULT_SOCKS_LISTEN: SocketAddr = SocketAddr::V4(SocketAddrV4::new(
 /// SOCKS5 proxy exposed by the `tor` service (the user-installable Tor plugin),
 /// reachable from the host via the embedded DNS once that service is running.
 /// Matches the default the registry server uses for its own onion requests.
-const TOR_PROXY: (&str, u16) = ("tor.startos", 9050);
+fn tor_proxy() -> SocketAddr {
+    SocketAddr::V4(SocketAddrV4::new(
+        Ipv4Addr::new(HOST_IP[0], HOST_IP[1], HOST_IP[2], HOST_IP[3]),
+        9050,
+    ))
+}
 
 /// Open a connection to a SOCKS `CONNECT` target, special-casing the two address
 /// families the host's resolver/router can't reach on its own:
@@ -38,7 +43,7 @@ const TOR_PROXY: (&str, u16) = ("tor.startos", 9050);
 async fn connect_target(addr: Address) -> Result<TcpStream, Error> {
     match addr {
         Address::DomainAddress(domain, port) if domain.ends_with(".onion") => {
-            let mut tor = TcpStream::connect(TOR_PROXY)
+            let mut tor = TcpStream::connect(tor_proxy())
                 .await
                 .with_kind(ErrorKind::Network)?;
             socks5_impl::client::connect(&mut tor, Address::DomainAddress(domain, port), None)

--- a/shared-libs/crates/start-core/src/registry/context.rs
+++ b/shared-libs/crates/start-core/src/registry/context.rs
@@ -118,7 +118,16 @@ impl RegistryContext {
             .tor_proxy
             .clone()
             .map(Ok)
-            .unwrap_or_else(|| "socks5h://tor.startos:9050".parse())?;
+            .unwrap_or_else(|| {
+                format!(
+                    "socks5h://{}.{}.{}.{}:9050",
+                    crate::HOST_IP[0],
+                    crate::HOST_IP[1],
+                    crate::HOST_IP[2],
+                    crate::HOST_IP[3]
+                )
+                .parse()
+            })?;
         let metrics_db_path = datadir.join("metrics.db");
         let metrics_db = Connection::open(&metrics_db_path).with_kind(ErrorKind::Database)?;
         metrics_db


### PR DESCRIPTION
Closes #3293 

## Summary
This PR implements the new service-to-service communication topology by routing inter-service traffic over the intrinsically secure `lxcbr0` host bridge. It effectively deprecates the `.startos` overlay DNS namespace, resolving the long-standing DNS-caching failure class where long-lived clients failed to reconnect after a dependency restarted with a new internal IP.

## Scope / Tasks
- [x] **Core / OS:** mark the bridge network secure; expose each service on the bridge at its LAN-domain port.
- [x] **SDK 2.0:** provide an API for a service to obtain the host bridge address (and a helper to build a dependency's service-to-service base URL from its interface/port).
- [x] **Backwards compatibility:** keep `.startos` resolving for one version, then remove it. (Added a `tracing::warn!` to loudly alert developers to migrate).
- [x] **Documentation:** add an authoritative networking section to the packaging guide (and a one-line pointer in the README template) describing the host-bridge model.
- [ ] **Fleet-wide service migration:** replace `.startos` / container-IP usage with the SDK-supplied bridge address across all packages. *(Note: We migrated StartOS's own internal `tor` proxy usages in this PR. Downstream packages like `open-webui`, `ollama`, and `vllm` will be migrated in their respective repositories.)*

## Architecture & Code Changes
* **Bridge Exposure (`net_controller.rs`)**: Services are now explicitly exposed on the host bridge (`10.0.3.1`) at their LAN-domain port. Traffic over this bridge natively bypasses the TLS proxy and routes over plain HTTP.
* **Internal OS Migration (`socks.rs` & `context.rs`)**: Updated StartOS's own internal connections (specifically to the `tor` proxy) to dogfood the new bridge addressing architecture instead of hardcoding `tor.startos`.
* **SDK Bridge API (`StartSdk.ts`)**: Added a highly readable `sdk.getServiceBridgeUrl` helper. This abstracts the `10.0.3.1` host IP fetch and allows developers to easily construct dynamic base URLs for their dependencies at runtime.

## Verification
- Verified `start-core` compilation and successful translation of DNAT forwarding rules.
- Confirmed backward compatibility for `.startos` resolution.
- Reviewed all documentation links and TypeScript SDK linting.


 
  Note: Because the bridge network never leaves the host, this communication happens securely over plain HTTP, bypassing TLS overhead ; we can discuss if we need to change that!!
  
  
  
       