### PR TITLE
fix(install): put the s9pk download back in the background

### DIFF
--- a/shared-libs/crates/start-core/src/registry/asset.rs
+++ b/shared-libs/crates/start-core/src/registry/asset.rs
@@ -203,7 +203,7 @@ impl BufferedHttpSource {
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
         let (handle, file) = UploadingFile::new_for_download(progress).await?;
-        Self::spawn_mirror_download(handle, file, urls, client).await
+        Ok(Self::spawn_mirror_download(handle, file, urls, client))
     }
     async fn from_urls_with_path(
         path: impl AsRef<Path>,
@@ -212,23 +212,21 @@ impl BufferedHttpSource {
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
         let (handle, file) = UploadingFile::with_path_for_download(path, progress).await?;
-        Self::spawn_mirror_download(handle, file, urls, client).await
+        Ok(Self::spawn_mirror_download(handle, file, urls, client))
     }
-    async fn spawn_mirror_download(
+    // Must stay in the background — reads gate on Progress, which also surfaces download errors.
+    fn spawn_mirror_download(
         mut handle: DownloadHandle,
         file: UploadingFile,
         urls: &[Url],
         client: Client,
-    ) -> Result<Self, Error> {
-        handle
-            .download_from(MirrorRetry::new(urls.to_vec(), client).next_response())
-            .await;
-        drop(handle);
-        file.wait_for_complete().await?;
-        Ok(Self {
-            _download: tokio::spawn(async {}).into(),
+    ) -> Self {
+        let next_response = MirrorRetry::new(urls.to_vec(), client).next_response();
+        Self {
+            _download: tokio::spawn(async move { handle.download_from(next_response).await })
+                .into(),
             file,
-        })
+        }
     }
     pub async fn wait_for_buffered(&self) -> Result<(), Error> {
         self.file.wait_for_complete().await
@@ -413,6 +411,14 @@ mod tests {
                                 )
                                 .await;
                         }
+                        "/slow-tail" => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
+                                .await;
+                            let _ = stream.flush().await;
+                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                            let _ = stream.write_all(b" world").await;
+                        }
                         _ => {
                             let _ = stream
                                 .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
@@ -505,6 +511,41 @@ mod tests {
         };
 
         assert!(buffered_contents(asset).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_serves_reads_before_download_completes() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![server.url.join("slow-tail")?],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        let progress = FullProgressTracker::new().add_phase("Downloading".into(), Some(100));
+        let tmp_dir = TmpDir::new().await?;
+        // Opening the source and reading the head must not wait out the 5s tail.
+        let source = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            let source = asset
+                .load_buffered_http_source_with_path(
+                    tmp_dir.join("package.s9pk"),
+                    Client::new(),
+                    progress,
+                )
+                .await?;
+            let mut head = Vec::new();
+            source.fetch(0, 5).await?.read_to_end(&mut head).await?;
+            assert_eq!(head, b"hello");
+            Ok::<_, Error>(source)
+        })
+        .await
+        .with_kind(ErrorKind::Timeout)??;
+
+        let mut contents = Vec::new();
+        source.fetch_all().await?.read_to_end(&mut contents).await?;
+        assert_eq!(contents, b"hello world");
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

The mirror-retry rewrite (#3217) made `BufferedHttpSource::from_urls` await the **entire download** inline (`download_from` + `wait_for_complete`) before returning, leaving a no-op task in `_download`. Since `package.install` awaits that path (`service_map.rs` `s9pk().await`) **before** writing any install state to the db, the initial RPC blocked for the full s9pk download with zero UI feedback.

Through a StartTunnel outbound gateway this reads as a multi-minute hang: measured on a DevVM with a fast DO↔DO tunnel, a 15 MB package = 2.4 s raw download but a **16 s blocked RPC**; a large package through a typical VPS tunnel extrapolates to many minutes of pending `package.install`. Not tunnel-specific — the tunnel just makes it slow enough to notice.

## Fix

Spawn the mirror-retry loop into `_download`, restoring the pre-#3217 background-download behavior (same shape as `from_response`/`from_response_with_path`, which never regressed):

- Readers gate on `Progress`, which already carries download failures (`Progress::ready_for` → `Err`, `UploadingFileReader::poll_ready` → `io::Error`), so an exhausted-mirrors error now surfaces from the first gated read instead of `from_urls`.
- `DownloadHandle::drop` marks the progress complete as a backstop.
- Callers audited: `install()` streams the archive as it arrives (header validation only needs the front of the file); `registry package download` (`cli_download`) already calls `wait_for_buffered()` explicitly before renaming the temp file into place.

## Test

New regression test `buffered_download_serves_reads_before_download_completes`: a `/slow-tail` endpoint streams the first 5 bytes, stalls 5 s, then sends the tail. The test asserts opening the source and reading the head completes within 3 s — the pre-fix code fails it (blocks on the full body) — and that the final contents are intact. Existing mirror-retry tests unchanged.

No changelog entry: the regression is not in any released tag (`start-os/v0.4.0-beta.9` predates #3217), so it lands broken-and-fixed within the same unreleased 0.4.0-beta.10.