### PR TITLE
fix(net): derive StartTunnel PCP gateway from the subnet, not NM

### DIFF
--- a/shared-libs/crates/start-core/src/net/port_map/client.rs
+++ b/shared-libs/crates/start-core/src/net/port_map/client.rs
@@ -18,11 +18,12 @@ use std::time::Duration;
 use crab_nat::{InternetProtocol, PortMapping, PortMappingOptions, TimeoutConfig, pcp};
 use igd_next::aio::Gateway;
 use igd_next::aio::tokio::Tokio;
+use ipnet::IpNet;
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::{Instant, interval, timeout};
 
-use crate::db::model::public::NetworkInterfaceInfo;
+use crate::db::model::public::{GatewayType, NetworkInterfaceInfo};
 use crate::net::port_map::pcp::capability::has_start9_capability;
 use crate::net::port_map::pcp::hostname::OPTION_HOSTNAME;
 use crate::net::port_map::pcp::portset::{OPTION_PORT_SET, PortSet};
@@ -55,10 +56,12 @@ type MappingKey = (IpAddr, u16, Option<String>);
 
 /// Candidate PCP/NAT-PMP servers for a gateway interface: the NM default
 /// gateways (router) that fall on one of this interface's own subnets, plus the
-/// v6 link-local default gateway.
+/// v6 link-local default gateway. A StartTunnel gateway is on-link (routed by
+/// AllowedIPs, no next-hop), so NM reports no gateway — fall back per family to
+/// the tunnel server's address, the subnet's first host, where its PCP server
+/// listens.
 pub fn candidate_gateways(info: &NetworkInterfaceInfo) -> Vec<(IpAddr, Option<u32>)> {
-    let mut out: Vec<(IpAddr, Option<u32>)> = Vec::new();
-    let mut push = |ip: IpAddr, scope_id: Option<u32>| {
+    fn push(out: &mut Vec<(IpAddr, Option<u32>)>, ip: IpAddr, scope_id: Option<u32>) {
         let bad = match ip {
             IpAddr::V4(v4) => v4.is_unspecified() || v4.is_loopback() || v4.is_broadcast(),
             IpAddr::V6(v6) => v6.is_unspecified() || v6.is_loopback(),
@@ -66,26 +69,62 @@ pub fn candidate_gateways(info: &NetworkInterfaceInfo) -> Vec<(IpAddr, Option<u3
         if !bad && !out.iter().any(|(g, _)| *g == ip) {
             out.push((ip, scope_id));
         }
+    }
+
+    let mut out: Vec<(IpAddr, Option<u32>)> = Vec::new();
+    let Some(ip_info) = &info.ip_info else {
+        return out;
     };
-    if let Some(ip_info) = &info.ip_info {
-        for ip in &ip_info.lan_ip {
-            // v4: the gateway must sit within one of our own subnets. v6: accept
-            // the link-local default gateway (fe80::, the common case) or one in
-            // our subnets.
-            match ip {
-                IpAddr::V4(_) => {
-                    if ip_info.subnets.iter().any(|s| s.contains(ip)) {
-                        push(*ip, None);
-                    }
+
+    for ip in &ip_info.lan_ip {
+        // v4: the gateway must sit within one of our own subnets. v6: accept the
+        // link-local default gateway (fe80::, the common case) or one in our
+        // subnets.
+        match ip {
+            IpAddr::V4(_) => {
+                if ip_info.subnets.iter().any(|s| s.contains(ip)) {
+                    push(&mut out, *ip, None);
                 }
-                IpAddr::V6(v6) => {
-                    if ipv6_is_link_local(*v6) || ip_info.subnets.iter().any(|s| s.contains(ip)) {
-                        push(*ip, Some(ip_info.scope_id));
-                    }
+            }
+            IpAddr::V6(v6) => {
+                if ipv6_is_link_local(*v6) || ip_info.subnets.iter().any(|s| s.contains(ip)) {
+                    push(&mut out, *ip, Some(ip_info.scope_id));
                 }
             }
         }
     }
+
+    // StartTunnel fallback: the tunnel is on-link (routed by AllowedIPs, no
+    // next-hop) so NM reports no gateway and `lan_ip` is empty. The server's PCP
+    // listener is at the subnet's first host — `.1` for v4, and the v6 that host
+    // takes under the delegated prefix, which the client now carries on its own
+    // /prefix v6 so `host_v6` is exact. Fill a family only when NM gave none, so
+    // a real gateway always wins.
+    if info.gateway_type == Some(GatewayType::InboundOutbound) {
+        let have_v4 = out.iter().any(|(g, _)| g.is_ipv4());
+        let have_v6 = out.iter().any(|(g, _)| g.is_ipv6());
+        let server_v4 = ip_info.subnets.iter().find_map(|s| match s {
+            IpNet::V4(n) => n.hosts().next(),
+            IpNet::V6(_) => None,
+        });
+        if let Some(server_v4) = server_v4 {
+            if !have_v4 {
+                push(&mut out, IpAddr::V4(server_v4), None);
+            }
+            // Skip a bare /128 (a legacy config with no prefix): `host_v6` would
+            // resolve to the client's own address, not the server's.
+            if !have_v6 {
+                if let Some(prefix) = ip_info.subnets.iter().find_map(|s| match s {
+                    IpNet::V6(n) if n.prefix_len() < 128 => Some(*n),
+                    _ => None,
+                }) {
+                    let server_v6 = crate::tunnel::wg6::host_v6(prefix, server_v4);
+                    push(&mut out, IpAddr::V6(server_v6), Some(ip_info.scope_id));
+                }
+            }
+        }
+    }
+
     out
 }
 
@@ -707,5 +746,84 @@ mod tests {
         assert!(!announce_marker_ok(&not_success));
 
         assert!(!announce_marker_ok(&resp[..24]), "no marker option");
+    }
+
+    fn iface(
+        subnets: &[&str],
+        lan_ip: &[&str],
+        gateway_type: Option<GatewayType>,
+    ) -> NetworkInterfaceInfo {
+        use crate::db::model::public::IpInfo;
+        NetworkInterfaceInfo {
+            ip_info: Some(std::sync::Arc::new(IpInfo {
+                scope_id: 42,
+                subnets: subnets.iter().map(|s| s.parse::<IpNet>().unwrap()).collect(),
+                lan_ip: lan_ip.iter().map(|s| s.parse::<IpAddr>().unwrap()).collect(),
+                ..Default::default()
+            })),
+            gateway_type,
+            ..Default::default()
+        }
+    }
+
+    // A StartTunnel gateway has no NM gateway (on-link), so we fall back to the
+    // subnet's first host per family: v4 `.1` and the v6 that host maps to under
+    // the delegated /prefix the client now carries.
+    #[test]
+    fn tunnel_fallback_derives_server_v4_and_v6() {
+        let gws = candidate_gateways(&iface(
+            &["10.59.0.2/24", "2001:db8:abcd::a3b:2/64"],
+            &[],
+            Some(GatewayType::InboundOutbound),
+        ));
+        assert!(gws.contains(&(Ipv4Addr::new(10, 59, 0, 1).into(), None)));
+        let server_v6: IpAddr = "2001:db8:abcd::a3b:1".parse().unwrap();
+        assert!(gws.iter().any(|(g, _)| *g == server_v6), "got {gws:?}");
+    }
+
+    // On a /124 the client carries its /128 at /124, so `host_v6` stays exact
+    // where a naive v4-bit XOR would corrupt the prefix.
+    #[test]
+    fn tunnel_fallback_v6_exact_on_a_small_prefix() {
+        let gws = candidate_gateways(&iface(
+            &["10.59.0.2/24", "2001:db8:abcd:1::f2/124"],
+            &[],
+            Some(GatewayType::InboundOutbound),
+        ));
+        let server_v6: IpAddr = "2001:db8:abcd:1::f1".parse().unwrap();
+        assert!(gws.iter().any(|(g, _)| *g == server_v6), "got {gws:?}");
+    }
+
+    // A real NM gateway always wins; the fallback fills only the missing family.
+    #[test]
+    fn tunnel_fallback_is_per_family() {
+        let gws = candidate_gateways(&iface(
+            &["10.59.0.2/24", "2001:db8:abcd::a3b:2/64"],
+            &["10.59.0.1"], // NM has v4 but no v6
+            Some(GatewayType::InboundOutbound),
+        ));
+        assert_eq!(gws.iter().filter(|(g, _)| g.is_ipv4()).count(), 1);
+        let server_v6: IpAddr = "2001:db8:abcd::a3b:1".parse().unwrap();
+        assert!(gws.iter().any(|(g, _)| *g == server_v6), "got {gws:?}");
+    }
+
+    // The fallback is scoped to StartTunnel; a plain interface with no NM gateway
+    // yields nothing (no bogus `.1`).
+    #[test]
+    fn non_tunnel_no_gateway_yields_nothing() {
+        assert!(candidate_gateways(&iface(&["192.168.1.5/24"], &[], None)).is_empty());
+    }
+
+    // A legacy /128 client (pre-/prefix config) can't derive the server v6, so
+    // the v6 fallback is skipped rather than resolving to the client's own addr.
+    #[test]
+    fn tunnel_fallback_skips_bare_128_v6() {
+        let gws = candidate_gateways(&iface(
+            &["10.59.0.2/24", "2001:db8:abcd::a3b:2/128"],
+            &[],
+            Some(GatewayType::InboundOutbound),
+        ));
+        assert!(gws.contains(&(Ipv4Addr::new(10, 59, 0, 1).into(), None)));
+        assert!(!gws.iter().any(|(g, _)| g.is_ipv6()), "no v6 from a bare /128");
     }
 }

--- a/shared-libs/crates/start-core/src/tunnel/api.rs
+++ b/shared-libs/crates/start-core/src/tunnel/api.rs
@@ -1164,7 +1164,8 @@ pub async fn show_config(
             subnet,
             wg.as_key().de()?.verifying_key(),
             (wan_addr, wg.as_port().de()?).into(),
-            subnet_v6.map(|p| crate::tunnel::wg6::host_v6(p, ip)),
+            subnet_v6
+                .map(|p| Ipv6Net::new_assert(crate::tunnel::wg6::host_v6(p, ip), p.prefix_len())),
         )
         .to_string())
 }

--- a/shared-libs/crates/start-core/src/tunnel/wg.rs
+++ b/shared-libs/crates/start-core/src/tunnel/wg.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{Ipv4Addr, SocketAddr};
 
 use imbl_value::InternedString;
 use ipnet::{Ipv4Net, Ipv6Net};
@@ -261,7 +261,7 @@ impl WgConfig {
         subnet: Ipv4Net,
         server_pubkey: Base64<PublicKey>,
         server_addr: SocketAddr,
-        client_v6: Option<Ipv6Addr>,
+        client_v6: Option<Ipv6Net>,
     ) -> ClientConfig {
         ClientConfig {
             client_config: self,
@@ -317,14 +317,16 @@ pub struct ClientConfig {
     server_pubkey: Base64<PublicKey>,
     server_addr: SocketAddr,
     #[serde(default)]
-    client_v6: Option<Ipv6Addr>,
+    client_v6: Option<Ipv6Net>,
 }
 impl std::fmt::Display for ClientConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let v4_addr = Ipv4Net::new_assert(self.client_addr, self.subnet.prefix_len());
-        // Each host gets a single /128 from its subnet's prefix.
+        // The host's /128 rendered at the subnet's prefix length — declaring the
+        // tunnel's IPv6 subnet on-link, symmetric with the IPv4 /24 above. The
+        // host still owns only this one address; the server routes just its /128.
         let addr = match self.client_v6 {
-            Some(v6) => format!("{v4_addr}, {v6}/128"),
+            Some(v6) => format!("{v4_addr}, {v6}"),
             None => v4_addr.to_string(),
         };
         // Only the subnet's IPv4 `.1` is advertised for DNS — the proxy binds
@@ -381,11 +383,14 @@ mod tests {
     }
 
     #[test]
-    fn client_config_with_subnet_prefix_carries_a_128() {
-        // 10.59.0.2 == 0x0a3b0002, so the /128 host bits are `a3b:2`.
-        let v6 = wg6::host_v6(
-            "2001:db8:abcd::/64".parse().unwrap(),
-            "10.59.0.2".parse().unwrap(),
+    fn client_config_carries_v6_at_the_subnet_prefix() {
+        // 10.59.0.2 == 0x0a3b0002, so the host bits are `a3b:2`; the client's own
+        // /128 is carried at the delegated prefix length (declaring the subnet
+        // on-link like the IPv4 /24) so the client can derive the server's v6.
+        let prefix: Ipv6Net = "2001:db8:abcd::/64".parse().unwrap();
+        let v6 = Ipv6Net::new_assert(
+            wg6::host_v6(prefix, "10.59.0.2".parse().unwrap()),
+            prefix.prefix_len(),
         );
         let cfg = client()
             .client_config(
@@ -396,7 +401,7 @@ mod tests {
                 Some(v6),
             )
             .to_string();
-        assert!(cfg.contains("Address = 10.59.0.2/24, 2001:db8:abcd::a3b:2/128"));
+        assert!(cfg.contains("Address = 10.59.0.2/24, 2001:db8:abcd::a3b:2/64"));
         // Only the IPv4 DNS is advertised (the proxy binds IPv4 only).
         assert!(cfg.contains("DNS = 10.59.0.1"));
         assert!(!cfg.contains("DNS = 10.59.0.1, 2001"));


### PR DESCRIPTION
## Problem

Automatic port mapping (PCP) over a **StartTunnel** gateway silently stopped working: the client sends no PCP at all, so nothing gets mapped — SSL/SNI (PCP HOSTNAME) exposures and plain v4 forwards alike. A live capture on the tunnel server confirmed **zero** PCP packets from the client.

## Root cause

`candidate_gateways` sources its PCP/NAT-PMP targets only from NetworkManager's reported gateway (`ip_info.lan_ip`). A WireGuard StartTunnel is **on-link** — routed by `AllowedIPs` with no next-hop — so NM reports *no* gateway and `lan_ip` is empty. Commit `a7c70599b` removed the old subnet-`.1` fallback (correctly, as a global heuristic), which left the tunnel case with an empty candidate list → no PCP target → no mapping.

This was masked on some boxes because the StartTunnel server persists forwards permanently (SNI/DNAT bindings ignore the PCP lifetime and never expire), so a box that mapped *before* the regression kept working on stale entries while newly-provisioned tunnels could never map.

## Fix

**Client — `candidate_gateways` (`net/port_map/client.rs`)**: a per-family fallback, scoped to `InboundOutbound` (StartTunnel) gateways and applied only when NM gave no gateway for that family (so a real router always wins):
- **v4** → the subnet's first host. `add_subnet` normalizes every subnet so the server address *is* `hosts().next()` (`api.rs:568`), so this equals the real server for **any** subnet size, not just `/24`.
- **v6** → `host_v6(client_prefix, server_v4)` — the exact mapping the server uses for its own address.

**Server — client config rendering (`tunnel/wg.rs`, `tunnel/api.rs`)**: render the client's wg v6 `Address` at the delegated **`/prefix`** instead of `/128`. The client needs the real prefix to derive the server's v6 exactly — a naive v4-bit swap corrupts the prefix on a small block (a `/124` packs <16 hosts). This declares the tunnel's v6 subnet on-link, symmetric with the existing IPv4 `/24`; the host still owns only its `/128` and the server routes just that `/128` (`server-peer` `AllowedIPs = client_v6/128`).

A legacy `/128` client config yields **no** v6 candidate (skipped) rather than a wrong one — degrading to prior behavior until re-provisioned.

## Why not the alternatives
- **Cross-family (send v6 pinhole requests over v4)**: breaks the server's ownership guarantee — `add_pinhole` forces the target to the request *source*, which over v4 can't prove the v6 GUA belongs to the sender.
- **Naive prefix-free XOR for v6**: incorrect on `/124` (differing v4 bits can land outside the retained host space); the client genuinely needs the prefix.

## Testing
- 5 new `candidate_gateways` unit tests (v4+v6 derivation, `/124` exactness, per-family, non-tunnel yields nothing, legacy `/128` skip) + updated wg config test.
- `tunnel::` + `net::port_map` + `net::forward` + `net::net_controller`: **73 passed, 0 failed**; `cargo check -p start-core` clean.
- Adversarial 4-dimension review (v6 math, server-config safety, gate/regression, completeness): **no findings**.
- End-to-end over a live tunnel needs a StartOS client deployed on this branch (not exercised in CI); the unit tests cover the derivation and config rendering directly.

## Changelog / version
None. Both `start-os` `0.4.0-beta.10` and `start-tunnel` `1.1.0` are **unreleased** and already document this behavior (beta.10 "Automatic port forwarding" / "PCP HOSTNAME"; 1.1.0 "Per-subnet IPv6" / "IPv6 port forwarding … via PCP"). This fixes an unreleased regression with no version bump.