### PR TITLE
fix(start-wrt): restore OpenWrt host deps in the CI image job

### DIFF
--- a/.github/workflows/start-wrt.yaml
+++ b/.github/workflows/start-wrt.yaml
@@ -112,6 +112,23 @@ jobs:
         with:
           nodejs-version: ${{ env.NODEJS_VERSION }}
 
+      # Host deps for the OpenWrt build, restored from the old standalone
+      # repo's setup-build action (the monorepo's shared setup-build serves
+      # every product, so this install lives here instead). The riscv64
+      # binutils also serve build/verify-isa.sh, which runs in this job too:
+      # the image depends on the startwrt binary (build.mk: files/.staged),
+      # and at verify time the in-tree toolchain doesn't exist yet (the
+      # binary builds before `make -C openwrt`).
+      - name: Install OpenWrt build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential clang flex bison g++ gawk gcc-multilib \
+            g++-multilib gettext git libncurses-dev libssl-dev \
+            python3-setuptools rsync swig unzip \
+            zlib1g-dev file wget device-tree-compiler \
+            binutils-riscv64-linux-gnu
+
       # Restored BEFORE openwrt-setup.sh runs — the script rebuilds openwrt/
       # around the cached dl/ (which also caches the pinned source tarball).
       - name: Cache OpenWrt download directory

--- a/projects/start-wrt/build/verify-isa.sh
+++ b/projects/start-wrt/build/verify-isa.sh
@@ -28,7 +28,9 @@ for candidate in \
     fi
 done
 if [ -z "$OBJDUMP" ]; then
-    for f in openwrt/staging_dir/toolchain-riscv64*/bin/*-objdump; do
+    # Script-relative so the fallback works from any cwd (the build runs from
+    # the monorepo root, where a bare openwrt/ would miss projects/start-wrt/).
+    for f in "$(dirname "$0")/../openwrt"/staging_dir/toolchain-riscv64*/bin/*-objdump; do
         if [ -x "$f" ]; then
             OBJDUMP="$f"
             break


### PR DESCRIPTION
The old standalone repo's setup-build action installed the OpenWrt host build deps (flex, bison, swig, device-tree-compiler, ..., and the riscv64 binutils) in every job. The monorepo migration adopted the shared setup-build action, which has no such step, and re-added binutils only to the `compile` job — so the `image` job died in build/verify-isa.sh (no riscv64 objdump; it also builds the binary via build.mk's files/.staged) right after the Rust build, and would have been missing the rest of the host deps for the multi-hour OpenWrt build after that. Restore the old action's full install list in the image job.

Also fix verify-isa.sh's in-tree toolchain fallback, which still globbed the pre-monorepo openwrt/ location relative to the cwd; resolve it script-relative so it finds projects/start-wrt/openwrt/staging_dir/ from the monorepo root.