### PR TITLE
fix(tunnel): manual SNI (hostname) forwards no longer show as Automatic

### DIFF
--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -21,10 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Automatic (PCP) mappings now honor their lease.** A forward, pinhole, or SNI route opened automatically by a connected device carries a finite lease that the device renews while it still wants the port. The tunnel now expires and tears down an automatic mapping whose device stops renewing it — because it went offline, rotated its key, or withdrew the exposure — instead of leaving a stale forward in place indefinitely. Manually-added forwards are unaffected and remain persistent.
 - **Admin actions retire a device's forwards immediately.** Deleting a device or demoting it to a client now clears all of its forwards, SNI routes, and IPv6 pinholes (previously a deleted device's v6 pinholes could linger); disabling **automatic port forwarding** for a device clears its automatic forwards while leaving any you added manually. Cleanup no longer waits for the lease to lapse.
 
-### Fixed
-
-- **Manual SNI (hostname) forwards no longer show as Automatic.** A port forward you added by hand with a hostname was stored as if a connected device had created it via PCP — so it appeared in the **Automatic** table (labeled `PCP`) instead of **Manual**, and, being treated as a lease-based automatic route, could be reaped when no device renewed it. Manually-added hostname forwards are now correctly recorded as manual, keep the label you gave them, and stay put. Automatic (PCP) hostname routes are unaffected, and a PCP renewal can no longer take over a hostname you added by hand.
-
 ## [1.0.0]
 
 - **Independent versioning.** `start-tunnel` now carries its own version (starting at `1.0.0`) in its `Cargo.toml`, decoupled from the StartOS release line; its `.deb` is versioned from the manifest.

--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Manual SNI (hostname) forwards no longer show as Automatic.** A port forward you added by hand with a hostname was stored as if a connected device had created it via PCP — so it appeared in the **Automatic** table (labeled `PCP`) instead of **Manual**, and, being treated as a lease-based automatic route, could be reaped when no device renewed it. Manually-added hostname forwards are now correctly recorded as manual, keep the label you gave them, and stay put. Automatic (PCP) hostname routes are unaffected, and a PCP renewal can no longer take over a hostname you added by hand.
+
 ## [1.1.0]
 
 ### Added

--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Manual SNI (hostname) forwards no longer show as Automatic.** A port forward you added by hand with a hostname was stored as if a connected device had created it via PCP — so it appeared in the **Automatic** table (labeled `PCP`) instead of **Manual**, and, being treated as a lease-based automatic route, could be reaped when no device renewed it. Manually-added hostname forwards are now correctly recorded as manual, keep the label you gave them, and stay put. Automatic (PCP) hostname routes are unaffected, and a PCP renewal can no longer take over a hostname you added by hand.
-
 ## [1.1.0]
 
 ### Added
@@ -24,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Automatic (PCP) mappings now honor their lease.** A forward, pinhole, or SNI route opened automatically by a connected device carries a finite lease that the device renews while it still wants the port. The tunnel now expires and tears down an automatic mapping whose device stops renewing it — because it went offline, rotated its key, or withdrew the exposure — instead of leaving a stale forward in place indefinitely. Manually-added forwards are unaffected and remain persistent.
 - **Admin actions retire a device's forwards immediately.** Deleting a device or demoting it to a client now clears all of its forwards, SNI routes, and IPv6 pinholes (previously a deleted device's v6 pinholes could linger); disabling **automatic port forwarding** for a device clears its automatic forwards while leaving any you added manually. Cleanup no longer waits for the lease to lapse.
+
+### Fixed
+
+- **Manual SNI (hostname) forwards no longer show as Automatic.** A port forward you added by hand with a hostname was stored as if a connected device had created it via PCP — so it appeared in the **Automatic** table (labeled `PCP`) instead of **Manual**, and, being treated as a lease-based automatic route, could be reaped when no device renewed it. Manually-added hostname forwards are now correctly recorded as manual, keep the label you gave them, and stay put. Automatic (PCP) hostname routes are unaffected, and a PCP renewal can no longer take over a hostname you added by hand.
 
 ## [1.0.0]
 

