### PR TITLE
fix(brochure): localize dependency descriptions instead of [object Object]

### DIFF
--- a/projects/brochure-marketplace/ARCHITECTURE.md
+++ b/projects/brochure-marketplace/ARCHITECTURE.md
@@ -34,6 +34,7 @@ src/
       live-api.service.ts      real impl: RPC over HTTP to registries (prod)
       mock-api.service.ts      fixture impl backed by api.fixures.ts (dev)
       marketplace.service.ts   AbstractMarketplaceService impl (registry state)
+      localize.ts              collapses LocaleString metadata to the active locale at ingress
       marketplace.service spec / fixtures / icons / md-sample.md
 ```
 
@@ -45,6 +46,7 @@ src/
    - Default registries (Start9 + Community) come from `@start9labs/shared`'s `defaultRegistries`.
    - Custom registries are persisted in `localStorage` under the `_startos/` prefix and exposed reactively via a `BehaviorSubject`.
    - It fetches registry info + packages through `ApiService` and converts raw registry responses into `MarketplacePkg` objects; fetch failures emit on `registryError$`.
+   - **Localization boundary.** Registries return i18n metadata as `LocaleString` (`string | Record<lang, string>`) and only flatten it to one locale when a request carries a StartOS `device_info` — which this static, hostless site never sends. So `localize.ts` collapses every `LocaleString` field to the active locale here, as data enters the app, mirroring what the StartOS backend does for the embedded UI. Without it the raw `Record` form reaches templates and renders as `[object Object]`. This single boundary (rather than per-template `| localize`) is also where a future in-app language selector would re-localize.
 4. `LiveApiService` talks to registries with JSON-RPC over HTTP (`RELATIVE_URL` = `/rpc/v0`), using `@start9labs/shared`'s `HttpService`; it also proxies static package files (`LICENSE.md`, `instructions.md`). `MockApiService` returns the fixtures instead.
 
 ## UI stack

--- a/projects/brochure-marketplace/src/app/services/api.fixures.ts
+++ b/projects/brochure-marketplace/src/app/services/api.fixures.ts
@@ -48,7 +48,12 @@ export namespace Mock {
     title: 'Bitcoin',
     icon: BTC_ICON,
     optional: false,
-    description: 'Needed to run',
+    // Localized (Record) form — mirrors what live registries return and
+    // exercises the LocaleString branch that used to render "[object Object]".
+    description: {
+      en_US: 'Needed to run',
+      de_DE: 'Zum Ausführen erforderlich',
+    },
   }
 
   export const ProxyDep: T.DependencyMetadata = {

--- a/projects/brochure-marketplace/src/app/services/localize.ts
+++ b/projects/brochure-marketplace/src/app/services/localize.ts
@@ -1,0 +1,73 @@
+import { GetPackageRes } from '@start9labs/marketplace'
+import { T } from '@start9labs/start-core'
+
+/**
+ * Registries serve i18n metadata as `LocaleString` (`string | Record<lang,
+ * string>`) and only collapse it to the active locale when the request carries
+ * a StartOS `device_info` — which this static, hostless site never sends. So we
+ * flatten every `LocaleString` leaf to a string here, at the single data-ingress
+ * boundary, mirroring what the StartOS backend does for the embedded UI. Without
+ * it the raw `Record` form reaches templates and renders as "[object Object]".
+ *
+ * Centralizing it here (rather than relying on per-template `| localize`) holds
+ * the guarantee even if a component forgets to localize, and is the hook a
+ * future in-app language selector re-runs to re-localize without re-fetching.
+ */
+export type Localize = (value: T.LocaleString) => string
+
+export function localizeRegistryInfo(
+  info: T.RegistryInfo,
+  localize: Localize,
+): T.RegistryInfo {
+  return {
+    ...info,
+    categories: mapValues(info.categories, c => ({
+      ...c,
+      name: localize(c.name),
+    })),
+  }
+}
+
+export function localizePackageRes(
+  res: GetPackageRes,
+  localize: Localize,
+): GetPackageRes {
+  return {
+    ...res,
+    best: mapValues(res.best, v => localizeVersionInfo(v, localize)),
+    otherVersions:
+      res.otherVersions &&
+      mapValues(res.otherVersions, v => ({
+        ...v,
+        releaseNotes: localize(v.releaseNotes),
+      })),
+  }
+}
+
+function localizeVersionInfo(
+  v: T.PackageVersionInfo,
+  localize: Localize,
+): T.PackageVersionInfo {
+  return {
+    ...v,
+    description: {
+      short: localize(v.description.short),
+      long: localize(v.description.long),
+    },
+    releaseNotes: localize(v.releaseNotes),
+    dependencyMetadata: mapValues(v.dependencyMetadata, d => ({
+      ...d,
+      title: d.title == null ? d.title : localize(d.title),
+      description:
+        d.description == null ? d.description : localize(d.description),
+    })),
+  }
+}
+
+const mapValues = <V, R>(
+  record: Record<string, V>,
+  fn: (value: V) => R,
+): Record<string, R> =>
+  Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, fn(value)]),
+  )

--- a/projects/brochure-marketplace/src/app/services/marketplace.service.ts
+++ b/projects/brochure-marketplace/src/app/services/marketplace.service.ts
@@ -11,6 +11,7 @@ import {
   defaultRegistries,
   Exver,
   i18nPipe,
+  i18nService,
   registryUrl,
   sameUrl,
 } from '@start9labs/shared'
@@ -36,6 +37,7 @@ import {
 } from 'rxjs/operators'
 
 import { ApiService } from './api.service'
+import { Localize, localizePackageRes, localizeRegistryInfo } from './localize'
 
 const { start9, community } = defaultRegistries
 
@@ -51,6 +53,12 @@ export class MarketplaceService extends AbstractMarketplaceService {
   private readonly exver = inject(Exver)
   private readonly storage = inject(WA_LOCAL_STORAGE)
   private readonly i18n = inject(i18nPipe)
+  private readonly i18nService = inject(i18nService)
+
+  // Collapse LocaleString metadata to the active locale as it enters the app —
+  // see localize.ts for why this static site must do it client-side.
+  private readonly localize: Localize = value =>
+    this.i18nService.localize(value)
 
   // Emits the url of a registry that failed to load (unreachable / CORS).
   readonly registryError$ = new Subject<string>()
@@ -155,6 +163,7 @@ export class MarketplaceService extends AbstractMarketplaceService {
 
   fetchInfo$(url: string): Observable<T.RegistryInfo> {
     return from(this.api.getRegistryInfo(url)).pipe(
+      map(info => localizeRegistryInfo(info, this.localize)),
       map(info => ({
         ...info,
         categories: { all: { name: 'All' }, ...info.categories },
@@ -176,8 +185,9 @@ export class MarketplaceService extends AbstractMarketplaceService {
   private fetchPackages$(url: string): Observable<MarketplacePkg[]> {
     return from(this.api.getRegistryPackages(url)).pipe(
       map(packages =>
-        Object.entries(packages).flatMap(([id, pkgInfo]) =>
-          Object.keys(pkgInfo.best).flatMap(version => {
+        Object.entries(packages).flatMap(([id, raw]) => {
+          const pkgInfo = localizePackageRes(raw, this.localize)
+          return Object.keys(pkgInfo.best).flatMap(version => {
             const pkg = this.convertToMarketplacePkg(
               id,
               version,
@@ -185,8 +195,8 @@ export class MarketplaceService extends AbstractMarketplaceService {
               pkgInfo,
             )
             return pkg ? [pkg] : []
-          }),
-        ),
+          })
+        }),
       ),
     )
   }
@@ -201,7 +211,12 @@ export class MarketplaceService extends AbstractMarketplaceService {
       this.api.getRegistryPackage(url, id, version ? `=${version}` : null),
     ).pipe(
       map(pkgInfo =>
-        this.convertToMarketplacePkg(id, version, flavor, pkgInfo),
+        this.convertToMarketplacePkg(
+          id,
+          version,
+          flavor,
+          localizePackageRes(pkgInfo, this.localize),
+        ),
       ),
     )
   }

--- a/shared-libs/ts-modules/marketplace/src/components/dependency.component.ts
+++ b/shared-libs/ts-modules/marketplace/src/components/dependency.component.ts
@@ -1,7 +1,7 @@
 import { KeyValue } from '@angular/common'
 import { Component, inject, input } from '@angular/core'
 import { RouterModule } from '@angular/router'
-import { i18nPipe, i18nService } from '@start9labs/shared'
+import { i18nPipe, i18nService, LocalizePipe } from '@start9labs/shared'
 import { T } from '@start9labs/start-core'
 import { TuiCell, TuiTitle } from '@taiga-ui/core'
 import { TuiAvatar } from '@taiga-ui/kit'
@@ -20,11 +20,13 @@ import { MarketplacePkgBase } from '../types'
       } @else {
         ({{ 'Required' | i18n }})
       }
-      <span tuiSubtitle>{{ dep().value.description }}</span>
+      @if (dep().value.description; as description) {
+        <span tuiSubtitle>{{ description | localize }}</span>
+      }
     </span>
   `,
   hostDirectives: [TuiCell],
