### PR TITLE
fix(ci): stop master pushes from cancelling dispatched release builds

### DIFF
--- a/.github/workflows/start-cli.yaml
+++ b/.github/workflows/start-cli.yaml
@@ -57,9 +57,11 @@ on:
       - ".github/workflows/start-cli.yaml"
       - ".github/actions/setup-build/**"
 
+# The group is scoped by event so a master push can't cancel an in-flight
+# dispatched release build; dispatches queue behind each other, never cancel.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   NODEJS_VERSION: "24.11.0"

--- a/.github/workflows/start-registry.yaml
+++ b/.github/workflows/start-registry.yaml
@@ -55,9 +55,11 @@ on:
       - ".github/workflows/start-registry.yaml"
       - ".github/actions/setup-build/**"
 
+# The group is scoped by event so a master push can't cancel an in-flight
+# dispatched release build; dispatches queue behind each other, never cancel.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   NODEJS_VERSION: "24.11.0"

--- a/.github/workflows/start-tunnel.yaml
+++ b/.github/workflows/start-tunnel.yaml
@@ -69,9 +69,11 @@ on:
       - ".github/workflows/start-tunnel.yaml"
       - ".github/actions/setup-build/**"
 
+# The group is scoped by event so a master push can't cancel an in-flight
+# dispatched release build; dispatches queue behind each other, never cancel.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   NODEJS_VERSION: "24.17.0"

--- a/.github/workflows/start-wrt.yaml
+++ b/.github/workflows/start-wrt.yaml
@@ -60,9 +60,11 @@ on:
       - ".github/workflows/start-wrt.yaml"
       - ".github/actions/setup-build/**"
 
+# The group is scoped by event so a master push can't cancel an in-flight
+# dispatched release build; dispatches queue behind each other, never cancel.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   NODEJS_VERSION: "24.17.0"

--- a/.github/workflows/startos-iso.yaml
+++ b/.github/workflows/startos-iso.yaml
@@ -82,9 +82,11 @@ on:
       - ".github/workflows/startos-iso.yaml"
       - ".github/actions/setup-build/**"
 
+# The group is scoped by event so a master push can't cancel an in-flight
+# dispatched release build; dispatches queue behind each other, never cancel.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 env:
   NODEJS_VERSION: "24.17.0"


### PR DESCRIPTION
All five product workflows shared one concurrency group per ref, so a workflow_dispatch release build and any push run on master landed in the same group and cancel-in-progress killed the dispatch — the start-wrt beta.4 image build died 21 minutes in when an unrelated PR (touching shared-libs/crates/, which correctly triggers the workflow) merged to master. The old standalone repo carried the same stanza but only built on tags/dispatch, so the collision surfaced with the monorepo's push triggers.

Scope the group by event_name so push/PR cancellation semantics stay intact but can't touch dispatch runs, and evaluate cancel-in-progress so a second dispatch queues behind a running one instead of cancelling a multi-hour release build.