### PR TITLE
docs(packaging): authoritative service-to-service networking guide (#3407)

### DIFF
--- a/projects/start-sdk/docs/src/SUMMARY.md
+++ b/projects/start-sdk/docs/src/SUMMARY.md
@@ -86,6 +86,7 @@
 - [Main](main.md)
 - [Initialization](init.md)
 - [Interfaces](interfaces.md)
+- [Service-to-Service Networking](service-to-service.md)
 - [Actions](actions.md)
 - [Tasks](tasks.md)
 - [Notifications](notifications.md)

--- a/projects/start-sdk/docs/src/dependencies.md
+++ b/projects/start-sdk/docs/src/dependencies.md
@@ -63,8 +63,14 @@ export const setDependencies = sdk.setupDependencies(async ({ effects }) => {
   await sdk.action.createTask(effects, 'dependency-id', someAction, 'critical', {
     input: {
       kind: 'partial',
-      accept: [{ /* one or more acceptable partial inputs */ }],
-      set: { /* the value to pre-fill when none are accepted */ },
+      accept: [
+        {
+          /* one or more acceptable partial inputs */
+        },
+      ],
+      set: {
+        /* the value to pre-fill when none are accepted */
+      },
     },
     when: { condition: 'input-not-matches', once: false },
     reason: i18n('Human-readable reason shown to user'),
@@ -98,47 +104,35 @@ sdk.action.createTask(
 ```
 
 > [!NOTE]
+>
 > - Import the action object from the dependency's published package.
 > - The dependency must be listed in your `package.json` (e.g., `"synapse-startos": "file:../synapse-wrapper"`).
 > - `when: { condition: 'input-not-matches', once: false }` re-triggers until the action's input matches.
 > - `replayId` prevents duplicate tasks across restarts.
 
-## Reading Dependency Interfaces
+> [!IMPORTANT]
+> **`accept` entries are matched against the dependency's *resolved* action input, not its raw config file.** That input is the dependency action's prefill — its config parsed through its file model — so an optional field comes back carrying its **resolved default**, never a missing key. bitcoind's `prune`, for example, reads as the number `0` on an unpruned node (its file model coerces an absent `prune` to `0`), so `accept: [{ prune: 0 }]` matches an unpruned node exactly. Match the concrete value the input actually holds.
+>
+> An `accept` field value is compared for equality: `null` matches the literal value `null` — nothing else. It is **not** a wildcard and does **not** stand in for a defaulted or absent field. To leave a field unconstrained, **omit it** from the entry — an absent (`undefined`) key is not checked at all. (`undefined` means absence, not `null`: writing `undefined` for a field in a `set`/config would *delete* that key.) To require a specific value, name it. Multiple entries mean "any of these matches."
 
-Get the dependency's **host** with `sdk.host.get()` (the `hostId` and interface `id` are part of the dependency's documented contract), then read the interface off its bindings — its `addressInfo` is already filled, so `.format()` yields resolvable URLs:
+## Reaching a Dependency at Runtime
 
-```typescript
-const host = await sdk.host
-  .get(effects, { hostId: 'host-id', packageId: 'dependency-id' })
-  .const() // re-runs setupMain if the dependency's host changes
+A dependency is reached over the internal host bridge, by resolving its live bridge address (`10.0.3.1:<assigned port>`) with `sdk.host.get(...).const()`.
 
-const iface = Object.values(host?.bindings ?? {})
-  .flatMap((b) => Object.values(b.interfaces))
-  .find((i) => i.id === 'interface-id')
-
-const url = iface?.addressInfo.format()[0] ?? null
-```
-
-Alternatively, services are reachable directly by hostname at `http://<package-id>.startos:<port>`:
-
-```typescript
-const url = 'http://bitcoind.startos:8332'
-```
+The mechanics — reading `net.assignedPort`, the `.const()` restart matrix, the `bridgeAddress`, the Tor `fallbackPort` case, and where a backend-_selection_ value belongs — are all in **[Service-to-Service Networking](service-to-service.md)**. Read that page before dialing any dependency.
 
 ## Mounting Dependency Volumes
 
 Mount a dependency's volume for direct file access in `main.ts`:
 
 ```typescript
-const mounts = sdk.Mounts.of()
-  .mountVolume({ volumeId: 'main', subpath: null, mountpoint: '/data', readonly: false })
-  .mountDependency({
-    dependencyId: 'bitcoind',
-    volumeId: 'main',
-    subpath: null,
-    mountpoint: '/mnt/bitcoind',
-    readonly: true,
-  })
+const mounts = sdk.Mounts.of().mountVolume({ volumeId: 'main', subpath: null, mountpoint: '/data', readonly: false }).mountDependency({
+  dependencyId: 'bitcoind',
+  volumeId: 'main',
+  subpath: null,
+  mountpoint: '/mnt/bitcoind',
+  readonly: true,
+})
 ```
 
 ## Init Order

--- a/projects/start-sdk/docs/src/file-models.md
+++ b/projects/start-sdk/docs/src/file-models.md
@@ -99,6 +99,9 @@ import { FileHelper, z } from "@start9labs/start-sdk";
 import { sdk } from "../sdk";
 
 const knownProxiesSchema = z.object({
+  // 10.0.3.1 is the OS bridge gateway — the reverse proxy this container should
+  // trust. It is the OS's own fixed address (see Service-to-Service Networking),
+  // not a dependency dial, so the literal is correct here.
   string: z.literal("10.0.3.1").array().catch(["10.0.3.1"]),
 });
 

--- a/projects/start-sdk/docs/src/recipe-alternative-deps.md
+++ b/projects/start-sdk/docs/src/recipe-alternative-deps.md
@@ -4,9 +4,9 @@ Some services can work with multiple backends — LND or Core Lightning for Ligh
 
 ## Solution
 
-Create a selection action with `Value.select()` that lets the user choose between backends (e.g., LND vs CLN). Persist the choice to a file model. In `setupDependencies()`, read the choice and conditionally return only the selected dependency. In `setupMain()`, read the same choice to conditionally mount the selected dependency's volumes and set the appropriate env vars or config.
+Create a selection action with `Value.select()` that lets the user choose between backends (e.g., LND vs CLN). Persist the choice to **`store.json` on the `startos` volume** — it is StartOS-level state, not part of the upstream service's config, so it must not be an invented key in the app's config file. In `setupDependencies()`, read the choice and conditionally return only the selected dependency. In `setupMain()`/`init`, read the same choice to conditionally mount the selected dependency's volumes and resolve *that* backend's bridge address into the appropriate env vars or config keys.
 
-**Reference:** [Dependencies](dependencies.md) · [Actions](actions.md) · [Main](main.md)
+**Reference:** [Dependencies](dependencies.md) · [Service-to-Service Networking](service-to-service.md#state-that-a-config-value-is-derived-from) · [Actions](actions.md) · [Main](main.md)
 
 ## Examples
 

--- a/projects/start-sdk/docs/src/recipe-dependency.md
+++ b/projects/start-sdk/docs/src/recipe-dependency.md
@@ -1,6 +1,6 @@
 # Depend on Another Service
 
-When your service needs another StartOS service (e.g., Bitcoin Core for a wallet, or PostgreSQL from a shared instance), declare it as a dependency. You can require it to be installed, running, or healthy, and optionally pin a version range.
+When your service needs another StartOS service (e.g., a Bitcoin node for a wallet, or PostgreSQL from a shared instance), declare it as a dependency. You can require it to be installed, running, or healthy, and optionally pin a version range.
 
 ## Solution
 
@@ -8,9 +8,9 @@ In `setupDependencies()`, return an object mapping dependency package IDs to the
 
 These declarations drive the **warning UI** StartOS shows the user when a dependency isn't installed, isn't running, or has a listed health check failing. They do **not** gate your service's startup — your service starts whenever the user starts it, regardless of dependency state. If your service genuinely cannot operate before a dependency reaches a particular state, handle that at runtime in `setupMain` (poll, retry, or surface your own error); don't expect the dependency declaration to block startup for you.
 
-Read the dependency's connection info in `setupMain` either via `sdk.host.get()` (walk the host's bindings to the interface) or directly as `http://<package-id>.startos:<port>`.
+Read the dependency's connection info in `setupMain` by resolving its bridge address with `sdk.host.get(...).const()` — see [Service-to-Service Networking](service-to-service.md) for the one correct way (and the two forbidden ones: `.startos` DNS names and cross-package container IPs).
 
-**Reference:** [Dependencies](dependencies.md)
+**Reference:** [Dependencies](dependencies.md) · [Service-to-Service Networking](service-to-service.md)
 
 ## Examples
 

--- a/projects/start-sdk/docs/src/recipe-enforce-dependency.md
+++ b/projects/start-sdk/docs/src/recipe-enforce-dependency.md
@@ -1,6 +1,6 @@
 # Enforce Settings on a Dependency
 
-Sometimes your service requires specific configuration on a dependency — Bitcoin Core must have `txindex=true`, or ZMQ must be enabled. A cross-service task fires on the dependency whenever its config drifts from the required values.
+Sometimes your service requires specific configuration on a dependency — a Bitcoin node must have `txindex=true`, or ZMQ must be enabled. A cross-service task fires on the dependency whenever its config drifts from the required values.
 
 ## Solution
 
@@ -10,4 +10,4 @@ In `setupDependencies()`, call `sdk.action.createTask()` targeting the dependenc
 
 ## Examples
 
-See `startos/dependencies.ts` in: [fulcrum](https://github.com/Start9Labs/fulcrum-startos) (txindex + ZMQ on Bitcoin Core), [public-pool](https://github.com/Start9Labs/public-pool-startos) (ZMQ on Bitcoin Core)
+See `startos/dependencies.ts` in: [fulcrum](https://github.com/Start9Labs/fulcrum-startos) (txindex + ZMQ on Bitcoin), [public-pool](https://github.com/Start9Labs/public-pool-startos) (ZMQ on Bitcoin)

--- a/projects/start-sdk/docs/src/recipes.md
+++ b/projects/start-sdk/docs/src/recipes.md
@@ -57,6 +57,7 @@ If you're using [Claude Code](https://claude.com/claude-code) (recommended), poi
 | [Expose a Web UI](recipe-web-ui.md) | Single HTTP interface for browser access |
 | [Expose Multiple Interfaces](recipe-multi-interface.md) | RPC, API, peer, WebSocket, or SSH on different ports |
 | [Expose an API-Only Interface](recipe-api-interface.md) | Programmatic access with no browser UI |
+| [Reach Another Service](service-to-service.md) | Dial a dependency over the host bridge (`getOsIp` + assigned port) |
 
 ## Dependencies
 

--- a/projects/start-sdk/docs/src/service-to-service.md
+++ b/projects/start-sdk/docs/src/service-to-service.md
@@ -1,0 +1,148 @@
+# Service-to-Service Networking
+
+[Interfaces](interfaces.md) covers how your service exposes ports **inbound**. This page covers the reverse: how your service reaches **another** service at runtime — a wallet dialing Bitcoin's RPC, an indexer dialing Bitcoin's P2P port, anything dialing Tor's SOCKS proxy.
+
+There is exactly one supported way to do this, and two once-common patterns that are now forbidden.
+
+## The host bridge
+
+Every StartOS service runs in its own container on a single internal bridge, `lxcbr0`. The bridge gateway — the OS itself — always sits at a fixed address you read with:
+
+```typescript
+const osIp = await sdk.getOsIp(effects) // "10.0.3.1" — a plain Promise, not reactive
+```
+
+`getOsIp` is a one-shot read of a compile-time constant. It never changes and never needs watching.
+
+Every port a service **binds** (via `sdk.MultiHost.of(...).bindPort(...)` in [interfaces.ts](interfaces.md)) is reachable from other containers at `10.0.3.1:<assigned external port>`. This holds even for a binding with **no exported interface** — binding a port is enough to make it reachable on the bridge (see [Exposing a bridge-only port](#exposing-a-bridge-only-port) below).
+
+> [!IMPORTANT]
+> The bridge exposes a service at its **assigned external port**, which you must not assume. `preferredExternalPort` is a request, not a guarantee: the first service to claim a given external port gets it and later claimants fall back to a random port, and when `preferredExternalPort` is omitted it defaults to the protocol default (`http` → 80). So the external port is only knowable at runtime, by reading the dependency's live binding. What *is* stable is the dependency's **internal** port and **host id** — import those as constants from the dependency's package.
+
+## Reaching a dependency
+
+Resolve a dependency's bridge address by reading its host and mapping to `<osIp>:<assignedPort>`:
+
+```typescript
+const osIp = await sdk.getOsIp(effects)
+
+const rpcAddr = await sdk.host
+  .get(effects, { packageId: 'bitcoind', hostId: rpcHostId }, (host) => {
+    const port = host?.bindings[rpcInternalPort]?.net.assignedPort
+    return port != null ? `${osIp}:${port}` : null
+  })
+  .const()
+```
+
+Three things make this correct, and each matters:
+
+1. **Read `net.assignedPort`, keyed by the dependency's internal port** — not an `addressInfo` hostname. `assignedPort` is the minimal thing that identifies the bridge address, and it changes *only* when the external port changes. A binding's `addressInfo` hostname list, by contrast, folds in things that have nothing to do with reaching it over the bridge — the box's LAN IP changing, a Tor or clearnet address being added or removed — any of which would change a hostname-derived value and needlessly restart your service. `osIp` + `assignedPort` is stable against all of that. `rpcHostId` and `rpcInternalPort` are imported from the dependency's package (`bitcoin-core-startos/startos/utils`), not hardcoded — the internal port and host id are the stable contract.
+
+2. **`.const()` on a minimal mapped value.** `.const()` re-runs `main` only when the **mapped** value changes, not on every churn of the dependency's host record. Because the mapped value is just the address string, the restart behavior is exactly what you want:
+
+   | Event | Restarts your service? |
+   |-------|------------------------|
+   | Dependency updated | **No** — its assigned port survives an update |
+   | Dependency installed *after* yours | Once, to heal onto the now-resolvable address |
+   | Dependency uninstalled | Once, to reconfigure to the absent state |
+   | Dependency reinstalled, same port | No |
+   | Dependency reinstalled, new port | Once, to heal |
+   | Conditional binding appears (e.g. LND unlock) | Once, then stable across lock/unlock |
+
+   Do **not** use `.once()` (it snapshots `null` forever if the dependency isn't installed yet — your service never heals when the user installs the dependency second) or `.waitFor()` (it blocks `main` before any daemon or health check exists, leaving the service stuck "starting" with no signal). `.const()` on the minimal value is the only option that both avoids needless restarts and self-heals.
+
+3. **Absent means absent — never fabricate an address.** When the map returns `null` (dependency not installed), write *nothing* for that dependency: leave the config key out, make the file-model field `.optional().catch(undefined)`, omit the env var. Let the dial fail and the health check go red. **Never** write a placeholder like `127.0.0.1:8332` for a cross-container dependency — that address can't reach the dependency's container and only masks the real state. The `.const()` heals the moment the dependency appears.
+
+### A reusable helper
+
+Packages wrap the pattern above in a small `utils.ts` helper so each call site stays a one-liner. This is the fleet convention and a drop-in for the planned `sdk.host.getBridgeAddress`:
+
+```typescript
+export function bridgeAddress(
+  effects: T.Effects,
+  opts: { packageId: string; hostId: string; internalPort: number; fallbackPort?: number },
+) {
+  const watchable = async () => {
+    const osIp = await sdk.getOsIp(effects)
+    return sdk.host.get(effects, { packageId: opts.packageId, hostId: opts.hostId }, (host) => {
+      const port = host?.bindings[opts.internalPort]?.net.assignedPort ?? opts.fallbackPort
+      if (port == null) return null
+      return `${osIp}:${port}`
+    })
+  }
+  return {
+    const: async () => (await watchable()).const(), // reactive, in main / init
+    once: async () => (await watchable()).once(),   // snapshot, in an action
+  }
+}
+```
+
+Use `.const()` in `setupMain` and `setupOnInit`; use `.once()` only inside an action, where a live snapshot (not a subscription) is what you want.
+
+## The Tor exception: always-on flags
+
+Some flags should be passed **unconditionally**, even when the dependency is absent — most commonly Bitcoin's `-onion=<tor SOCKS>`. A dead bridge address there is harmless (connection refused), and passing the flag always means Tor works the moment it's installed with no reconfiguration.
+
+For this, and only this, use `fallbackPort` so the value is never `null`:
+
+```typescript
+const torSocks = await bridgeAddress(effects, {
+  packageId: 'tor',
+  hostId: socksHostId,
+  internalPort: socksPort, // 9050
+  fallbackPort: socksPort, // keeps the value at `${osIp}:9050` when Tor is absent
+}).const()
+```
+
+Tor's SOCKS port (9050) is the one external port StartOS guarantees is claimable, so `${osIp}:9050` is always valid. This is not a license to fabricate addresses generally (see rule 3 above) — it applies to Tor's SOCKS proxy, whose address is fixed and whose flag is inert when unreachable.
+
+Track a dependency's *presence* (for a health check, say) with `sdk.getStatus(effects, { packageId }).onChange(...)`, registered **unconditionally** — it returns `null` when the dependency is uninstalled and re-fires when it's installed. Never gate the watch itself behind a startup-time presence check.
+
+## State that a config value is derived from
+
+Sometimes an address depends on a choice the user made — which of several interchangeable backends to use (Fulcrum vs. Electrs, LND vs. CLN). That choice is **StartOS-level state**. It belongs in your package's own `store.json` — **never** as an invented key in the upstream service's config file, which may contain only keys the upstream software recognizes.
+
+A package keeps StartOS state in a single `store.json` file model (see [File Models](file-models.md)). If your package has no other on-disk state to colocate it with, put it on the dedicated `startos` volume:
+
+```typescript
+// store.json.ts — StartOS state, kept out of the upstream config
+const shape = z.object({
+  indexer: z.enum(['electrs', 'fulcrum']).optional().catch(undefined),
+})
+export const storeJson = FileHelper.json(
+  { base: sdk.volumes.startos, subpath: '/store.json' },
+  shape,
+)
+```
+
+Declare the volume in the manifest (`volumes: [..., 'startos']`) and add it to the backup set if the choice must survive a restore. `setupDependencies` and the selection action read/write `store.json`; `init` reads the choice, resolves *that* backend's bridge address, and writes only the real upstream keys into the app config. It is a bug to add a discriminator field (`INDEXER`, `BACKEND_CHOICE`, …) to a file model that maps the upstream service's own config file.
+
+## Exposing a bridge-only port
+
+If you are on the *provider* side — you want other services to reach a port but you do **not** want it on the LAN — bind the port and simply don't export an interface on it. A binding with no exported interface is reachable on `lo`/`lxcbr0` only, never the LAN. This is how the Tor service publishes its SOCKS proxy:
+
+```typescript
+// tor-startos/startos/interfaces.ts
+await sdk.MultiHost.of(effects, socksHostId).bindPort(socksPort, {
+  protocol: null,
+  preferredExternalPort: socksPort,
+  addSsl: null,
+  secure: { ssl: false },
+})
+// no origin.export([...]) — bridge/lo only, off the LAN
+```
+
+Export the host id and internal port as constants so dependents import them rather than hardcoding.
+
+## Forbidden patterns
+
+Two patterns that older packages used are being removed. Do not introduce them:
+
+- **`<package-id>.startos` DNS names** (`http://bitcoind.startos:8332`). The overlay DNS that resolved these is deprecated and will be removed. Resolve the bridge address instead.
+- **Cross-package container IPs** (`sdk.getContainerIp(effects, { packageId })`). A dependency's container IP is not stable across its restarts/updates and reading it reactively restarts your service on every dependency churn. Use the bridge. (`getContainerIp` with **no** `packageId` — your *own* container IP — remains fine.)
+
+## Reference implementations
+
+- **`bitcoin-core`** — `startos/utils.ts` (`bridgeAddress` helper) and `startos/main.ts` (`torSocks` with the `fallbackPort` case).
+- **`lnd`** — `startos/utils.ts` resolves bitcoind's RPC and ZMQ hosts; a conditional (unlock-gated) binding handled by the same `.const()` pattern.
+- **`mempool`** — `startos/utils.ts` + `startos/file-models/store.json.ts`: the backend-selection choice in `store.json`, the resolved address written to the upstream config's real keys.


### PR DESCRIPTION
Closes scope item 3 of #3407 (authoritative host-bridge networking section in the packaging guide).

## What

- **New reference page** `service-to-service.md` — the one supported way to reach another service at runtime:
  - The host bridge and `sdk.getOsIp(effects)` (one-shot `10.0.3.1`).
  - Resolving a dependency's address with `sdk.host.get(...).const()` on the **minimal** `osIp:assignedPort` value; read `net.assignedPort` (stable) not an `addressInfo` hostname (folds in unrelated LAN/Tor/domain churn).
  - The restart matrix (dep update = 0 restarts; installed-after = 1 heal; uninstall = 1; lock/unlock = 0) and why `.once()` (never heals) and `.waitFor()` (blocks `main` before daemons exist) are both wrong.
  - Absent means absent — never fabricate a `127.0.0.1` placeholder for a cross-container dependency.
  - The Tor `fallbackPort` exception for always-on flags like `-onion`.
  - Backend-**selection** state → the package's `store.json`, never an invented key in the upstream config file.
  - Binding a bridge-only port (no exported interface) for the provider side.
  - The two forbidden patterns: `.startos` DNS names and cross-package container IPs.

- **Rewrote the pages that taught the old model**: `dependencies.md` (removed the `.startos` "Alternatively" block and the restart-annotated `.const()`; corrected the `accept`-matching note — matched against the dependency's *resolved* input, `null` matches the literal value `null`, `undefined` means an absent key) and `recipe-dependency.md` (points at the new page).

- **`recipe-alternative-deps.md`**: persist the backend choice to `store.json`, not an app-config file model.

- **Neutral Bitcoin naming** in `recipe-enforce-dependency.md` / `recipe-dependency.md`; de-mystified the `10.0.3.1` KnownProxies example in `file-models.md`; added the page to `SUMMARY.md` and `recipes.md`.

Every technical claim on the new page was checked against `start-core`/SDK source and the shipped reference packages (bitcoin-core, lnd, mempool). mdbook builds clean; no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)