### PR TITLE
refactor(net): make gateway type non-nullable, default inbound-outbound

### DIFF
--- a/projects/start-os/web/ui/src/app/services/api/mock-patch.ts
+++ b/projects/start-os/web/ui/src/app/services/api/mock-patch.ts
@@ -152,7 +152,7 @@ export const mockPatchData: DataModel = {
         eth0: {
           name: null,
           secure: null,
-          type: null,
+          type: 'inbound-outbound',
           ipInfo: {
             name: 'Wired Connection 1',
             scopeId: 1,
@@ -167,7 +167,7 @@ export const mockPatchData: DataModel = {
         wlan0: {
           name: null,
           secure: null,
-          type: null,
+          type: 'inbound-outbound',
           ipInfo: {
             name: 'Wireless Connection 1',
             scopeId: 2,

--- a/projects/start-tunnel/web/src/app/services/patch-db/data-model.ts
+++ b/projects/start-tunnel/web/src/app/services/patch-db/data-model.ts
@@ -112,7 +112,7 @@ export const mockTunnelData: TunnelData = {
     eth0: {
       name: null,
       secure: null,
-      type: null,
+      type: 'inbound-outbound',
       ipInfo: {
         name: 'Wired Connection 1',
         scopeId: 1,

--- a/shared-libs/crates/start-core/src/db/model/public.rs
+++ b/shared-libs/crates/start-core/src/db/model/public.rs
@@ -260,8 +260,20 @@ pub struct NetworkInterfaceInfo {
     pub name: Option<InternedString>,
     pub secure: Option<bool>,
     pub ip_info: Option<Arc<IpInfo>>,
+    // Pre-release dev DBs persisted this as `null` for auto-discovered gateways;
+    // coerce absent/null to the default so those nodes still load.
     #[serde(default, rename = "type")]
-    pub gateway_type: Option<GatewayType>,
+    #[serde(deserialize_with = "deserialize_null_default")]
+    #[ts(rename = "type")]
+    pub gateway_type: GatewayType,
+}
+
+fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
 impl NetworkInterfaceInfo {
     pub fn secure(&self) -> bool {
@@ -395,4 +407,40 @@ pub struct ServerSpecs {
     pub cpu: String,
     pub disk: String,
     pub memory: String,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn gateway_type_of(type_field: serde_json::Value) -> GatewayType {
+        serde_json::from_value::<NetworkInterfaceInfo>(serde_json::json!({ "type": type_field }))
+            .unwrap()
+            .gateway_type
+    }
+
+    #[test]
+    fn gateway_type_defaults_and_tolerates_legacy_null() {
+        // Absent `type` (fresh installs / interfaces older than the field) -> default.
+        assert_eq!(
+            serde_json::from_value::<NetworkInterfaceInfo>(serde_json::json!({}))
+                .unwrap()
+                .gateway_type,
+            GatewayType::InboundOutbound
+        );
+        // Pre-release dev DBs persisted `type: null` for auto-discovered gateways;
+        // it must still load (else the whole db fails to deserialize on boot).
+        assert_eq!(
+            gateway_type_of(serde_json::Value::Null),
+            GatewayType::InboundOutbound
+        );
+        assert_eq!(
+            gateway_type_of(serde_json::json!("inbound-outbound")),
+            GatewayType::InboundOutbound
+        );
+        assert_eq!(
+            gateway_type_of(serde_json::json!("outbound-only")),
+            GatewayType::OutboundOnly
+        );
+    }
 }

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -2107,7 +2107,7 @@ async fn poll_ip_info(
 
     write_to.send_if_modified(|m: &mut OrdMap<GatewayId, NetworkInterfaceInfo>| {
         let (name, secure, gateway_type, prev_wan_ip) =
-            m.get(iface).map_or((None, None, None, None), |i| {
+            m.get(iface).map_or((None, None, Default::default(), None), |i| {
                 (
                     i.name.clone(),
                     i.secure,

--- a/shared-libs/crates/start-core/src/net/host/mod.rs
+++ b/shared-libs/crates/start-core/src/net/host/mod.rs
@@ -377,7 +377,7 @@ impl Model<Host> {
             for (gid, g) in gateways {
                 // Never expose a range on an outbound-only gateway (e.g. a VPN
                 // egress) — they don't receive inbound forwards.
-                if matches!(g.gateway_type, Some(GatewayType::OutboundOnly)) {
+                if g.gateway_type == GatewayType::OutboundOnly {
                     continue;
                 }
                 let Some(ip_info) = &g.ip_info else {

--- a/shared-libs/crates/start-core/src/net/port_map/client.rs
+++ b/shared-libs/crates/start-core/src/net/port_map/client.rs
@@ -67,7 +67,7 @@ pub fn candidate_gateways(info: &NetworkInterfaceInfo) -> Vec<(IpAddr, Option<u3
     // VPN) exposes no PCP/NAT-PMP server we'd ever ask for a pinhole. Return no
     // candidates so every port-map call site — this is the one they all funnel
     // through — never attempts PCP against it.
-    if info.gateway_type == Some(GatewayType::OutboundOnly) {
+    if info.gateway_type == GatewayType::OutboundOnly {
         return Vec::new();
     }
 
@@ -115,7 +115,7 @@ pub fn candidate_gateways(info: &NetworkInterfaceInfo) -> Vec<(IpAddr, Option<u3
     // takes under the delegated prefix, which the client now carries on its own
     // /prefix v6 so `host_v6` is exact. Fill a family only when NM gave none, so
     // a real gateway always wins.
-    if info.gateway_type == Some(GatewayType::InboundOutbound) {
+    if info.gateway_type == GatewayType::InboundOutbound {
         let have_v4 = out.iter().any(|(g, _)| g.is_ipv4());
         let have_v6 = out.iter().any(|(g, _)| g.is_ipv6());
         let server_v4 = ip_info.subnets.iter().find_map(|s| match s {
@@ -802,11 +802,7 @@ mod tests {
         assert!(!announce_marker_ok(&resp[..24]), "no marker option");
     }
 
-    fn iface(
-        subnets: &[&str],
-        lan_ip: &[&str],
-        gateway_type: Option<GatewayType>,
-    ) -> NetworkInterfaceInfo {
+    fn iface(subnets: &[&str], lan_ip: &[&str], gateway_type: GatewayType) -> NetworkInterfaceInfo {
         use crate::db::model::public::IpInfo;
         NetworkInterfaceInfo {
             ip_info: Some(std::sync::Arc::new(IpInfo {
@@ -828,7 +824,7 @@ mod tests {
         let gws = candidate_gateways(&iface(
             &["10.59.0.2/24", "2001:db8:abcd::a3b:2/64"],
             &[],
-            Some(GatewayType::InboundOutbound),
+            GatewayType::InboundOutbound,
         ));
         assert!(gws.contains(&(Ipv4Addr::new(10, 59, 0, 1).into(), None)));
         let server_v6: IpAddr = "2001:db8:abcd::a3b:1".parse().unwrap();
@@ -842,7 +838,7 @@ mod tests {
         let gws = candidate_gateways(&iface(
             &["10.59.0.2/24", "2001:db8:abcd:1::f2/124"],
             &[],
-            Some(GatewayType::InboundOutbound),
+            GatewayType::InboundOutbound,
         ));
         let server_v6: IpAddr = "2001:db8:abcd:1::f1".parse().unwrap();
         assert!(gws.iter().any(|(g, _)| *g == server_v6), "got {gws:?}");
@@ -854,18 +850,24 @@ mod tests {
         let gws = candidate_gateways(&iface(
             &["10.59.0.2/24", "2001:db8:abcd::a3b:2/64"],
             &["10.59.0.1"], // NM has v4 but no v6
-            Some(GatewayType::InboundOutbound),
+            GatewayType::InboundOutbound,
         ));
         assert_eq!(gws.iter().filter(|(g, _)| g.is_ipv4()).count(), 1);
         let server_v6: IpAddr = "2001:db8:abcd::a3b:1".parse().unwrap();
         assert!(gws.iter().any(|(g, _)| *g == server_v6), "got {gws:?}");
     }
 
-    // The fallback is scoped to StartTunnel; a plain interface with no NM gateway
-    // yields nothing (no bogus `.1`).
+    // Gateway type is a two-state default of inbound-outbound, so the
+    // subnet-derived `.1` fallback now applies to any inbound-outbound gateway
+    // with no NM gateway — not only explicit StartTunnel ones.
     #[test]
-    fn non_tunnel_no_gateway_yields_nothing() {
-        assert!(candidate_gateways(&iface(&["192.168.1.5/24"], &[], None)).is_empty());
+    fn inbound_outbound_no_nm_gateway_derives_first_host() {
+        let gws = candidate_gateways(&iface(
+            &["192.168.1.5/24"],
+            &[],
+            GatewayType::InboundOutbound,
+        ));
+        assert!(gws.contains(&(Ipv4Addr::new(192, 168, 1, 1).into(), None)));
     }
 
     // A legacy /128 client (pre-/prefix config) can't derive the server v6, so
@@ -875,7 +877,7 @@ mod tests {
         let gws = candidate_gateways(&iface(
             &["10.59.0.2/24", "2001:db8:abcd::a3b:2/128"],
             &[],
-            Some(GatewayType::InboundOutbound),
+            GatewayType::InboundOutbound,
         ));
         assert!(gws.contains(&(Ipv4Addr::new(10, 59, 0, 1).into(), None)));
         assert!(!gws.iter().any(|(g, _)| g.is_ipv6()), "no v6 from a bare /128");
@@ -889,7 +891,7 @@ mod tests {
         let gws = candidate_gateways(&iface(
             &["10.59.0.2/24", "2001:db8:abcd:1::f2/124"],
             &["fe80::a3b:1"],
-            Some(GatewayType::InboundOutbound),
+            GatewayType::InboundOutbound,
         ));
         assert!(!gws.iter().any(|(g, _)| match g {
             IpAddr::V6(v6) => ipv6_is_link_local(*v6),
@@ -906,7 +908,7 @@ mod tests {
         let gws = candidate_gateways(&iface(
             &["192.168.1.5/24"],
             &["192.168.1.1", "fe80::1"],
-            None,
+            GatewayType::InboundOutbound,
         ));
         assert!(
             !gws.iter()
@@ -930,7 +932,7 @@ mod tests {
                 "fe80::1234:5678:9abc:def0/64",
             ],
             &["fe80::a3b:1"],
-            Some(GatewayType::InboundOutbound),
+            GatewayType::InboundOutbound,
         ));
         assert!(
             !gws.iter().any(|(g, _)| match g {
@@ -954,7 +956,7 @@ mod tests {
         let gws = candidate_gateways(&iface(
             &["10.8.0.2/24", "2001:db8::2/64"],
             &["10.8.0.1", "fe80::1"],
-            Some(GatewayType::OutboundOnly),
+            GatewayType::OutboundOnly,
         ));
         assert!(gws.is_empty(), "OutboundOnly must yield no candidates, got {gws:?}");
     }

--- a/shared-libs/crates/start-core/src/net/tunnel.rs
+++ b/shared-libs/crates/start-core/src/net/tunnel.rs
@@ -87,7 +87,7 @@ pub async fn add_tunnel(
                         name: Some(name),
                         secure: None,
                         ip_info: None,
-                        gateway_type: Some(gateway_type),
+                        gateway_type,
                     },
                 );
                 return true;

--- a/shared-libs/ts-modules/start-core/lib/osBindings/NetworkInterfaceInfo.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/NetworkInterfaceInfo.ts
@@ -6,5 +6,5 @@ export type NetworkInterfaceInfo = {
   name: string | null
   secure: boolean | null
   ipInfo: IpInfo | null
-  type: GatewayType | null
+  type: GatewayType
 }

--- a/shared-libs/ts-modules/start-core/lib/osBindings/tunnel/NetworkInterfaceInfo.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/tunnel/NetworkInterfaceInfo.ts
@@ -6,5 +6,5 @@ export type NetworkInterfaceInfo = {
   name: string | null
   secure: boolean | null
   ipInfo: IpInfo | null
-  type: GatewayType | null
+  type: GatewayType
 }


### PR DESCRIPTION
## What

`NetworkInterfaceInfo.gateway_type` (`gateway.type` in the db / bindings) was `Option<GatewayType>` defaulting to `None`. This collapses it to a **non-nullable `GatewayType` defaulting to `inbound-outbound`**, per @dr-bonez's request.

The gateways UI already renders anything that isn't `outbound-only` as **Inbound/Outbound** (`item.component.ts`), so auto-discovered eth/wifi gateways (which stored `type: null`) already displayed as inbound-outbound — this just aligns the data model with the behavior users already see, and continues @dr-bonez's recent net tri-state removals.

## Changes

- `db/model/public.rs` — field is now `pub gateway_type: GatewayType` (the enum already `#[default]`s to `InboundOutbound`).
- Call sites simplified: `Some(GatewayType::X)` comparisons → direct `==`, the tuple/insert defaults use the enum default, and `net tunnel add` drops the `Some(..)` wrapper.
- `net tunnel add`'s **CLI param stays `Option<GatewayType>`** so it can still auto-detect the type from the WireGuard config (StartTunnel marker → inbound-outbound, else outbound-only).
- Regenerated osBindings (`type: GatewayType`, no longer nullable) + updated the web/tunnel mocks that hard-coded `type: null`.

## Legacy `null` tolerance (why the custom deserializer)

The `type` field is unreleased (added post-`v0.4.0-beta.9`, only on `main`), but current dev/`main` builds **persist `type: null`** for every auto-discovered gateway (a `None` with no `skip_serializing_if`). `version::Current::pre_init` strict-deserializes the entire db (`from_value::<Database>`) on **every** boot — including the same-version `Ordering::Equal` path — so a bare non-`Option` change would make those dev boxes fail to load into the diagnostic UI.

So `gateway_type` uses a small null-tolerant deserializer (`deserialize_null_default`): absent **or** `null` → default. The boot round-trip (`to_value(&from_value::<Database>(..))`) then re-serializes the concrete value, so the persisted `null` self-heals on the next boot. No migration/version bump needed.

## One behavioral nuance worth a look

`candidate_gateways` (port-mapping) previously gated the StartTunnel `.1`-fallback on `type == Some(InboundOutbound)`, so a `None`-typed interface skipped it. With the default now `inbound-outbound`, any inbound-outbound gateway with no NM-reported gateway derives the subnet's first host. In practice a real gateway always has an NM gateway (so `have_v4`/`have_v6` short-circuit the fallback), so this only affects the synthetic "no NM gateway" case — I updated `non_tunnel_no_gateway_yields_nothing` → `inbound_outbound_no_nm_gateway_derives_first_host` accordingly. If you'd rather keep that fallback scoped strictly to tunnels, I can gate it on `device_type == Wireguard` instead — lmk.

## Docs / changelog

None: the field is unreleased (part of the in-progress beta.10 "Automatic gateway configuration" work already in the changelog), and the change is not user-visible (UI already showed inbound-outbound).

## Testing

- `cargo check -p start-core` + `make`-equivalent unit tests: `db::model::public` (incl. a new test that `type` absent/`null`/valid all deserialize) and `net::port_map::client` (12 tests) pass.
- `tsc --noEmit` for the `ui` and `start-tunnel` web projects pass; prettier clean on touched TS.