### PR TITLE
fix(install): keep UploadingFileReader wakers registered across polls

### DIFF
--- a/shared-libs/crates/start-core/src/registry/asset.rs
+++ b/shared-libs/crates/start-core/src/registry/asset.rs
@@ -203,7 +203,7 @@ impl BufferedHttpSource {
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
         let (handle, file) = UploadingFile::new_for_download(progress).await?;
-        Self::spawn_mirror_download(handle, file, urls, client).await
+        Ok(Self::spawn_mirror_download(handle, file, urls, client))
     }
     async fn from_urls_with_path(
         path: impl AsRef<Path>,
@@ -212,23 +212,21 @@ impl BufferedHttpSource {
         progress: PhaseProgressTrackerHandle,
     ) -> Result<Self, Error> {
         let (handle, file) = UploadingFile::with_path_for_download(path, progress).await?;
-        Self::spawn_mirror_download(handle, file, urls, client).await
+        Ok(Self::spawn_mirror_download(handle, file, urls, client))
     }
-    async fn spawn_mirror_download(
+    // Must stay in the background — reads gate on Progress, which also surfaces download errors.
+    fn spawn_mirror_download(
         mut handle: DownloadHandle,
         file: UploadingFile,
         urls: &[Url],
         client: Client,
-    ) -> Result<Self, Error> {
-        handle
-            .download_from(MirrorRetry::new(urls.to_vec(), client).next_response())
-            .await;
-        drop(handle);
-        file.wait_for_complete().await?;
-        Ok(Self {
-            _download: tokio::spawn(async {}).into(),
+    ) -> Self {
+        let next_response = MirrorRetry::new(urls.to_vec(), client).next_response();
+        Self {
+            _download: tokio::spawn(async move { handle.download_from(next_response).await })
+                .into(),
             file,
-        })
+        }
     }
     pub async fn wait_for_buffered(&self) -> Result<(), Error> {
         self.file.wait_for_complete().await
@@ -413,6 +411,14 @@ mod tests {
                                 )
                                 .await;
                         }
+                        "/slow-tail" => {
+                            let _ = stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
+                                .await;
+                            let _ = stream.flush().await;
+                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                            let _ = stream.write_all(b" world").await;
+                        }
                         _ => {
                             let _ = stream
                                 .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n")
@@ -505,6 +511,41 @@ mod tests {
         };
 
         assert!(buffered_contents(asset).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_serves_reads_before_download_completes() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![server.url.join("slow-tail")?],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        let progress = FullProgressTracker::new().add_phase("Downloading".into(), Some(100));
+        let tmp_dir = TmpDir::new().await?;
+        // Opening the source and reading the head must not wait out the 5s tail.
+        let source = tokio::time::timeout(std::time::Duration::from_secs(3), async {
+            let source = asset
+                .load_buffered_http_source_with_path(
+                    tmp_dir.join("package.s9pk"),
+                    Client::new(),
+                    progress,
+                )
+                .await?;
+            let mut head = Vec::new();
+            source.fetch(0, 5).await?.read_to_end(&mut head).await?;
+            assert_eq!(head, b"hello");
+            Ok::<_, Error>(source)
+        })
+        .await
+        .with_kind(ErrorKind::Timeout)??;
+
+        let mut contents = Vec::new();
+        source.fetch_all().await?.read_to_end(&mut contents).await?;
+        assert_eq!(contents, b"hello world");
         Ok(())
     }
 }

--- a/shared-libs/crates/start-core/src/upload.rs
+++ b/shared-libs/crates/start-core/src/upload.rs
@@ -77,60 +77,48 @@ impl Progress {
             .ok()
             .and_then(|a| a.expected_size)
     }
-    async fn ready_for(watch: &mut watch::Receiver<Self>, size: u64) -> Result<(), Error> {
-        match &*watch
-            .wait_for(|progress| {
-                progress.error.is_some()
-                    || progress.written >= size
-                    || progress.expected_size.map_or(false, |e| e < size)
-            })
+    /// `None` = keep waiting; `Some(res)` = stop waiting with `res`.
+    fn check(&self, target: WaitTarget) -> Option<Result<(), Error>> {
+        if let Some(e) = &self.error {
+            return Some(Err(e.clone_output()));
+        }
+        match target {
+            WaitTarget::Complete => self.complete.then(|| Ok(())),
+            WaitTarget::DataAt(position) => {
+                (self.complete || self.written > position).then(|| Ok(()))
+            }
+            WaitTarget::SizeAtLeast(size) => {
+                if self.written >= size {
+                    Some(Ok(()))
+                } else if self.expected_size.map_or(false, |e| e < size) {
+                    Some(Err(Error::new(
+                        eyre!("file size is less than requested"),
+                        ErrorKind::Network,
+                    )))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+    async fn wait(watch: &mut watch::Receiver<Self>, target: WaitTarget) -> Result<(), Error> {
+        watch
+            .wait_for(|progress| progress.check(target).is_some())
             .await
             .map_err(|_| {
                 Error::new(
                     eyre!("failed to determine upload progress"),
                     ErrorKind::Network,
                 )
-            })? {
-            Progress { error: Some(e), .. } => Err(e.clone_output()),
-            Progress {
-                expected_size: Some(e),
-                ..
-            } if *e < size => Err(Error::new(
-                eyre!("file size is less than requested"),
-                ErrorKind::Network,
-            )),
-            _ => Ok(()),
-        }
+            })?
+            .check(target)
+            .expect("wait_for predicate held")
+    }
+    async fn ready_for(watch: &mut watch::Receiver<Self>, size: u64) -> Result<(), Error> {
+        Self::wait(watch, WaitTarget::SizeAtLeast(size)).await
     }
     async fn ready(watch: &mut watch::Receiver<Self>) -> Result<(), Error> {
-        match &*watch
-            .wait_for(|progress| progress.error.is_some() || progress.complete)
-            .await
-            .map_err(|_| {
-                Error::new(
-                    eyre!("failed to determine upload progress"),
-                    ErrorKind::Network,
-                )
-            })? {
-            Progress { error: Some(e), .. } => Err(e.clone_output()),
-            _ => Ok(()),
-        }
-    }
-    async fn data_at(watch: &mut watch::Receiver<Self>, position: u64) -> Result<(), Error> {
-        match &*watch
-            .wait_for(|progress| {
-                progress.error.is_some() || progress.complete || progress.written > position
-            })
-            .await
-            .map_err(|_| {
-                Error::new(
-                    eyre!("failed to determine upload progress"),
-                    ErrorKind::Network,
-                )
-            })? {
-            Progress { error: Some(e), .. } => Err(e.clone_output()),
-            _ => Ok(()),
-        }
+        Self::wait(watch, WaitTarget::Complete).await
     }
     fn complete(&mut self) -> bool {
         let mut changed = !self.complete;
@@ -323,20 +311,17 @@ impl<'a> UploadingFileReaderProjection<'a> {
         target: WaitTarget,
     ) -> Result<bool, std::io::Error> {
         if self.wait.as_ref().map(|(t, _)| *t) != Some(target) {
+            // fast path: already satisfied — skip allocating a wait future
+            let ready = self.progress.borrow().check(target);
+            if let Some(res) = ready {
+                *self.wait = None;
+                res.map_err(|e| std::io::Error::other(e.source))?;
+                return Ok(true);
+            }
             let mut progress = self.progress.clone();
             *self.wait = Some((
                 target,
-                Box::pin(async move {
-                    match target {
-                        WaitTarget::Complete => Progress::ready(&mut progress).await,
-                        WaitTarget::SizeAtLeast(size) => {
-                            Progress::ready_for(&mut progress, size).await
-                        }
-                        WaitTarget::DataAt(position) => {
-                            Progress::data_at(&mut progress, position).await
-                        }
-                    }
-                }),
+                Box::pin(async move { Progress::wait(&mut progress, target).await }),
             ));
         }
         let (_, wait) = self.wait.as_mut().expect("wait future was just created");
@@ -358,12 +343,29 @@ impl AsyncRead for UploadingFileReader {
     ) -> Poll<std::io::Result<()>> {
         let mut this = self.project();
 
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
         let position = *this.position;
         if this.poll_wait(cx, WaitTarget::DataAt(position))? {
             let start = buf.filled().len();
-            let res = this.file.poll_read(cx, buf);
-            *this.position += (buf.filled().len() - start) as u64;
-            res
+            ready!(this.file.as_mut().poll_read(cx, buf))?;
+            let read = (buf.filled().len() - start) as u64;
+            *this.position += read;
+            if read == 0 {
+                let eof = {
+                    let p = this.progress.borrow();
+                    p.error.is_none() && p.complete && p.written <= *this.position
+                };
+                if !eof {
+                    // A mirror retry truncated the file out from under us (or its bytes
+                    // aren't visible yet) — retry rather than report a false EOF. The
+                    // self-wake yields so the writer task can catch up.
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            }
+            Poll::Ready(Ok(()))
         } else {
             Poll::Pending
         }

--- a/shared-libs/crates/start-core/src/upload.rs
+++ b/shared-libs/crates/start-core/src/upload.rs
@@ -10,7 +10,7 @@ use axum::body::Body;
 use axum::extract::Request;
 use axum::response::Response;
 use bytes::Bytes;
-use futures::{FutureExt, Stream, StreamExt, ready};
+use futures::{Stream, StreamExt, ready};
 use http::header::{CONTENT_LENGTH, CONTENT_RANGE};
 use http::{HeaderMap, StatusCode};
 use imbl_value::InternedString;
@@ -105,6 +105,22 @@ impl Progress {
     async fn ready(watch: &mut watch::Receiver<Self>) -> Result<(), Error> {
         match &*watch
             .wait_for(|progress| progress.error.is_some() || progress.complete)
+            .await
+            .map_err(|_| {
+                Error::new(
+                    eyre!("failed to determine upload progress"),
+                    ErrorKind::Network,
+                )
+            })? {
+            Progress { error: Some(e), .. } => Err(e.clone_output()),
+            _ => Ok(()),
+        }
+    }
+    async fn data_at(watch: &mut watch::Receiver<Self>, position: u64) -> Result<(), Error> {
+        match &*watch
+            .wait_for(|progress| {
+                progress.error.is_some() || progress.complete || progress.written > position
+            })
             .await
             .map_err(|_| {
                 Error::new(
@@ -270,12 +286,20 @@ impl ArchiveSource for UploadingFile {
             position: 0,
             to_seek: None,
             progress: self.progress.clone(),
+            wait: None,
         })
     }
     async fn fetch(&self, position: u64, size: u64) -> Result<Self::FetchReader, Error> {
         Progress::ready_for(&mut self.progress.clone(), position + size).await?;
         self.file.fetch(position, size).await
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum WaitTarget {
+    Complete,
+    SizeAtLeast(u64),
+    DataAt(u64),
 }
 
 #[pin_project::pin_project(project = UploadingFileReaderProjection)]
@@ -286,27 +310,44 @@ pub struct UploadingFileReader {
     #[pin]
     file: FileCursor,
     progress: watch::Receiver<Progress>,
+    wait: Option<(
+        WaitTarget,
+        Pin<Box<dyn Future<Output = Result<(), Error>> + Send + Sync>>,
+    )>,
 }
 impl<'a> UploadingFileReaderProjection<'a> {
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Result<bool, std::io::Error> {
-        let ready = Progress::ready(&mut *self.progress);
-        tokio::pin!(ready);
-        Ok(ready
-            .poll_unpin(cx)
-            .map_err(|e| std::io::Error::other(e.source))?
-            .is_ready())
-    }
-    fn poll_ready_for(
+    // The wait future is kept across polls — dropping it would deregister its waker.
+    fn poll_wait(
         &mut self,
         cx: &mut std::task::Context<'_>,
-        size: u64,
+        target: WaitTarget,
     ) -> Result<bool, std::io::Error> {
-        let ready = Progress::ready_for(&mut *self.progress, size);
-        tokio::pin!(ready);
-        Ok(ready
-            .poll_unpin(cx)
-            .map_err(|e| std::io::Error::other(e.source))?
-            .is_ready())
+        if self.wait.as_ref().map(|(t, _)| *t) != Some(target) {
+            let mut progress = self.progress.clone();
+            *self.wait = Some((
+                target,
+                Box::pin(async move {
+                    match target {
+                        WaitTarget::Complete => Progress::ready(&mut progress).await,
+                        WaitTarget::SizeAtLeast(size) => {
+                            Progress::ready_for(&mut progress, size).await
+                        }
+                        WaitTarget::DataAt(position) => {
+                            Progress::data_at(&mut progress, position).await
+                        }
+                    }
+                }),
+            ));
+        }
+        let (_, wait) = self.wait.as_mut().expect("wait future was just created");
+        match wait.as_mut().poll(cx) {
+            Poll::Ready(res) => {
+                *self.wait = None;
+                res.map_err(|e| std::io::Error::other(e.source))?;
+                Ok(true)
+            }
+            Poll::Pending => Ok(false),
+        }
     }
 }
 impl AsyncRead for UploadingFileReader {
@@ -318,7 +359,7 @@ impl AsyncRead for UploadingFileReader {
         let mut this = self.project();
 
         let position = *this.position;
-        if this.poll_ready(cx)? || this.poll_ready_for(cx, position + buf.remaining() as u64)? {
+        if this.poll_wait(cx, WaitTarget::DataAt(position))? {
             let start = buf.filled().len();
             let res = this.file.poll_read(cx, buf);
             *this.position += (buf.filled().len() - start) as u64;
@@ -348,7 +389,7 @@ impl AsyncSeek for UploadingFileReader {
                     match expected_size {
                         Some(end) => (end as i64 + n) as u64,
                         None => {
-                            if !this.poll_ready(cx)? {
+                            if !this.poll_wait(cx, WaitTarget::Complete)? {
                                 return Poll::Pending;
                             }
                             (this.progress.borrow().expected_size.ok_or_else(|| {
@@ -362,7 +403,7 @@ impl AsyncSeek for UploadingFileReader {
                     }
                 }
             };
-            if !this.poll_ready_for(cx, size)? {
+            if !this.poll_wait(cx, WaitTarget::SizeAtLeast(size))? {
                 return Poll::Pending;
             }
         }


### PR DESCRIPTION
Follow-up to #3431, whose test suite hangs in CI (master's "Automated Tests" run is currently stuck on it).

## Root cause

`UploadingFileReader::poll_ready{,_for}` created a fresh `watch::Receiver::wait_for` future, polled it **once**, and dropped it. Dropping the future deregisters its waker, so a progress update that lands between polls is lost and the reader's task is never woken — it pends forever.

The bug is latent, not new: production reads gate through `UploadingFile::fetch` (a genuine `.await`, safe), so only `fetch_all` on a still-downloading file reaches the broken poll path. Before #3217 nothing hit it; #3217's inline download guaranteed completion before any read; #3431 restored the background download and its tests read via `fetch_all` mid-download — hanging the suite (locally reproduced: download task completes and records its outcome, reader never wakes).

## Fix

- Store the wait future in the reader across polls (keyed by wait target: `Complete` / `SizeAtLeast` / `DataAt`), so the waker stays registered while pending; drop it only once it resolves.
- Gate `poll_read` on `DataAt(position)` — "data available at my position, or the transfer finished" — instead of `ready_for(position + buf.remaining())`, which mid-download either pended (with the lost waker) or spuriously errored with "file size is less than requested" whenever the destination buffer overshot the file size. Reads now stream as bytes arrive; EOF surfaces naturally once complete. Seeks keep the old `ready_for` semantics.

## Verification

Previously-hanging combinations now pass (were reproducible hangs locally, >30min):
- full `registry::asset` suite serial + parallel: 6 passed in ~5s
- cross-module pair (`net::acme` + asset): passes
- `s9pk::merkle_archive` suite: passes

Full local test-binary sweep and CI will confirm the rest of the crate.