### PR TITLE
ci: skip binary/image builds on doc-only changes

### DIFF
--- a/.github/workflows/start-cli.yaml
+++ b/.github/workflows/start-cli.yaml
@@ -43,6 +43,9 @@ on:
       - "debian/**"
       - ".github/workflows/start-cli.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits shouldn't trigger a build. (start-cli has no docs/ subtree
+      # today, but this guards a README or future docs added under the allowlist.)
+      - "!**/*.md"
   pull_request:
     branches:
       - master
@@ -56,6 +59,9 @@ on:
       - "debian/**"
       - ".github/workflows/start-cli.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits shouldn't trigger a build. (start-cli has no docs/ subtree
+      # today, but this guards a README or future docs added under the allowlist.)
+      - "!**/*.md"
 
 # The group is scoped by event so a master push can't cancel an in-flight
 # dispatched release build; dispatches queue behind each other, never cancel.

--- a/.github/workflows/start-registry.yaml
+++ b/.github/workflows/start-registry.yaml
@@ -41,6 +41,9 @@ on:
       - "debian/**"
       - ".github/workflows/start-registry.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits shouldn't trigger a build. (start-registry has no docs/
+      # subtree today, but this guards a README or future docs under the allowlist.)
+      - "!**/*.md"
   pull_request:
     branches:
       - master
@@ -54,6 +57,9 @@ on:
       - "debian/**"
       - ".github/workflows/start-registry.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits shouldn't trigger a build. (start-registry has no docs/
+      # subtree today, but this guards a README or future docs under the allowlist.)
+      - "!**/*.md"
 
 # The group is scoped by event so a master push can't cancel an in-flight
 # dispatched release build; dispatches queue behind each other, never cancel.

--- a/.github/workflows/start-tunnel.yaml
+++ b/.github/workflows/start-tunnel.yaml
@@ -48,6 +48,9 @@ on:
       - "apt/**"
       - ".github/workflows/start-tunnel.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits under the allowlisted project trees (e.g.
+      # projects/start-tunnel/docs/**) shouldn't trigger a build.
+      - "!**/*.md"
   pull_request:
     branches:
       - master
@@ -68,6 +71,9 @@ on:
       - "apt/**"
       - ".github/workflows/start-tunnel.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits under the allowlisted project trees (e.g.
+      # projects/start-tunnel/docs/**) shouldn't trigger a build.
+      - "!**/*.md"
 
 # The group is scoped by event so a master push can't cancel an in-flight
 # dispatched release build; dispatches queue behind each other, never cancel.

--- a/.github/workflows/start-wrt.yaml
+++ b/.github/workflows/start-wrt.yaml
@@ -41,6 +41,9 @@ on:
       - "build/**"
       - ".github/workflows/start-wrt.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits under the allowlisted project trees (e.g.
+      # projects/start-wrt/docs/**) shouldn't trigger a build.
+      - "!**/*.md"
   pull_request:
     branches:
       - master
@@ -59,6 +62,9 @@ on:
       - "build/**"
       - ".github/workflows/start-wrt.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits under the allowlisted project trees (e.g.
+      # projects/start-wrt/docs/**) shouldn't trigger a build.
+      - "!**/*.md"
 
 # The group is scoped by event so a master push can't cancel an in-flight
 # dispatched release build; dispatches queue behind each other, never cancel.

--- a/.github/workflows/startos-iso.yaml
+++ b/.github/workflows/startos-iso.yaml
@@ -61,6 +61,9 @@ on:
       - "apt/**"
       - ".github/workflows/startos-iso.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits under the allowlisted project trees (e.g.
+      # projects/start-os/docs/**) shouldn't trigger a build.
+      - "!**/*.md"
   pull_request:
     branches:
       - master
@@ -81,6 +84,9 @@ on:
       - "apt/**"
       - ".github/workflows/startos-iso.yaml"
       - ".github/actions/setup-build/**"
+      # Doc-only edits under the allowlisted project trees (e.g.
+      # projects/start-os/docs/**) shouldn't trigger a build.
+      - "!**/*.md"
 
 # The group is scoped by event so a master push can't cancel an in-flight
 # dispatched release build; dispatches queue behind each other, never cancel.


### PR DESCRIPTION
## Problem

The five binary/image build workflows — `startos-iso`, `start-wrt`, `start-tunnel`, `start-cli`, `start-registry` — allowlist their entire project subtree (`projects/<product>/**`). Because each product's docs live *inside* that tree (`projects/start-os/docs/`, `projects/start-wrt/docs/`, `projects/start-tunnel/docs/`, `projects/start-sdk/docs/`), a **doc-only** edit satisfies the path filter and triggers a full build.

Concretely, #3435 changed nothing but two `trust-ca.md` files yet kicked off the entire ISO matrix (9 platforms + base-binary compiles) and the WRT build:

- `projects/start-os/docs/src/trust-ca.md` → matched `projects/start-os/**` → `startos-iso`
- `projects/start-wrt/docs/src/trust-ca.md` → matched `projects/start-wrt/**` → `start-wrt`

`test.yaml` correctly skipped it (it uses `paths-ignore: "**/*.md"`), and `deploy-brochure.yml` had already fixed this exact trap with a trailing `- "!**/*.md"` — the build workflows just never copied it.

## Change

Append `- "!**/*.md"` as the final entry of every `push` and `pull_request` `paths:` list in the five build workflows. GitHub evaluates path patterns in order, so the trailing negation drops any markdown change; a doc-only PR now matches nothing and skips the build.

`start-cli` and `start-registry` have no `docs/` subtree today — the exclusion is added there too for consistency and to guard a future README/docs under the allowlist.

## Not affected

- **`docs-deploy.yml` is untouched.** Doc edits under `projects/*/docs/**` still build the mdBooks and deploy to docs.start9.com on push to `master`, exactly as before.
- This keeps the `paths:` aligned with their documented contract (AGENTS.md "Coupled changes": the filters mirror `build.mk` build inputs, and `build.mk` doesn't list `docs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)