### PR TITLE
feat(net): un-restrict external ports 9050 and 9051 (stale host tor daemon reservation)

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -46,15 +46,15 @@ file tracks notable changes since the move to the monorepo.
 
 ### Changed
 
-- **External port 9050 is no longer restricted (#3407).** The port allocator
-  reserved 9050/9051 for the 0.3.x host Tor daemon, which no longer exists.
-  Freeing 9050 lets the tor service bind its SOCKS proxy with
+- **External ports 9050 and 9051 are no longer restricted (#3407).** The port
+  allocator reserved 9050/9051 for the 0.3.x host Tor daemon, which no longer
+  exists. Freeing 9050 lets the tor service bind its SOCKS proxy with
   `preferredExternalPort: 9050` (without exporting an interface), giving every
   service a stable, always-valid service-to-service address for Tor SOCKS on
   the internal bridge — `10.0.3.1:9050` — with no reactive watch on the tor
   package and therefore no dependent restarts when tor is installed, updated,
-  or removed. 9051 (control port) stays restricted; 0.4.x tor uses a Unix
-  control socket.
+  or removed. 9051 (the old control port) is freed as well; 0.4.x tor uses a
+  Unix control socket, so nothing binds it host-side.
 - **The StartOS admin UI is now addressed like a regular service interface (#3387).**
   At the SDK/effects layer the server's own host is identified by the reserved
   package id `start-os`, host id `admin`, and interface id `admin-ui` (renamed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -46,6 +46,15 @@ file tracks notable changes since the move to the monorepo.
 
 ### Changed
 
+- **External port 9050 is no longer restricted (#3407).** The port allocator
+  reserved 9050/9051 for the 0.3.x host Tor daemon, which no longer exists.
+  Freeing 9050 lets the tor service bind its SOCKS proxy with
+  `preferredExternalPort: 9050` (without exporting an interface), giving every
+  service a stable, always-valid service-to-service address for Tor SOCKS on
+  the internal bridge — `10.0.3.1:9050` — with no reactive watch on the tor
+  package and therefore no dependent restarts when tor is installed, updated,
+  or removed. 9051 (control port) stays restricted; 0.4.x tor uses a Unix
+  control socket.
 - **The StartOS admin UI is now addressed like a regular service interface (#3387).**
   At the SDK/effects layer the server's own host is identified by the reserved
   package id `start-os`, host id `admin`, and interface id `admin-ui` (renamed

--- a/shared-libs/crates/start-core/src/net/forward.rs
+++ b/shared-libs/crates/start-core/src/net/forward.rs
@@ -26,8 +26,11 @@ use crate::{GatewayId, HOST_IP};
 
 pub const START9_BRIDGE_IFACE: &str = "lxcbr0";
 const EPHEMERAL_PORT_START: u16 = 49152;
-// vhost.rs:89 — not allowed: <=1024, >=32768, 5355, 5432, 9050, 6010, 9051, 5353
-const RESTRICTED_PORTS: &[u16] = &[5353, 5355, 5432, 6010, 9050, 9051];
+// Reserved by/for host daemons (mDNS 5353, LLMNR 5355, postgres 5432, X11
+// forwarding 6010, tor control 9051). 9050 is claimable on purpose: the tor
+// service binds it without exporting an interface so its SOCKS proxy sits at
+// a stable 10.0.3.1:9050 on the bridge — do not re-restrict it.
+const RESTRICTED_PORTS: &[u16] = &[5353, 5355, 5432, 6010, 9051];
 
 fn is_restricted(port: u16) -> bool {
     port <= 1024 || RESTRICTED_PORTS.contains(&port)

--- a/shared-libs/crates/start-core/src/net/forward.rs
+++ b/shared-libs/crates/start-core/src/net/forward.rs
@@ -27,10 +27,11 @@ use crate::{GatewayId, HOST_IP};
 pub const START9_BRIDGE_IFACE: &str = "lxcbr0";
 const EPHEMERAL_PORT_START: u16 = 49152;
 // Reserved by/for host daemons (mDNS 5353, LLMNR 5355, postgres 5432, X11
-// forwarding 6010, tor control 9051). 9050 is claimable on purpose: the tor
-// service binds it without exporting an interface so its SOCKS proxy sits at
-// a stable 10.0.3.1:9050 on the bridge — do not re-restrict it.
-const RESTRICTED_PORTS: &[u16] = &[5353, 5355, 5432, 6010, 9051];
+// forwarding 6010). 9050/9051 are claimable on purpose: they were the 0.3.x
+// host tor daemon's reservation (gone in 0.4.x), and the tor service now binds
+// 9050 without exporting an interface so its SOCKS proxy sits at a stable
+// 10.0.3.1:9050 on the bridge — do not re-restrict them.
+const RESTRICTED_PORTS: &[u16] = &[5353, 5355, 5432, 6010];
 
 fn is_restricted(port: u16) -> bool {
     port <= 1024 || RESTRICTED_PORTS.contains(&port)

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -243,8 +243,6 @@ fn list_passthrough(ctx: RpcContext) -> Result<Vec<PassthroughInfo>, Error> {
     Ok(ctx.net_controller.vhost.list_passthrough())
 }
 
-// not allowed: <=1024, >=32768, 5355, 5432, 9050, 6010, 9051, 5353
-
 struct PassthroughHandle {
     _rc: Arc<()>,
     backend: SocketAddr,

--- a/shared-libs/ts-modules/start-core/lib/interfaces/Host.ts
+++ b/shared-libs/ts-modules/start-core/lib/interfaces/Host.ts
@@ -199,7 +199,7 @@ export class MultiHost {
     }
     // Both ranges must be in-bounds and above the reserved/privileged range.
     // StartOS additionally rejects a few specific ports (e.g. 5353, 5432,
-    // 9051) server-side at allocation time.
+    // 6010) server-side at allocation time.
     for (const [name, start] of [
       ['internalStartPort', internalStartPort],
       ['externalStartPort', externalStartPort],

--- a/shared-libs/ts-modules/start-core/lib/interfaces/Host.ts
+++ b/shared-libs/ts-modules/start-core/lib/interfaces/Host.ts
@@ -199,7 +199,7 @@ export class MultiHost {
     }
     // Both ranges must be in-bounds and above the reserved/privileged range.
     // StartOS additionally rejects a few specific ports (e.g. 5353, 5432,
-    // 9050) server-side at allocation time.
+    // 9051) server-side at allocation time.
     for (const [name, start] of [
       ['internalStartPort', internalStartPort],
       ['externalStartPort', externalStartPort],


### PR DESCRIPTION
## Summary

Part of #3407 (service-to-service addressing over the secure host bridge).

- Remove **9050 and 9051** from `RESTRICTED_PORTS` in `forward.rs`. The 9050/9051 reservation dates from the 0.3.x host tor daemon; nothing host-side binds either port in 0.4.x (the host SOCKS proxy listens on `10.0.3.1:1080`, the OS *dials* `tor.startos:9050` as a client, and 0.4.x tor uses a Unix control socket — no TCP control port on 9051).
- With 9050 claimable, the tor service binds its SOCKS proxy with `preferredExternalPort: 9050` and **no exported interface**, so the binding lands only on lo/lxcbr0 (`BindInfo::enabled_addresses`) and every service reaches Tor SOCKS at the **stable bridge address `10.0.3.1:9050`** — no `.startos` DNS, no container IPs, no reactive watch on the tor package, and therefore no dependent restarts when tor is installed, updated, or removed. (Tor-side binding: Start9Labs/tor-startos `next`, commit 06a2ae1.)
- Drop the stale `vhost.rs` "not allowed" comment (no enforcement there — `is_restricted()` in `forward.rs` is the single gate) and update the restricted-port example in the `Host.ts` doc comment.
- Changelog entry under 0.4.0-beta.10.

Verified: `cargo check -p start-core` clean; `cargo test -p start-core forward --features=test` 15/15 pass. (The port-freeing follow-up for 9051 is a comment/list/changelog change only; no build re-run per request.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpJxhk25X42WTafMdkUx6t
