### PR TITLE
fix(start-wrt): point beta registry constants at the live hostname

### DIFF
--- a/.github/workflows/start-wrt.yaml
+++ b/.github/workflows/start-wrt.yaml
@@ -159,7 +159,7 @@ jobs:
     env:
       S3_BUCKET: s3://startwrt-images
       S3_CDN: https://startwrt-images.nyc3.cdn.digitaloceanspaces.com
-      REGISTRY: https://beta-startwrt-registry.start9.com
+      REGISTRY: https://startwrt-beta-registry.start9.com
       PLATFORM: spacemit,k1-x
     steps:
       - uses: actions/checkout@v6

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -42,7 +42,7 @@ APT_COMPONENT="main"
 # slot) and a sysupgrade image (OTA update -> the `squashfs` slot; see
 # cmd_register for the hardlink trick that maps the .img.gz names onto those
 # slots). Override either registry per run.
-STARTWRT_SOURCE_REGISTRY="${STARTWRT_SOURCE_REGISTRY:-https://beta-startwrt-registry.start9.com}"
+STARTWRT_SOURCE_REGISTRY="${STARTWRT_SOURCE_REGISTRY:-https://startwrt-beta-registry.start9.com}"
 STARTWRT_TARGET_REGISTRY="${STARTWRT_TARGET_REGISTRY:-https://startwrt-registry.start9.com}"
 STARTWRT_S3_BUCKET="s3://startwrt-images"
 STARTWRT_S3_CDN="https://startwrt-images.nyc3.cdn.digitaloceanspaces.com"


### PR DESCRIPTION
The beta registry is now deployed at startwrt-beta-registry.start9.com (the DNS record diverged from the beta-startwrt-registry placeholder). Update the coupled pair together: the CI deploy job's REGISTRY env and manage-release.sh's STARTWRT_SOURCE_REGISTRY default.