--- a/shared-libs/crates/start-core/src/tunnel/api.rs
+++ b/shared-libs/crates/start-core/src/tunnel/api.rs
@@ -1236,7 +1236,7 @@ pub async fn add_forward(
                 ErrorKind::InvalidRequest,
             ));
         }
-        ctx.add_sni_forward(source, target, &sni, None)
+        ctx.persist_sni_forward(source, target, &sni, None, false, label)
             .await
             .map_err(|code| {
                 Error::new(

--- a/shared-libs/crates/start-core/src/tunnel/db.rs
+++ b/shared-libs/crates/start-core/src/tunnel/db.rs
@@ -114,218 +114,6 @@ impl Model<TunnelDatabase> {
 }
 
 #[test]
-fn sni_and_dnat_persistence_round_trip() {
-    use crate::tunnel::migrations::{PortForwardKind, TunnelMigration};
-
-    let route = SniRoute {
-        target: "10.59.0.2:443".parse().unwrap(),
-        label: None,
-        enabled: true,
-        auto: true,
-    };
-    let mut routes = BTreeMap::new();
-    routes.insert("id.example.com".to_string(), route);
-    let sni = PortForward::Sni { routes };
-
-    let sni_json = serde_json::to_value(&sni).unwrap();
-    eprintln!("SNI serialized: {sni_json}");
-    assert_eq!(sni_json["kind"], serde_json::json!("sni"));
-    let sni_back: PortForward = serde_json::from_value(sni_json).unwrap();
-    match &sni_back {
-        PortForward::Sni { routes } => {
-            let r = routes.get("id.example.com").expect("route present");
-            assert_eq!(r.target, "10.59.0.2:443".parse().unwrap());
-            assert_eq!(r.label, None);
-            assert!(r.enabled);
-        }
-        other => panic!("expected Sni, got {other:?}"),
-    }
-
-    let dnat = PortForward::Dnat {
-        target: "10.59.0.2:443".parse().unwrap(),
-        label: None,
-        enabled: true,
-        count: 1,
-        auto: false,
-    };
-    let dnat_json = serde_json::to_value(&dnat).unwrap();
-    eprintln!("DNAT serialized: {dnat_json}");
-    assert_eq!(dnat_json["kind"], serde_json::json!("dnat"));
-    let dnat_back: PortForward = serde_json::from_value(dnat_json).unwrap();
-    assert!(matches!(dnat_back, PortForward::Dnat { count: 1, .. }));
-
-    // Legacy entry with no `kind` field, run through the m_01 migration.
-    let mut legacy: imbl_value::Value = imbl_value::json!({
-        "portForwards": {
-            "1.2.3.4:443": {
-                "target": "10.59.0.2:443",
-                "label": null,
-                "enabled": true,
-                "count": 1
-            }
-        }
-    });
-    PortForwardKind.action(&mut legacy).unwrap();
-    eprintln!("Migrated legacy: {legacy}");
-    let migrated_entry = legacy["portForwards"]["1.2.3.4:443"].clone();
-    let migrated: PortForward =
-        serde_json::from_value(serde_json::to_value(&migrated_entry).unwrap()).unwrap();
-    assert!(
-        matches!(migrated, PortForward::Dnat { count: 1, .. }),
-        "migrated legacy entry should be Dnat, got {migrated:?}"
-    );
-
-    // Whole PortForwards map mixing a migrated dnat and a new sni entry.
-    let mixed = serde_json::json!({
-        "1.2.3.4:443": {
-            "kind": "dnat",
-            "target": "10.59.0.2:443",
-            "label": null,
-            "enabled": true,
-            "count": 1
-        },
-        "5.6.7.8:443": {
-            "kind": "sni",
-            "routes": {
-                "id.example.com": {
-                    "target": "10.59.0.2:443",
-                    "label": null,
-                    "enabled": true
-                }
-            }
-        }
-    });
-    let map: PortForwards = serde_json::from_value(mixed).unwrap();
-    assert_eq!(map.0.len(), 2);
-    let dnat_e = map.0.get(&"1.2.3.4:443".parse().unwrap()).unwrap();
-    assert!(matches!(dnat_e, PortForward::Dnat { .. }));
-    let sni_e = map.0.get(&"5.6.7.8:443".parse().unwrap()).unwrap();
-    match sni_e {
-        PortForward::Sni { routes } => {
-            let r = routes.get("id.example.com").unwrap();
-            assert!(r.enabled);
-        }
-        other => panic!("expected Sni, got {other:?}"),
-    }
-}
-
-#[test]
-fn port_forward_overlap_detection() {
-    let dnat = |target: &str, count: u16| PortForward::Dnat {
-        target: target.parse().unwrap(),
-        label: None,
-        enabled: true,
-        count,
-        auto: false,
-    };
-    let src = |s: &str| s.parse::<SocketAddrV4>().unwrap();
-
-    let mut map = BTreeMap::new();
-    // An existing 10-port range 8000..=8009 on WAN IP 1.2.3.4.
-    map.insert(src("1.2.3.4:8000"), dnat("10.0.0.2:8000", 10));
-    // An SNI forward occupying the single port 443.
-    map.insert(
-        src("1.2.3.4:443"),
-        PortForward::Sni {
-            routes: BTreeMap::new(),
-        },
-    );
-    let forwards = PortForwards(map);
-
-    // A single port inside the existing range overlaps it.
-    assert_eq!(
-        forwards.overlapping(src("1.2.3.4:8005"), 1),
-        Some(src("1.2.3.4:8000")),
-    );
-    // A new range straddling the end of the existing range overlaps.
-    assert_eq!(
-        forwards.overlapping(src("1.2.3.4:8009"), 5),
-        Some(src("1.2.3.4:8000")),
-    );
-    // A range that swallows the single SNI port overlaps it.
-    assert_eq!(
-        forwards.overlapping(src("1.2.3.4:440"), 8),
-        Some(src("1.2.3.4:443")),
-    );
-    // An adjacent, disjoint range (8010..=8019) does not overlap.
-    assert_eq!(forwards.overlapping(src("1.2.3.4:8010"), 10), None);
-    // The same span on a different WAN IP does not overlap.
-    assert_eq!(forwards.overlapping(src("5.6.7.8:8005"), 1), None);
-    // The exact same source key is excluded (collision / re-assert, not overlap).
-    assert_eq!(forwards.overlapping(src("1.2.3.4:8000"), 10), None);
-}
-
-#[test]
-fn pinhole_persistence_round_trip() {
-    let gua = |s: &str| s.parse::<SocketAddrV6>().unwrap();
-    let ph = Pinhole {
-        label: Some("Home Assistant".into()),
-        enabled: true,
-        count: 1,
-        internal_port: None,
-        auto: false,
-    };
-    let json = serde_json::to_value(&ph).unwrap();
-    let back: Pinhole = serde_json::from_value(json).unwrap();
-    assert_eq!(back.label.as_deref(), Some("Home Assistant"));
-    assert!(back.enabled);
-    assert_eq!(back.count, 1);
-    assert!(!back.auto);
-    // No remap → pure pinhole; internal port resolves to the external (key) port.
-    assert_eq!(back.internal_port(8443), 8443);
-    assert!(!back.is_dnat(8443));
-
-    // A gateway (PCP) entry deserialized from a bare map: defaults fill enabled/count.
-    let map: Pinholes6 = serde_json::from_value(serde_json::json!({
-        "[2001:db8::1]:8443": { "label": "PCP", "auto": true }
-    }))
-    .unwrap();
-    let e = map.0.get(&gua("[2001:db8::1]:8443")).unwrap();
-    assert!(e.enabled);
-    assert_eq!(e.count, 1);
-    assert!(e.auto);
-    assert_eq!(e.internal_port, None);
-
-    // A port-DNAT entry (80 → 443, the v6 HTTP-redirect case).
-    let redirect = Pinhole {
-        label: Some("HTTP redirect".into()),
-        enabled: true,
-        count: 1,
-        internal_port: Some(443),
-        auto: false,
-    };
-    let back: Pinhole = serde_json::from_value(serde_json::to_value(&redirect).unwrap()).unwrap();
-    assert_eq!(back.internal_port(80), 443);
-    assert!(back.is_dnat(80));
-}
-
-#[test]
-fn pinhole_overlap_detection() {
-    let gua = |s: &str| s.parse::<SocketAddrV6>().unwrap();
-    let ph = |count: u16| Pinhole {
-        label: None,
-        enabled: true,
-        count,
-        internal_port: None,
-        auto: false,
-    };
-    let mut map = BTreeMap::new();
-    map.insert(gua("[2001:db8::1]:8000"), ph(10));
-    let holes = Pinholes6(map);
-    // Overlaps the 8000..=8009 range.
-    assert_eq!(
-        holes.overlapping(gua("[2001:db8::1]:8005"), 1),
-        Some(gua("[2001:db8::1]:8000"))
-    );
-    // Adjacent, disjoint (8010) does not overlap.
-    assert_eq!(holes.overlapping(gua("[2001:db8::1]:8010"), 1), None);
-    // Same span on a different GUA does not overlap.
-    assert_eq!(holes.overlapping(gua("[2001:db8::2]:8005"), 1), None);
-    // The exact key is excluded (collision / re-assert, not overlap).
-    assert_eq!(holes.overlapping(gua("[2001:db8::1]:8000"), 10), None);
-}
-
-#[test]
 fn export_bindings_tunnel_db() {
     use crate::tunnel::api::*;
     use crate::tunnel::auth::{AddKeyParams, RemoveKeyParams, SetPasswordParams};
@@ -780,4 +568,216 @@ pub async fn subscribe(
         .await;
 
     Ok(SubscribeRes { dump, guid })
+}
+
+#[test]
+fn sni_and_dnat_persistence_round_trip() {
+    use crate::tunnel::migrations::{PortForwardKind, TunnelMigration};
+
+    let route = SniRoute {
+        target: "10.59.0.2:443".parse().unwrap(),
+        label: None,
+        enabled: true,
+        auto: true,
+    };
+    let mut routes = BTreeMap::new();
+    routes.insert("id.example.com".to_string(), route);
+    let sni = PortForward::Sni { routes };
+
+    let sni_json = serde_json::to_value(&sni).unwrap();
+    eprintln!("SNI serialized: {sni_json}");
+    assert_eq!(sni_json["kind"], serde_json::json!("sni"));
+    let sni_back: PortForward = serde_json::from_value(sni_json).unwrap();
+    match &sni_back {
+        PortForward::Sni { routes } => {
+            let r = routes.get("id.example.com").expect("route present");
+            assert_eq!(r.target, "10.59.0.2:443".parse().unwrap());
+            assert_eq!(r.label, None);
+            assert!(r.enabled);
+        }
+        other => panic!("expected Sni, got {other:?}"),
+    }
+
+    let dnat = PortForward::Dnat {
+        target: "10.59.0.2:443".parse().unwrap(),
+        label: None,
+        enabled: true,
+        count: 1,
+        auto: false,
+    };
+    let dnat_json = serde_json::to_value(&dnat).unwrap();
+    eprintln!("DNAT serialized: {dnat_json}");
+    assert_eq!(dnat_json["kind"], serde_json::json!("dnat"));
+    let dnat_back: PortForward = serde_json::from_value(dnat_json).unwrap();
+    assert!(matches!(dnat_back, PortForward::Dnat { count: 1, .. }));
+
+    // Legacy entry with no `kind` field, run through the m_01 migration.
+    let mut legacy: imbl_value::Value = imbl_value::json!({
+        "portForwards": {
+            "1.2.3.4:443": {
+                "target": "10.59.0.2:443",
+                "label": null,
+                "enabled": true,
+                "count": 1
+            }
+        }
+    });
+    PortForwardKind.action(&mut legacy).unwrap();
+    eprintln!("Migrated legacy: {legacy}");
+    let migrated_entry = legacy["portForwards"]["1.2.3.4:443"].clone();
+    let migrated: PortForward =
+        serde_json::from_value(serde_json::to_value(&migrated_entry).unwrap()).unwrap();
+    assert!(
+        matches!(migrated, PortForward::Dnat { count: 1, .. }),
+        "migrated legacy entry should be Dnat, got {migrated:?}"
+    );
+
+    // Whole PortForwards map mixing a migrated dnat and a new sni entry.
+    let mixed = serde_json::json!({
+        "1.2.3.4:443": {
+            "kind": "dnat",
+            "target": "10.59.0.2:443",
+            "label": null,
+            "enabled": true,
+            "count": 1
+        },
+        "5.6.7.8:443": {
+            "kind": "sni",
+            "routes": {
+                "id.example.com": {
+                    "target": "10.59.0.2:443",
+                    "label": null,
+                    "enabled": true
+                }
+            }
+        }
+    });
+    let map: PortForwards = serde_json::from_value(mixed).unwrap();
+    assert_eq!(map.0.len(), 2);
+    let dnat_e = map.0.get(&"1.2.3.4:443".parse().unwrap()).unwrap();
+    assert!(matches!(dnat_e, PortForward::Dnat { .. }));
+    let sni_e = map.0.get(&"5.6.7.8:443".parse().unwrap()).unwrap();
+    match sni_e {
+        PortForward::Sni { routes } => {
+            let r = routes.get("id.example.com").unwrap();
+            assert!(r.enabled);
+        }
+        other => panic!("expected Sni, got {other:?}"),
+    }
+}
+
+#[test]
+fn port_forward_overlap_detection() {
+    let dnat = |target: &str, count: u16| PortForward::Dnat {
+        target: target.parse().unwrap(),
+        label: None,
+        enabled: true,
+        count,
+        auto: false,
+    };
+    let src = |s: &str| s.parse::<SocketAddrV4>().unwrap();
+
+    let mut map = BTreeMap::new();
+    // An existing 10-port range 8000..=8009 on WAN IP 1.2.3.4.
+    map.insert(src("1.2.3.4:8000"), dnat("10.0.0.2:8000", 10));
+    // An SNI forward occupying the single port 443.
+    map.insert(
+        src("1.2.3.4:443"),
+        PortForward::Sni {
+            routes: BTreeMap::new(),
+        },
+    );
+    let forwards = PortForwards(map);
+
+    // A single port inside the existing range overlaps it.
+    assert_eq!(
+        forwards.overlapping(src("1.2.3.4:8005"), 1),
+        Some(src("1.2.3.4:8000")),
+    );
+    // A new range straddling the end of the existing range overlaps.
+    assert_eq!(
+        forwards.overlapping(src("1.2.3.4:8009"), 5),
+        Some(src("1.2.3.4:8000")),
+    );
+    // A range that swallows the single SNI port overlaps it.
+    assert_eq!(
+        forwards.overlapping(src("1.2.3.4:440"), 8),
+        Some(src("1.2.3.4:443")),
+    );
+    // An adjacent, disjoint range (8010..=8019) does not overlap.
+    assert_eq!(forwards.overlapping(src("1.2.3.4:8010"), 10), None);
+    // The same span on a different WAN IP does not overlap.
+    assert_eq!(forwards.overlapping(src("5.6.7.8:8005"), 1), None);
+    // The exact same source key is excluded (collision / re-assert, not overlap).
+    assert_eq!(forwards.overlapping(src("1.2.3.4:8000"), 10), None);
+}
+
+#[test]
+fn pinhole_persistence_round_trip() {
+    let gua = |s: &str| s.parse::<SocketAddrV6>().unwrap();
+    let ph = Pinhole {
+        label: Some("Home Assistant".into()),
+        enabled: true,
+        count: 1,
+        internal_port: None,
+        auto: false,
+    };
+    let json = serde_json::to_value(&ph).unwrap();
+    let back: Pinhole = serde_json::from_value(json).unwrap();
+    assert_eq!(back.label.as_deref(), Some("Home Assistant"));
+    assert!(back.enabled);
+    assert_eq!(back.count, 1);
+    assert!(!back.auto);
+    // No remap → pure pinhole; internal port resolves to the external (key) port.
+    assert_eq!(back.internal_port(8443), 8443);
+    assert!(!back.is_dnat(8443));
+
+    // A gateway (PCP) entry deserialized from a bare map: defaults fill enabled/count.
+    let map: Pinholes6 = serde_json::from_value(serde_json::json!({
+        "[2001:db8::1]:8443": { "label": "PCP", "auto": true }
+    }))
+    .unwrap();
+    let e = map.0.get(&gua("[2001:db8::1]:8443")).unwrap();
+    assert!(e.enabled);
+    assert_eq!(e.count, 1);
+    assert!(e.auto);
+    assert_eq!(e.internal_port, None);
+
+    // A port-DNAT entry (80 → 443, the v6 HTTP-redirect case).
+    let redirect = Pinhole {
+        label: Some("HTTP redirect".into()),
+        enabled: true,
+        count: 1,
+        internal_port: Some(443),
+        auto: false,
+    };
+    let back: Pinhole = serde_json::from_value(serde_json::to_value(&redirect).unwrap()).unwrap();
+    assert_eq!(back.internal_port(80), 443);
+    assert!(back.is_dnat(80));
+}
+
+#[test]
+fn pinhole_overlap_detection() {
+    let gua = |s: &str| s.parse::<SocketAddrV6>().unwrap();
+    let ph = |count: u16| Pinhole {
+        label: None,
+        enabled: true,
+        count,
+        internal_port: None,
+        auto: false,
+    };
+    let mut map = BTreeMap::new();
+    map.insert(gua("[2001:db8::1]:8000"), ph(10));
+    let holes = Pinholes6(map);
+    // Overlaps the 8000..=8009 range.
+    assert_eq!(
+        holes.overlapping(gua("[2001:db8::1]:8005"), 1),
+        Some(gua("[2001:db8::1]:8000"))
+    );
+    // Adjacent, disjoint (8010) does not overlap.
+    assert_eq!(holes.overlapping(gua("[2001:db8::1]:8010"), 1), None);
+    // Same span on a different GUA does not overlap.
+    assert_eq!(holes.overlapping(gua("[2001:db8::2]:8005"), 1), None);
+    // The exact key is excluded (collision / re-assert, not overlap).
+    assert_eq!(holes.overlapping(gua("[2001:db8::1]:8000"), 10), None);
 }

--- a/shared-libs/crates/start-core/src/tunnel/forward/pcp.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/pcp.rs
@@ -228,6 +228,61 @@ impl GatewayBackend for TunnelContext {
         hostnames: &[String],
         lifetime: Option<u32>,
     ) -> Result<(), u8> {
+        // The PCP path owns its routes: mark them automatic, default label `PCP`.
+        self.persist_sni_forward(source, target, hostnames, lifetime, true, None)
+            .await
+    }
+
+    async fn remove_sni_forward(&self, source: SocketAddrV4, target: SocketAddrV4, hostnames: &[String]) {
+        self.sni().unregister(*source.ip(), source.port(), hostnames, target);
+        for h in hostnames {
+            lease::forget(
+                self,
+                &LeaseKey::Sni {
+                    source,
+                    hostname: h.clone(),
+                },
+            );
+        }
+        let hostnames = hostnames.to_vec();
+        self.db
+            .mutate(|db| {
+                db.as_port_forwards_mut().mutate(|pf| {
+                    use crate::tunnel::db::PortForward;
+                    let mut now_empty = false;
+                    if let Some(PortForward::Sni { routes }) = pf.0.get_mut(&source) {
+                        routes.retain(|h, r| !(r.target == target && hostnames.contains(h)));
+                        now_empty = routes.is_empty();
+                    }
+                    if now_empty {
+                        pf.0.remove(&source);
+                    }
+                    Ok(())
+                })
+            })
+            .await
+            .result
+            .log_err();
+    }
+}
+
+impl TunnelContext {
+    /// Persist + register SNI-demuxed hostname routes on `source` to `target`.
+    /// `auto` records who owns the route for the UI Manual/Automatic split: the
+    /// PCP path passes `true`; a manual add passes `false` and its own `label`.
+    /// `lifetime` leases the routes (auto only). Shared by both so the two paths
+    /// can't drift; only the ownership/label inputs differ.
+    pub async fn persist_sni_forward(
+        &self,
+        source: SocketAddrV4,
+        target: SocketAddrV4,
+        hostnames: &[String],
+        lifetime: Option<u32>,
+        auto: bool,
+        label: Option<String>,
+    ) -> Result<(), u8> {
+        // A fresh route with no explicit label defaults to `PCP` only when auto.
+        let default_label = if auto { Some("PCP".to_string()) } else { label };
         // Persist first (DB is source of truth): reject a DNAT-occupied port or a
         // foreign-owned hostname before touching the dataplane. Registering first
         // risked a rollback on a transient DB error tearing down a valid binding.
@@ -259,17 +314,9 @@ impl GatewayBackend for TunnelContext {
                                 }
                             }
                             for h in &hostnames_owned {
-                                // A renewal must not clobber a user's edits, so
-                                // keep any existing label/enabled; a brand-new
-                                // route gets a default label marking it PCP-added.
-                                let (label, enabled) = match routes.get(h) {
-                                    Some(r) => (
-                                        r.label.clone().or_else(|| Some("PCP".into())),
-                                        r.enabled,
-                                    ),
-                                    None => (Some("PCP".into()), true),
-                                };
-                                routes.insert(h.clone(), SniRoute { target, label, enabled, auto: true });
+                                let (label, enabled, auto) =
+                                    sni_route_fields(routes.get(h), auto, &default_label);
+                                routes.insert(h.clone(), SniRoute { target, label, enabled, auto });
                             }
                             Ok(())
                         }
@@ -310,37 +357,24 @@ impl GatewayBackend for TunnelContext {
         }
         Ok(())
     }
+}
 
-    async fn remove_sni_forward(&self, source: SocketAddrV4, target: SocketAddrV4, hostnames: &[String]) {
-        self.sni().unregister(*source.ip(), source.port(), hostnames, target);
-        for h in hostnames {
-            lease::forget(
-                self,
-                &LeaseKey::Sni {
-                    source,
-                    hostname: h.clone(),
-                },
-            );
-        }
-        let hostnames = hostnames.to_vec();
-        self.db
-            .mutate(|db| {
-                db.as_port_forwards_mut().mutate(|pf| {
-                    use crate::tunnel::db::PortForward;
-                    let mut now_empty = false;
-                    if let Some(PortForward::Sni { routes }) = pf.0.get_mut(&source) {
-                        routes.retain(|h, r| !(r.target == target && hostnames.contains(h)));
-                        now_empty = routes.is_empty();
-                    }
-                    if now_empty {
-                        pf.0.remove(&source);
-                    }
-                    Ok(())
-                })
-            })
-            .await
-            .result
-            .log_err();
+/// The stored `(label, enabled, auto)` for an upserted SNI route. A brand-new
+/// route takes the caller's `auto` and `default_label`; an existing one keeps
+/// its owner (`auto`), enabled state, and any user label — so a PCP renewal
+/// can't hijack a manual route, nor a manual re-add flip an automatic one.
+fn sni_route_fields(
+    existing: Option<&crate::tunnel::db::SniRoute>,
+    auto: bool,
+    default_label: &Option<String>,
+) -> (Option<String>, bool, bool) {
+    match existing {
+        Some(r) => (
+            r.label.clone().or_else(|| default_label.clone()),
+            r.enabled,
+            r.auto,
+        ),
+        None => (default_label.clone(), true, auto),
     }
 }
 
@@ -375,4 +409,63 @@ async fn remove_peer_forward(ctx: &TunnelContext, peer: Ipv4Addr, internal_port:
         ctx.forward.gc().await.log_err();
     }
     lease::forget(ctx, &LeaseKey::Dnat(source));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddrV4;
+
+    use super::sni_route_fields;
+    use crate::tunnel::db::SniRoute;
+
+    fn route(label: Option<&str>, enabled: bool, auto: bool) -> SniRoute {
+        SniRoute {
+            target: "10.59.0.2:443".parse::<SocketAddrV4>().unwrap(),
+            label: label.map(str::to_string),
+            enabled,
+            auto,
+        }
+    }
+
+    // A manually-added hostname on a fresh source is stored as manual, with the
+    // user's own label — never as an automatic `PCP` route (the reported bug).
+    #[test]
+    fn new_manual_route_is_not_auto() {
+        let (label, enabled, auto) = sni_route_fields(None, false, &Some("my label".to_string()));
+        assert_eq!(label.as_deref(), Some("my label"));
+        assert!(enabled);
+        assert!(!auto);
+    }
+
+    // A fresh PCP route defaults to the `PCP` label and is automatic.
+    #[test]
+    fn new_pcp_route_is_auto() {
+        let (label, enabled, auto) = sni_route_fields(None, true, &Some("PCP".to_string()));
+        assert_eq!(label.as_deref(), Some("PCP"));
+        assert!(enabled);
+        assert!(auto);
+    }
+
+    // A PCP re-assert of a hostname the user added manually keeps it manual — the
+    // renewal preserves the existing owner, label, and enabled state.
+    #[test]
+    fn pcp_renewal_preserves_manual_owner() {
+        let existing = route(Some("mine"), false, false);
+        let (label, enabled, auto) =
+            sni_route_fields(Some(&existing), true, &Some("PCP".to_string()));
+        assert_eq!(label.as_deref(), Some("mine"));
+        assert!(!enabled);
+        assert!(!auto);
+    }
+
+    // Symmetrically, a manual re-add over an existing automatic route leaves it
+    // automatic; an unlabeled existing route inherits the caller's default label.
+    #[test]
+    fn manual_readd_preserves_auto_owner_and_backfills_label() {
+        let existing = route(None, true, true);
+        let (label, _enabled, auto) =
+            sni_route_fields(Some(&existing), false, &Some("ignored".to_string()));
+        assert_eq!(label.as_deref(), Some("ignored"));
+        assert!(auto);
+    }
 }


### PR DESCRIPTION
## What

@drbonez reported: *manually-added forwards with hostnames, on the same host + port as automatic forwards with hostnames, also show as **Automatic**.*

## Root cause

The manual "add port forward" API (`tunnel/api.rs::add_forward`, SNI branch) and the PCP auto path **both** call the single `GatewayBackend::add_sni_forward` impl in `tunnel/forward/pcp.rs`, which hardcoded `auto: true` and label `"PCP"` on every SNI route it inserted. So a hand-added hostname forward was stored as if a device had created it via PCP:

- it appeared in the UI's **Automatic** table (labeled `PCP`) instead of **Manual**, and
- being an `auto` route, it got a startup lease and could be reaped by the PCP lease reaper when no device renewed it.

DNAT (v4) and pinhole (v6) manual paths were already correct — they set `auto: false` inline / `add_pinhole(.., false)`. SNI was the sole offender because it's the only forward kind whose manual and automatic paths share one function. The UI itself was fine (`port-forwards/utils.ts` maps `SniRoute.auto` 1:1); only the stored flag was wrong.

## Fix

- Extract an inherent `TunnelContext::persist_sni_forward(source, target, hostnames, lifetime, auto, label)`. The PCP trait method delegates with `(true, None)`; the manual API passes `(false, user_label)` — which also means a manual SNI forward now keeps the label you gave it instead of `"PCP"`.
- A pure helper `sni_route_fields(existing, auto, default_label)` decides a route's `(label, enabled, auto)`:
  - a **brand-new** route takes the caller's `auto` and default label;
  - an **existing** route preserves its own `auto` / enabled / label — so a PCP renewal can't hijack a hostname you added by hand, and a manual re-add can't flip an automatic route.

## Tests

- New unit tests for `sni_route_fields` covering: new-manual → not auto (the reported bug), new-PCP → auto, PCP-renewal-preserves-manual-owner, and manual-re-add-preserves-auto-owner.
- All 32 `tunnel::` unit tests pass (`cargo test -p start-core --lib tunnel::`).

## Housekeeping

- Moved the non-bindings tests in `tunnel/db.rs` to the bottom of the file (the `export_bindings_tunnel_db` test stays inline), per the "tests at the bottom except bindings exports" convention.
- CHANGELOG entry under `[Unreleased] → Fixed`.

Docs already describe the intended Manual/Automatic behavior, so no docs change — this restores documented behavior.