### PR TITLE
fix(tunnel): rebind device-bound listeners after wg interface reload

### DIFF
--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -66,6 +66,7 @@ StartOS provides the client side — see
 
 ### Fixed
 
+- **Automatic port forwarding no longer goes silent after a network config change.** Adding or removing a device or subnet (or any other change that reloads the WireGuard interface) recreated the interface out from under the PCP and UPnP IGD listeners, which are bound to it — leaving them unreachable until the daemon was restarted. Connected devices' renewals then went unanswered, so their automatic forwards, SNI routes, and IPv6 pinholes expired and their exposed services dropped offline. The listeners now rebind whenever the interface is reloaded. The same reload could also leave a subnet's DNS proxy serving a stale upstream configuration ("Address in use" in the logs); proxies now shut down cleanly before rebinding.
 - **Forwarded TCP MSS is clamped to the WireGuard path MTU (#3262, #3261).** A `mangle FORWARD … TCPMSS --clamp-mss-to-pmtu` rule fixes hung TLS handshakes where a large ClientHello (e.g. desktop Firefox/Chromium with the X25519MLKEM768 post-quantum key share) split into a segment that exceeded the tunnel's effective path MTU after WireGuard encapsulation and was silently dropped.
 - **"Default" DNS mode falls back to `/etc/resolv.conf`** when systemd-resolved is absent, unreadable, or yields no usable servers (84e99f1e9).
 - **Gateway type is auto-detected from the StartTunnel marker** when a pasted config declares no type, so outbound-only configs (e.g. Mullvad) are no longer mislabeled as inbound-capable (f76ac4bfe).

--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -66,7 +66,6 @@ StartOS provides the client side — see
 
 ### Fixed
 
-- **Automatic port forwarding no longer goes silent after a network config change.** Adding or removing a device or subnet (or any other change that reloads the WireGuard interface) recreated the interface out from under the PCP and UPnP IGD listeners, which are bound to it — leaving them unreachable until the daemon was restarted. Connected devices' renewals then went unanswered, so their automatic forwards, SNI routes, and IPv6 pinholes expired and their exposed services dropped offline. The listeners now rebind whenever the interface is reloaded. The same reload could also leave a subnet's DNS proxy serving a stale upstream configuration ("Address in use" in the logs); proxies now shut down cleanly before rebinding.
 - **Forwarded TCP MSS is clamped to the WireGuard path MTU (#3262, #3261).** A `mangle FORWARD … TCPMSS --clamp-mss-to-pmtu` rule fixes hung TLS handshakes where a large ClientHello (e.g. desktop Firefox/Chromium with the X25519MLKEM768 post-quantum key share) split into a segment that exceeded the tunnel's effective path MTU after WireGuard encapsulation and was silently dropped.
 - **"Default" DNS mode falls back to `/etc/resolv.conf`** when systemd-resolved is absent, unreadable, or yields no usable servers (84e99f1e9).
 - **Gateway type is auto-detected from the StartTunnel marker** when a pasted config declares no type, so outbound-only configs (e.g. Mullvad) are no longer mislabeled as inbound-capable (f76ac4bfe).

--- a/shared-libs/crates/start-core/src/tunnel/context.rs
+++ b/shared-libs/crates/start-core/src/tunnel/context.rs
@@ -174,10 +174,10 @@ pub struct TunnelContextSeed {
     /// Wakes the lease reaper when a stamp may have moved the soonest expiry
     /// earlier, so it can pull its next wake-up forward.
     pub lease_wake: tokio::sync::Notify,
-    /// Bumped after every `wg-quick` bounce: the PCP/IGD listeners are
+    /// Notified after every `wg-quick` bounce: the PCP/IGD listeners are
     /// `SO_BINDTODEVICE`-bound, which pins the ifindex at bind time, so a
     /// recreated interface leaves them deaf until they rebind.
-    pub forward_rebind: Watch<()>,
+    pub forward_rebind: tokio::sync::Notify,
     /// Serializes `resync_egress`; its read-DB → install → prune isn't atomic,
     /// so a concurrent reconcile could prune a rule another call just installed.
     pub egress_lock: tokio::sync::Mutex<()>,
@@ -365,7 +365,7 @@ impl TunnelContext {
             active_forwards: SyncMutex::new(active_forwards),
             leases: SyncMutex::new(BTreeMap::new()),
             lease_wake: tokio::sync::Notify::new(),
-            forward_rebind: Watch::new(()),
+            forward_rebind: tokio::sync::Notify::new(),
             egress_lock: tokio::sync::Mutex::new(()),
             v6_proxy: SyncMutex::new(BTreeMap::new()),
             v6_lock: tokio::sync::Mutex::new(()),
@@ -420,7 +420,7 @@ impl TunnelContext {
     /// must follow `server.sync()`.
     pub async fn sync_network(&self, server: &WgServer) -> Result<(), Error> {
         server.sync().await?;
-        self.forward_rebind.mark_changed();
+        self.forward_rebind.notify_waiters();
         self.dns_allowed.mutate(|s| *s = allowed_injectors(server));
         self.dns_keys.mutate(|m| *m = injector_keys(server));
         self.dns_proxy.sync(server, self.dns_injector.clone()).await?;

--- a/shared-libs/crates/start-core/src/tunnel/context.rs
+++ b/shared-libs/crates/start-core/src/tunnel/context.rs
@@ -174,6 +174,10 @@ pub struct TunnelContextSeed {
     /// Wakes the lease reaper when a stamp may have moved the soonest expiry
     /// earlier, so it can pull its next wake-up forward.
     pub lease_wake: tokio::sync::Notify,
+    /// Bumped after every `wg-quick` bounce: the PCP/IGD listeners are
+    /// `SO_BINDTODEVICE`-bound, which pins the ifindex at bind time, so a
+    /// recreated interface leaves them deaf until they rebind.
+    pub forward_rebind: Watch<()>,
     /// Serializes `resync_egress`; its read-DB → install → prune isn't atomic,
     /// so a concurrent reconcile could prune a rule another call just installed.
     pub egress_lock: tokio::sync::Mutex<()>,
@@ -361,6 +365,7 @@ impl TunnelContext {
             active_forwards: SyncMutex::new(active_forwards),
             leases: SyncMutex::new(BTreeMap::new()),
             lease_wake: tokio::sync::Notify::new(),
+            forward_rebind: Watch::new(()),
             egress_lock: tokio::sync::Mutex::new(()),
             v6_proxy: SyncMutex::new(BTreeMap::new()),
             v6_lock: tokio::sync::Mutex::new(()),
@@ -415,6 +420,7 @@ impl TunnelContext {
     /// must follow `server.sync()`.
     pub async fn sync_network(&self, server: &WgServer) -> Result<(), Error> {
         server.sync().await?;
+        self.forward_rebind.mark_changed();
         self.dns_allowed.mutate(|s| *s = allowed_injectors(server));
         self.dns_keys.mutate(|m| *m = injector_keys(server));
         self.dns_proxy.sync(server, self.dns_injector.clone()).await?;

--- a/shared-libs/crates/start-core/src/tunnel/dns.rs
+++ b/shared-libs/crates/start-core/src/tunnel/dns.rs
@@ -11,6 +11,7 @@ use hickory_server::store::forwarder::{ForwardConfig, ForwardZoneHandler};
 use hickory_server::zone_handler::{Catalog, ZoneHandler};
 use ipnet::Ipv4Net;
 use tokio::net::{TcpListener, UdpSocket};
+use tokio_util::sync::CancellationToken;
 
 use crate::net::dns::{
     DNS_RESPONSE_BUFFER_SIZE, forward_name_server, name_server_socket_addr, parse_resolv_conf,
@@ -24,6 +25,16 @@ use crate::util::sync::SyncMutex;
 
 const DNS_PORT: u16 = 53;
 const FORWARD_TIMEOUT: Duration = Duration::from_secs(30);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A running per-subnet proxy: the hickory server's cancellation token plus the
+/// task driving it. Shutdown must go through the token — aborting the task only
+/// schedules the abort of hickory's internal socket tasks, so the sockets can
+/// still be open when the caller rebinds the same address (EADDRINUSE).
+struct ProxyHandle {
+    shutdown: CancellationToken,
+    task: NonDetachingJoinHandle<()>,
+}
 
 /// Manages the per-subnet forward-only DNS proxies. Each subnet gets one
 /// `ServerFuture` bound to that subnet's in-tunnel server address (`.1:53`,
@@ -32,7 +43,7 @@ const FORWARD_TIMEOUT: Duration = Duration::from_secs(30);
 /// the proxy reachable only over the tunnel, not from the WAN.
 #[derive(Default)]
 pub struct DnsProxyController {
-    listeners: SyncMutex<BTreeMap<Ipv4Net, NonDetachingJoinHandle<()>>>,
+    listeners: SyncMutex<BTreeMap<Ipv4Net, ProxyHandle>>,
 }
 impl DnsProxyController {
     pub fn new() -> Self {
@@ -44,11 +55,14 @@ impl DnsProxyController {
     /// re-creates the interface addresses; callers MUST invoke this *after*
     /// `WgServer::sync()` so the `.1` addresses exist to bind to.
     pub async fn sync(&self, server: &WgServer, injector: Arc<DnsInjector>) -> Result<(), Error> {
-        // Drop the old listeners and wait for their tasks to finish so the
-        // sockets are released before we rebind the same addresses.
+        // Shut the old listeners down gracefully and wait, so the sockets are
+        // actually closed before we rebind the same addresses.
         let old = self.listeners.mutate(std::mem::take);
-        for (_, handle) in old {
-            let _ = handle.wait_for_abort().await;
+        for (subnet, proxy) in old {
+            proxy.shutdown.cancel();
+            if tokio::time::timeout(SHUTDOWN_TIMEOUT, proxy.task).await.is_err() {
+                tracing::warn!("DNS proxy for {subnet} did not shut down in time; aborting it");
+            }
         }
 
         let mut listeners = BTreeMap::new();
@@ -134,7 +148,7 @@ async fn bind_proxy(
     addr: Ipv4Addr,
     upstreams: Vec<SocketAddr>,
     injector: Arc<DnsInjector>,
-) -> Result<NonDetachingJoinHandle<()>, Error> {
+) -> Result<ProxyHandle, Error> {
     let listen = SocketAddrV4::new(addr, DNS_PORT);
     let udp = UdpSocket::bind(listen).await.with_kind(ErrorKind::Network)?;
     let tcp = TcpListener::bind(listen)
@@ -145,14 +159,16 @@ async fn bind_proxy(
     server.register_socket(udp);
     server.register_listener(tcp, FORWARD_TIMEOUT, DNS_RESPONSE_BUFFER_SIZE);
 
-    Ok(tokio::spawn(async move {
+    let shutdown = server.shutdown_token().clone();
+    let task = tokio::spawn(async move {
         server
             .block_until_done()
             .await
             .map_err(|e| Error::new(eyre!("{e}"), ErrorKind::Network))
             .log_err();
     })
-    .into())
+    .into();
+    Ok(ProxyHandle { shutdown, task })
 }
 
 /// A `Catalog` whose root zone is a single `ForwardAuthority` pointed at

--- a/shared-libs/crates/start-core/src/tunnel/forward/igd.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/igd.rs
@@ -83,15 +83,16 @@ fn ssdp_socket() -> Result<UdpSocket, Error> {
 
 async fn ssdp_loop(ctx: &TunnelContext, uuid: &str) -> Result<(), Error> {
     // Subscribe before binding so a bounce during setup still triggers a rebind.
-    let mut rebind = ctx.forward_rebind.clone();
-    rebind.mark_seen();
+    let rebind = ctx.forward_rebind.notified();
+    tokio::pin!(rebind);
+    rebind.as_mut().enable();
     let socket = ssdp_socket()?;
     tracing::info!("UPnP IGD SSDP responder listening on {WIREGUARD_INTERFACE_NAME}");
     let mut buf = [0u8; 2048];
     loop {
         let (n, from) = tokio::select! {
             res = socket.recv_from(&mut buf) => res.with_kind(ErrorKind::Network)?,
-            _ = rebind.changed() => {
+            _ = rebind.as_mut() => {
                 tracing::info!("{WIREGUARD_INTERFACE_NAME} recreated; rebinding SSDP responder");
                 return Ok(());
             }
@@ -136,14 +137,16 @@ pub(super) async fn subnet_gateway_for(ctx: &TunnelContext, peer: Ipv4Addr) -> O
 }
 
 async fn http_server(ctx: TunnelContext, root_desc: Arc<str>) {
-    let mut rebind = ctx.forward_rebind.clone();
     let app = Router::new()
         .route(ROOT_DESC_PATH, get(move || serve_static(root_desc.clone(), "text/xml")))
         .route(SCPD_PATH, get(|| serve_static(Arc::from(SCPD), "text/xml")))
         .route(CONTROL_PATH, post(control))
-        .with_state(ctx);
+        .with_state(ctx.clone());
     loop {
-        rebind.mark_seen();
+        // Subscribe before binding so a bounce during setup still triggers a rebind.
+        let rebind = ctx.forward_rebind.notified();
+        tokio::pin!(rebind);
+        rebind.as_mut().enable();
         match igd_http_listener() {
             Ok(listener) => {
                 tracing::info!("UPnP IGD control server listening on {WIREGUARD_INTERFACE_NAME}:{IGD_HTTP_PORT}");
@@ -157,7 +160,7 @@ async fn http_server(ctx: TunnelContext, root_desc: Arc<str>) {
                             tracing::warn!("UPnP IGD control server exited, retrying: {e}");
                         }
                     }
-                    _ = rebind.changed() => {
+                    _ = rebind.as_mut() => {
                         tracing::info!("{WIREGUARD_INTERFACE_NAME} recreated; rebinding IGD control server");
                         continue;
                     }

--- a/shared-libs/crates/start-core/src/tunnel/forward/igd.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/igd.rs
@@ -82,11 +82,20 @@ fn ssdp_socket() -> Result<UdpSocket, Error> {
 }
 
 async fn ssdp_loop(ctx: &TunnelContext, uuid: &str) -> Result<(), Error> {
+    // Subscribe before binding so a bounce during setup still triggers a rebind.
+    let mut rebind = ctx.forward_rebind.clone();
+    rebind.mark_seen();
     let socket = ssdp_socket()?;
     tracing::info!("UPnP IGD SSDP responder listening on {WIREGUARD_INTERFACE_NAME}");
     let mut buf = [0u8; 2048];
     loop {
-        let (n, from) = socket.recv_from(&mut buf).await.with_kind(ErrorKind::Network)?;
+        let (n, from) = tokio::select! {
+            res = socket.recv_from(&mut buf) => res.with_kind(ErrorKind::Network)?,
+            _ = rebind.changed() => {
+                tracing::info!("{WIREGUARD_INTERFACE_NAME} recreated; rebinding SSDP responder");
+                return Ok(());
+            }
+        };
         let Ok(text) = std::str::from_utf8(&buf[..n]) else {
             continue;
         };
@@ -127,23 +136,31 @@ pub(super) async fn subnet_gateway_for(ctx: &TunnelContext, peer: Ipv4Addr) -> O
 }
 
 async fn http_server(ctx: TunnelContext, root_desc: Arc<str>) {
+    let mut rebind = ctx.forward_rebind.clone();
     let app = Router::new()
         .route(ROOT_DESC_PATH, get(move || serve_static(root_desc.clone(), "text/xml")))
         .route(SCPD_PATH, get(|| serve_static(Arc::from(SCPD), "text/xml")))
         .route(CONTROL_PATH, post(control))
         .with_state(ctx);
     loop {
+        rebind.mark_seen();
         match igd_http_listener() {
             Ok(listener) => {
                 tracing::info!("UPnP IGD control server listening on {WIREGUARD_INTERFACE_NAME}:{IGD_HTTP_PORT}");
-                if let Err(e) = axum::serve(
-                    listener,
-                    app.clone()
-                        .into_make_service_with_connect_info::<SocketAddr>(),
-                )
-                .await
-                {
-                    tracing::warn!("UPnP IGD control server exited, retrying: {e}");
+                tokio::select! {
+                    res = axum::serve(
+                        listener,
+                        app.clone()
+                            .into_make_service_with_connect_info::<SocketAddr>(),
+                    ) => {
+                        if let Err(e) = res {
+                            tracing::warn!("UPnP IGD control server exited, retrying: {e}");
+                        }
+                    }
+                    _ = rebind.changed() => {
+                        tracing::info!("{WIREGUARD_INTERFACE_NAME} recreated; rebinding IGD control server");
+                        continue;
+                    }
                 }
             }
             Err(e) => tracing::warn!("UPnP IGD control server bind failed, retrying: {e}"),

--- a/shared-libs/crates/start-core/src/tunnel/forward/pcp.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/pcp.rs
@@ -86,15 +86,16 @@ fn socket6() -> Result<UdpSocket, Error> {
 
 async fn serve(ctx: &TunnelContext, started: Instant) -> Result<(), Error> {
     // Subscribe before binding so a bounce during setup still triggers a rebind.
-    let mut rebind = ctx.forward_rebind.clone();
-    rebind.mark_seen();
+    let rebind = ctx.forward_rebind.notified();
+    tokio::pin!(rebind);
+    rebind.as_mut().enable();
     let socket = socket()?;
     tracing::info!("PCP server listening on {WIREGUARD_INTERFACE_NAME}:{PCP_PORT}");
     let mut buf = [0u8; 1100];
     loop {
         let (n, from) = tokio::select! {
             res = socket.recv_from(&mut buf) => res.with_kind(ErrorKind::Network)?,
-            _ = rebind.changed() => {
+            _ = rebind.as_mut() => {
                 tracing::info!("{WIREGUARD_INTERFACE_NAME} recreated; rebinding PCP server");
                 return Ok(());
             }
@@ -110,15 +111,16 @@ async fn serve(ctx: &TunnelContext, started: Instant) -> Result<(), Error> {
 }
 
 async fn serve6(ctx: &TunnelContext, started: Instant) -> Result<(), Error> {
-    let mut rebind = ctx.forward_rebind.clone();
-    rebind.mark_seen();
+    let rebind = ctx.forward_rebind.notified();
+    tokio::pin!(rebind);
+    rebind.as_mut().enable();
     let socket = socket6()?;
     tracing::info!("PCP v6 server listening on {WIREGUARD_INTERFACE_NAME}:{PCP_PORT}");
     let mut buf = [0u8; 1100];
     loop {
         let (n, from) = tokio::select! {
             res = socket.recv_from(&mut buf) => res.with_kind(ErrorKind::Network)?,
-            _ = rebind.changed() => {
+            _ = rebind.as_mut() => {
                 tracing::info!("{WIREGUARD_INTERFACE_NAME} recreated; rebinding PCP v6 server");
                 return Ok(());
             }

--- a/shared-libs/crates/start-core/src/tunnel/forward/pcp.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/pcp.rs
@@ -25,7 +25,8 @@ use crate::tunnel::forward::sni::SniDemux;
 use crate::tunnel::wg::WIREGUARD_INTERFACE_NAME;
 
 /// Run the PCP server (IPv4 DNAT forwards + IPv6 GUA pinholes) for the life of
-/// the tunnel, each family self-restarting on error.
+/// the tunnel, each family self-restarting on error and rebinding on
+/// [`TunnelContext::forward_rebind`] (an `Ok` return from the serve loop).
 pub async fn run(ctx: TunnelContext) {
     let started = Instant::now();
     let v4 = async {
@@ -84,11 +85,20 @@ fn socket6() -> Result<UdpSocket, Error> {
 }
 
 async fn serve(ctx: &TunnelContext, started: Instant) -> Result<(), Error> {
+    // Subscribe before binding so a bounce during setup still triggers a rebind.
+    let mut rebind = ctx.forward_rebind.clone();
+    rebind.mark_seen();
     let socket = socket()?;
     tracing::info!("PCP server listening on {WIREGUARD_INTERFACE_NAME}:{PCP_PORT}");
     let mut buf = [0u8; 1100];
     loop {
-        let (n, from) = socket.recv_from(&mut buf).await.with_kind(ErrorKind::Network)?;
+        let (n, from) = tokio::select! {
+            res = socket.recv_from(&mut buf) => res.with_kind(ErrorKind::Network)?,
+            _ = rebind.changed() => {
+                tracing::info!("{WIREGUARD_INTERFACE_NAME} recreated; rebinding PCP server");
+                return Ok(());
+            }
+        };
         let IpAddr::V4(peer) = from.ip() else {
             continue;
         };
@@ -100,11 +110,19 @@ async fn serve(ctx: &TunnelContext, started: Instant) -> Result<(), Error> {
 }
 
 async fn serve6(ctx: &TunnelContext, started: Instant) -> Result<(), Error> {
+    let mut rebind = ctx.forward_rebind.clone();
+    rebind.mark_seen();
     let socket = socket6()?;
     tracing::info!("PCP v6 server listening on {WIREGUARD_INTERFACE_NAME}:{PCP_PORT}");
     let mut buf = [0u8; 1100];
     loop {
-        let (n, from) = socket.recv_from(&mut buf).await.with_kind(ErrorKind::Network)?;
+        let (n, from) = tokio::select! {
+            res = socket.recv_from(&mut buf) => res.with_kind(ErrorKind::Network)?,
+            _ = rebind.changed() => {
+                tracing::info!("{WIREGUARD_INTERFACE_NAME} recreated; rebinding PCP v6 server");
+                return Ok(());
+            }
+        };
         let IpAddr::V6(peer) = from.ip() else {
             continue;
         };


### PR DESCRIPTION
## What

After any tunnel config change that reloads the WireGuard interface (`add-subnet`, `remove-subnet`, `add-device`, `remove-device`, WAN reassignment — everything that calls `sync_network()`), the PCP server, SSDP responder, and IGD control server went permanently silent until the daemon was restarted.

## Why

`sync_network()` → `WgServer::sync()` runs `wg-quick down` + `wg-quick up`, which **deletes and recreates** `wg-start-tunnel`. The PCP/SSDP/IGD sockets are `SO_BINDTODEVICE`-bound, and that option pins the interface **index** at bind time — after the bounce they reference a dead ifindex and the kernel silently drops every inbound packet. The serve loops' self-restart never fires because a stale device binding doesn't error; it just never receives.

Observed in production on `tunnel-chad` (2026-07-07): an admin device change at 17:09:56 recreated the interface (ifindex 4 → 5); `ss` showed the listeners bound to `%if4` (a nonexistent interface); clients retried PCP MAP + SSDP M-SEARCH unanswered for hours; every auto forward, SNI route, and v6 pinhole lapsed ~1h later when the unanswered renewals hit their lease expiry, taking the exposed services offline.

The same bounce also broke the per-subnet DNS proxy resync with `Address in use`: `wait_for_abort()` on the proxy task only *schedules* the abort of hickory's internal socket tasks (dropping the `Server` drops its `JoinSet`, which aborts without awaiting), so the old `:53` sockets could still be open when `sync()` immediately rebound the same address — leaving the *old* proxy (with stale upstream config) serving.

## How

- `TunnelContextSeed` gains `forward_rebind: Watch<()>`; `sync_network()` bumps it right after `server.sync()`.
- The PCP v4/v6, SSDP, and IGD-control serve loops `select!` between their socket and `forward_rebind.changed()`, and rebind immediately (no 5s error backoff) when signaled. Each loop subscribes (`mark_seen`) **before** binding, so a bounce that lands mid-setup still triggers a rebind rather than being lost.
- `DnsProxyController` now keeps each proxy's hickory `CancellationToken` and shuts down via `shutdown_gracefully` semantics (cancel + await, 5s timeout) so the sockets are provably closed before rebinding.

## Verification

- Root cause and fix mechanism verified live on the affected production server: stale `%if4` bindings confirmed with `ss`/`tcpdump` (requests arriving, zero replies); after a daemon restart rebound the sockets by name, client PCP requests were answered again within seconds.
- `cargo check -p start-core` / `-p start-tunnel` clean; `cargo test -p start-core --features=test tunnel::` — 32 passed.

Changelog entry added under 1.1.0 (unreleased).

## Note (not in this PR)

`cargo test … export_manpage_start_tunnel` regenerates `projects/start-tunnel/man/start-tunnel-device-show-config.1` with the `WAN_ADDR` positional removed — the committed manpage is stale relative to the current CLI on master. Left out of this PR since it's unrelated drift.
