### PR TITLE
feat(net): block services from sending DNS straight to the gateway

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -151,6 +151,7 @@ file tracks notable changes since the move to the monorepo.
 
 - **TSIG-authenticated DNS UPDATE (#3306).** RFC 2136 injections are authenticated with TSIG (RFC 8945, HMAC-SHA256) keyed off a per-device key derived (HKDF-SHA256) from that device's WireGuard PSK, closing a forgery vector where any co-located service emitting from the server's tunnel IP could inject DNS.
 - **Packages are blocked from port-mapping the gateway (#3306).** Only startd may send UPnP/NAT-PMP/PCP upstream; a dedicated nftables guard table drops these protocols when forwarded from any interface (LXC), so a service can't open ports on the upstream gateway.
+- **Packages are blocked from talking DNS straight to the gateway.** The same guard table now drops DNS (udp/tcp 53) forwarded off the container bridge, so a service can't query a gateway or public resolver directly — its DNS goes through the OS resolver at `10.0.3.1:53`, same as every other lookup.
 - **Dependency/advisory cleanup:** resolved Dependabot alerts across core, web, and container-runtime (#3301); migrated to hickory 0.26 to clear DNS RUSTSEC advisories (#3302); resolved forked-dep RUSTSEC advisories in tokio-tar and async-acme (#3303).
 
 ## [0.4.0-beta.9] and earlier

--- a/shared-libs/crates/start-core/src/net/startos-base.nft
+++ b/shared-libs/crates/start-core/src/net/startos-base.nft
@@ -8,13 +8,20 @@ add chain ip startos mangle_prerouting { type filter hook prerouting priority ma
 add chain ip startos mangle_output { type route hook output priority mangle; policy accept; }
 add chain ip startos mangle_forward { type filter hook forward priority mangle; policy accept; }
 
-# Port-mapping protocols (PCP/NAT-PMP udp/5351, UPnP SSDP udp/1900) may originate
-# only from the host (startd, via the output hook); they are never forwarded
-# from a package container or any other interface. inet family so this covers
-# IPv4 and IPv6; flush+add keeps it idempotent across reloads. Runs before the
-# main forward filter; `accept` is non-terminal so non-port-map traffic still
-# falls through to the ip startos forward policy.
-add table inet startos_portmap_guard
-add chain inet startos_portmap_guard forward { type filter hook forward priority -10; policy accept; }
-flush chain inet startos_portmap_guard forward
-add rule inet startos_portmap_guard forward udp dport { 5351, 1900 } drop
+# Traffic a package container must never send straight at the network — it has to
+# go through the OS instead. Runs at priority -10, ahead of the main forward
+# filter; `drop` is terminal, everything else falls through to the ip startos
+# forward policy. inet family covers IPv4 and IPv6; flush+add keeps it idempotent
+# across reloads. iifname (not iif) matches by name, so the rules load even before
+# lxcbr0 exists.
+#   - Port-mapping (PCP/NAT-PMP udp/5351, UPnP SSDP udp/1900): only startd may open
+#     gateway ports, via the output hook; never forwarded from a container.
+#   - DNS (udp/tcp 53) off the bridge: services resolve through the OS proxy at
+#     10.0.3.1:53, a host-local input-hook destination that never hits this chain;
+#     a query aimed straight at a gateway or public resolver is dropped. lxcbr0 ==
+#     START9_BRIDGE_IFACE.
+add table inet startos_egress_guard
+add chain inet startos_egress_guard forward { type filter hook forward priority -10; policy accept; }
+flush chain inet startos_egress_guard forward
+add rule inet startos_egress_guard forward udp dport { 5351, 1900 } drop
+add rule inet startos_egress_guard forward iifname "lxcbr0" meta l4proto { tcp, udp } th dport 53 drop


### PR DESCRIPTION
## What

Blocks a package container from sending DNS traffic (udp/tcp 53) directly at a gateway or public resolver. Service DNS must go through the OS resolver at `10.0.3.1:53`, exactly as every container is already configured to (their `resolv.conf` is `nameserver 10.0.3.1`).

This mirrors the existing "packages are blocked from port-mapping the gateway" guard (UPnP/NAT-PMP/PCP), per @dr-bonez's request — same table, same mechanism.

## How

One nftables rule added to the forward-hook guard table (priority `-10`, runs ahead of the main `ip startos forward` chain, `inet` family so it covers IPv4 + IPv6):

```
add rule inet startos_egress_guard forward iifname "lxcbr0" meta l4proto { tcp, udp } th dport 53 drop
```

Scoped to the bridge ingress (`iifname "lxcbr0"`) so it only affects DNS **from** services:

- **Service → OS proxy** (`10.0.3.1:53`): host-local, hits the **input** hook, never this chain → unaffected. Normal name resolution keeps working.
- **Service → gateway / public resolver** (e.g. `192.168.1.1:53`, `1.1.1.1:53`): **forwarded** off `lxcbr0` → dropped.
- **Inbound DNS to a DNS-server package**: ingress is a WAN/tunnel iface, not `lxcbr0`, so it's not matched. (Port 53 is also `≤1024`-restricted from external-forward allocation, so this can't happen today regardless — the scoping is belt-and-suspenders / future-proofing.)

I also renamed the table `startos_portmap_guard` → `startos_egress_guard`, since it now guards more than port-mapping. The name only appeared in this one file (no Rust refs, no teardown); nft state is rebuilt from scratch on every boot and OS updates reboot, so there's no orphaned-table concern. Happy to revert the rename if you'd rather keep the old name.

## Verification

`nft` doesn't parse `include_str!` content at Rust compile time, so the meaningful test is that the ruleset loads in the kernel. Loaded the full `startos-base.nft` inside an isolated user+net namespace:

```
table inet startos_egress_guard {
	chain forward {
		type filter hook forward priority filter - 10; policy accept;
		udp dport { 1900, 5351 } drop
		iifname "lxcbr0" meta l4proto { tcp, udp } th dport 53 drop
	}
}
```

Loads clean, and (using `iifname`, not `iif`) applies even before `lxcbr0` exists. No Rust logic changed. Not exercised on a live StartOS box end-to-end — worth a smoke test that a service's direct `dig @1.1.1.1` fails while `dig` via the default resolver still works.

## Docs

Added a CHANGELOG Security entry alongside the port-mapping one (`projects/start-os/CHANGELOG.md`), matching how the port-mapping guard was documented.