### PR TITLE
fix(start-os-ui): GUA access tri-state as a segmented control

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/item.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/item.component.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms'
 import { i18nPipe, TaskService } from '@start9labs/shared'
 import { T } from '@start9labs/start-core'
 import { TuiButton, TuiIcon } from '@taiga-ui/core'
-import { TuiBadge, TuiSwitch } from '@taiga-ui/kit'
+import { TuiBadge, TuiSegmented, TuiSwitch } from '@taiga-ui/kit'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
 import { GatewayAddress, MappedServiceInterface } from '../../interface.service'
 import { GatewayActionsComponent } from './actions.component'
@@ -21,16 +21,33 @@ import { DomainHealthService } from './domain-health.service'
         @if (address.guaAccess !== null) {
           <!-- An IPv6 GUA is reachable LAN-only or also from the WAN, so it gets
                a Disabled / LAN / LAN+WAN tri-state instead of an on/off toggle. -->
-          <select
+          <tui-segmented
             class="gua-access"
-            [disabled]="toggling()"
-            [ngModel]="address.guaAccess"
-            (ngModelChange)="onSetGuaAccess($event)"
+            size="s"
+            [activeItemIndex]="guaIndex(address.guaAccess)"
           >
-            <option value="disabled">{{ 'Disabled' | i18n }}</option>
-            <option value="lan">{{ 'LAN' | i18n }}</option>
-            <option value="lan-wan">{{ 'LAN+WAN' | i18n }}</option>
-          </select>
+            <button
+              type="button"
+              [disabled]="toggling()"
+              (click)="onSetGuaAccess('disabled')"
+            >
+              {{ 'Disabled' | i18n }}
+            </button>
+            <button
+              type="button"
+              [disabled]="toggling()"
+              (click)="onSetGuaAccess('lan')"
+            >
+              {{ 'LAN' | i18n }}
+            </button>
+            <button
+              type="button"
+              [disabled]="toggling()"
+              (click)="onSetGuaAccess('lan-wan')"
+            >
+              {{ 'LAN+WAN' | i18n }}
+            </button>
+          </tui-segmented>
         } @else {
           <input
             type="checkbox"
@@ -242,6 +259,7 @@ import { DomainHealthService } from './domain-health.service'
     TuiBadge,
     TuiButton,
     TuiIcon,
+    TuiSegmented,
     TuiSwitch,
     FormsModule,
   ],
@@ -357,10 +375,16 @@ export class GatewayItemComponent {
     this.toggling.set(false)
   }
 