-  imports: [RouterModule, TuiAvatar, i18nPipe, TuiTitle],
+  imports: [RouterModule, TuiAvatar, i18nPipe, LocalizePipe, TuiTitle],
 })
 export class MarketplaceDependencyComponent {
   private readonly i18nService = inject(i18nService)


### PR DESCRIPTION
## Summary

The brochure marketplace showed `[object Object]` for a package dependency's description (e.g. [bitcoind / knots on beta-registry](https://marketplace.start9.com/?registry=https:%2F%2Fbeta-registry.start9.com%2F&id=bitcoind&flavor=knots)).

**Root cause.** Registries serve i18n metadata as `LocaleString` (`string | Record<lang, string>`) and only flatten it to a single locale when the request carries a StartOS `device_info` (the hardware-gated `for_device` path in `registry/package/index.rs`). The brochure is a **static, hostless site** that calls the registry RPC directly with no `device_info`, so it receives the raw `Record` form. The dependency description was interpolated raw and rendered as `[object Object]`. The embedded StartOS UI is unaffected because its host-proxy injects `device_info`, so the backend flattens server-side.

An audit confirmed this was the *only* raw-`LocaleString` render site — every other localizable field already localizes, and package/registry titles are plain `string` by type.

## Changes

- **Ingress localization** (`localize.ts`, wired into `MarketplaceService.fetchInfo$` / `fetchPackages$` / `fetchPackage$`): collapse every `LocaleString` field — `description.short/long`, `releaseNotes`, `dependencyMetadata[*].{title,description}`, category `name`, `otherVersions[*].releaseNotes` — to the active locale as data enters the app. This is a single boundary that mirrors what the backend does for the embedded UI, so no component can reintroduce the bug by forgetting to localize.
- **Shared component fix**: `MarketplaceDependencyComponent` now localizes the description. Needed independently of the brochure because it also covers the OS **sideload** path (a local `.s9pk` is never server-localized).
- **Dev fixtures**: one dependency description is now a localized `Record` and the other a string, so both `LocaleString` branches are exercised in mock/dev.
- **Docs**: `ARCHITECTURE.md` gains a localization-boundary note.

A future in-app language selector can re-localize at this same boundary (re-run against the retained raw response — no refetch), so it is not blocked on any backend change.

## Verification

`npm run check:marketplace`, `check:brochure`, and `check:ui` all pass; prettier clean. No app/image build performed.