+  // Segment index for the Disabled / LAN / LAN+WAN tri-state.
+  guaIndex(access: T.GuaAccess): number {
+    return access === 'disabled' ? 0 : access === 'lan' ? 1 : 2
+  }
+
   async onSetGuaAccess(access: T.GuaAccess) {
     const addr = this.address()
     const iface = this.value()
-    if (!iface) return
+    // Clicking the already-active segment shouldn't re-save.
+    if (!iface || access === addr.guaAccess) return
 
     this.toggling.set(true)
     await this.tasks.run(async () => {

--- a/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/item.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/item.component.ts
@@ -2,8 +2,8 @@ import { Component, computed, inject, input, signal } from '@angular/core'
 import { FormsModule } from '@angular/forms'
 import { i18nPipe, TaskService } from '@start9labs/shared'
 import { T } from '@start9labs/start-core'
-import { TuiButton, TuiIcon } from '@taiga-ui/core'
-import { TuiBadge, TuiSegmented, TuiSwitch } from '@taiga-ui/kit'
+import { TuiButton, TuiDataList, TuiDropdown, TuiIcon } from '@taiga-ui/core'
+import { TuiBadge, TuiSwitch } from '@taiga-ui/kit'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
 import { GatewayAddress, MappedServiceInterface } from '../../interface.service'
 import { GatewayActionsComponent } from './actions.component'
@@ -19,35 +19,17 @@ import { DomainHealthService } from './domain-health.service'
     @if (address(); as address) {
       <td>
         @if (address.guaAccess !== null) {
-          <!-- An IPv6 GUA is reachable LAN-only or also from the WAN, so it gets
-               a Disabled / LAN / LAN+WAN tri-state instead of an on/off toggle. -->
-          <tui-segmented
-            class="gua-access"
+          <!-- A GUA's on/off is its own toggle (like every other row); the
+               LAN vs LAN+WAN reach is the dropdown in the access column. -->
+          <input
+            type="checkbox"
+            tuiSwitch
             size="s"
-            [activeItemIndex]="guaIndex(address.guaAccess)"
-          >
-            <button
-              type="button"
-              [disabled]="toggling()"
-              (click)="onSetGuaAccess('disabled')"
-            >
-              {{ 'Disabled' | i18n }}
-            </button>
-            <button
-              type="button"
-              [disabled]="toggling()"
-              (click)="onSetGuaAccess('lan')"
-            >
-              {{ 'LAN' | i18n }}
-            </button>
-            <button
-              type="button"
-              [disabled]="toggling()"
-              (click)="onSetGuaAccess('lan-wan')"
-            >
-              {{ 'LAN+WAN' | i18n }}
-            </button>
-          </tui-segmented>
+            [showIcons]="false"
+            [disabled]="toggling()"
+            [ngModel]="address.guaAccess !== 'disabled'"
+            (ngModelChange)="onToggleGua($event)"
+          />
         } @else {
           <input
             type="checkbox"
@@ -63,12 +45,49 @@ import { DomainHealthService } from './domain-health.service'
         }
       </td>
       <td class="access">
-        <tui-icon
-          [icon]="address.access === 'public' ? '@tui.globe' : '@tui.house'"
-        />
-        <span>
-          {{ (address.access === 'public' ? 'Public' : 'Local') | i18n }}
-        </span>
+        @if (address.guaAccess !== null) {
+          <!-- A GUA's LAN vs LAN+WAN reach shows as Local/Public like the other
+               rows, but as a dropdown so it can be changed here. -->
+          <button
+            class="gua-access"
+            tuiButton
+            tuiDropdown
+            size="s"
+            appearance="flat-grayscale"
+            [tuiDropdownOpen]="guaOpen()"
+            (tuiDropdownOpenChange)="guaOpen.set($event)"
+            [disabled]="toggling() || address.guaAccess === 'disabled'"
+            [iconStart]="
+              guaIsPublic(address.guaAccess) ? '@tui.globe' : '@tui.house'
+            "
+            iconEnd="@tui.chevron-down"
+          >
+            {{ (guaIsPublic(address.guaAccess) ? 'Public' : 'Local') | i18n }}
+            <tui-data-list *tuiDropdown (click)="guaOpen.set(false)">
+              <button
+                tuiOption
+                iconStart="@tui.house"
+                (click)="onSetGuaAccess('lan')"
+              >
+                {{ 'Local' | i18n }}
+              </button>
+              <button
+                tuiOption
+                iconStart="@tui.globe"
+                (click)="onSetGuaAccess('lan-wan')"
+              >
+                {{ 'Public' | i18n }}
+              </button>
+            </tui-data-list>
+          </button>
+        } @else {
+          <tui-icon
+            [icon]="address.access === 'public' ? '@tui.globe' : '@tui.house'"
+          />
+          <span>
+            {{ (address.access === 'public' ? 'Public' : 'Local') | i18n }}
+          </span>
+        }
       </td>
       <td class="type">
         <span
@@ -258,8 +277,9 @@ import { DomainHealthService } from './domain-health.service'
     GatewayActionsComponent,
     TuiBadge,
     TuiButton,
+    TuiDataList,
+    TuiDropdown,
     TuiIcon,
-    TuiSegmented,
     TuiSwitch,
     FormsModule,
   ],
@@ -277,6 +297,7 @@ export class GatewayItemComponent {
 
   readonly toggling = signal(false)
   readonly currentlyMasked = signal(true)
+  readonly guaOpen = signal(false)
   // The Certificate Authority column only shows when some address is SSL; kept
   // in sync with GatewayComponent's header (both derive from the same data).
   readonly showCert = computed(
@@ -375,9 +396,14 @@ export class GatewayItemComponent {
     this.toggling.set(false)
   }
 
-  // Segment index for the Disabled / LAN / LAN+WAN tri-state.
-  guaIndex(access: T.GuaAccess): number {
-    return access === 'disabled' ? 0 : access === 'lan' ? 1 : 2
+  // A GUA's reach is public (LAN+WAN) vs local (LAN); a disabled GUA shows its
+  // would-be reach as local (the left toggle conveys the off state).
+  guaIsPublic(access: T.GuaAccess): boolean {
+    return access === 'lan-wan'
+  }
+
+  onToggleGua(enabled: boolean) {
+    this.onSetGuaAccess(enabled ? 'lan' : 'disabled')
   }
 
   async onSetGuaAccess(access: T.GuaAccess) {

--- a/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/item.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/item.component.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms'
 import { i18nPipe, TaskService } from '@start9labs/shared'
 import { T } from '@start9labs/start-core'
 import { TuiButton, TuiDataList, TuiDropdown, TuiIcon } from '@taiga-ui/core'
-import { TuiBadge, TuiSwitch } from '@taiga-ui/kit'
+import { TuiBadge, TuiChevron, TuiSwitch } from '@taiga-ui/kit'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
 import { GatewayAddress, MappedServiceInterface } from '../../interface.service'
 import { GatewayActionsComponent } from './actions.component'
@@ -49,18 +49,18 @@ import { DomainHealthService } from './domain-health.service'
           <!-- A GUA's LAN vs LAN+WAN reach shows as Local/Public like the other
                rows, but as a dropdown so it can be changed here. -->
           <button
-            class="gua-access"
             tuiButton
             tuiDropdown
+            tuiChevron
             size="s"
-            appearance="flat-grayscale"
+            appearance="secondary-grayscale"
+            [tuiAppearanceState]="guaOpen() ? 'hover' : null"
             [tuiDropdownOpen]="guaOpen()"
             (tuiDropdownOpenChange)="guaOpen.set($event)"
             [disabled]="toggling() || address.guaAccess === 'disabled'"
             [iconStart]="
               guaIsPublic(address.guaAccess) ? '@tui.globe' : '@tui.house'
             "
-            iconEnd="@tui.chevron-down"
           >
             {{ (guaIsPublic(address.guaAccess) ? 'Public' : 'Local') | i18n }}
             <tui-data-list *tuiDropdown (click)="guaOpen.set(false)">
@@ -245,7 +245,7 @@ import { DomainHealthService } from './domain-health.service'
         font: var(--tui-typography-body-m);
         font-weight: bold;
         color: var(--tui-text-primary);
-        padding-inline-end: 0.5rem;
+        padding-inline: 0.5rem;
       }
 
       .cert-cell {
@@ -277,6 +277,7 @@ import { DomainHealthService } from './domain-health.service'
     GatewayActionsComponent,
     TuiBadge,
     TuiButton,
+    TuiChevron,
     TuiDataList,
     TuiDropdown,
     TuiIcon,

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -2260,7 +2260,7 @@ For the full changelog, see https://github.com/bitcoin/bitcoin/blob/v27.0.0/doc/
             addresses: {
               enabled: [],
               disabled: [],
-              guaAccess: {},
+              guaAccess: { '[2001:db8:abcd::a3b:2]:1234': 'lan-wan' },
               available: [
                 {
                   ssl: true,
@@ -2299,6 +2299,13 @@ For the full changelog, see https://github.com/bitcoin/bitcoin/blob/v27.0.0/doc/
                   hostname: 'fe80:cd00:0000:0cde:1257:0000:211e:1234',
                   port: 1234,
                   metadata: { kind: 'ipv6', gateway: 'wlan0', scopeId: 3 },
+                },
+                {
+                  ssl: true,
+                  public: true,
+                  hostname: '2001:db8:abcd::a3b:2',
+                  port: 1234,
+                  metadata: { kind: 'ipv6', gateway: 'eth0', scopeId: 0 },
                 },
               ],
             },

--- a/projects/start-os/web/ui/src/app/services/api/mock-patch.ts
+++ b/projects/start-os/web/ui/src/app/services/api/mock-patch.ts
@@ -461,7 +461,7 @@ export const mockPatchData: DataModel = {
               addresses: {
                 enabled: ['203.0.113.45:42443'],
                 disabled: [],
-                guaAccess: {},
+                guaAccess: { '[2001:db8:abcd::a3b:2]:1234': 'lan-wan' },
                 available: [
                   {
                     ssl: true,
@@ -552,6 +552,13 @@ export const mockPatchData: DataModel = {
                       overflowActions: ['regenerate-key'],
                       info: null,
                     },
+                  },
+                  {
+                    ssl: true,
+                    public: true,
+                    hostname: '2001:db8:abcd::a3b:2',
+                    port: 1234,
+                    metadata: { kind: 'ipv6', gateway: 'eth0', scopeId: 0 },
                   },
                 ],
               },


### PR DESCRIPTION
Follow-up to #3368. The IPv6 GUA exposure control (Disabled / LAN / LAN+WAN) was implemented as a raw `<select>` dropdown — my mistake. This makes it a proper Taiga **`tui-segmented`** tri-state, matching the existing `FormTriStateComponent` and the sibling on/off `tuiSwitch` in the same cell.

- Same three options and API calls (`serverBindingSetGuaAccess` / `pkgBindingSetGuaAccess`); only the widget changes.
- Guards against a redundant save when the already-active segment is clicked (the old `<select>` only fired on change).

Verified: `check:ui` + full `build:ui` (Angular AOT) green.