### PR TITLE
fix(sdk): don't destroy a daemon's subcontainer on a dependency pause

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.3 — StartOS 0.4.0-beta.10 (2026-07-08)
+
+### Fixed
+
+- **A dependency-gated daemon no longer wedges permanently after its dependency's readiness flaps.** Since 2.0.0's hold/release refactor, `Daemon.term()` unconditionally destroyed the daemon's `SubContainer`, and `HealthDaemon` calls `term()` every time a dependency goes not-ready. When the dependency's health then recovered, the daemon's `start()` called `hold()` on the already-destroyed subcontainer and threw `cannot hold subcontainer …: already destroyed`. Because that `start()` was un-awaited, it surfaced as an unhandled rejection and the daemon never recovered — the health check reported "not ready" / "daemon crashed" indefinitely, curable only by a full package restart. Any service with a dependency-gated daemon was exposed (e.g. `c-lightning`'s and BTCPay's web UIs). The 2.0.0 refactor had removed the `destroySubcontainer` flag that previously kept the subcontainer alive across a stop, collapsing "pause" and "teardown" into one destroying `term()`. This restores the distinction under the hold/release model: `Daemon` gains a non-destroying **`stop()`** (aborts the loop, terminates the process, releases the hold — but leaves the `SubContainer` intact so a later `start()` re-holds it), and `HealthDaemon.changeRunning(false)` now calls `stop()` for a dependency-driven pause. `Daemon.term()` (used by `HealthDaemon.term()` and `Daemons.term()` for genuine teardown) still releases the hold and destroys the subcontainer. `HealthDaemon.changeRunning(true)` additionally awaits and catches `start()`, so a start failure becomes a health failure rather than a silent unhandled-rejection wedge
+- **Dependency-driven pause/resume transitions are now serialized.** `HealthDaemon.updateStatus()` runs fire-and-forget from dependency watchers, so a fast readiness flap (not-ready → ready before the pause's `stop()` finished draining the process) could overlap the pause with the following resume. Because `Daemon.start()` is a no-op while the previous run loop is still winding down, the resume's `start()` could silently do nothing and leave the daemon stopped while the health session believed it was running — the same class of wedge, reachable via a fast flap. `HealthDaemon` now applies pause/resume transitions on an in-order promise chain, so a resume always waits for the in-flight pause to complete before re-holding and restarting
+
 ## 2.0.2 — StartOS 0.4.0-beta.10 (2026-07-08)
 
 ### Changed

--- a/projects/start-sdk/lib/mainFn/CommandController.ts
+++ b/projects/start-sdk/lib/mainFn/CommandController.ts
@@ -173,7 +173,8 @@ export class CommandController<
    * Terminate the running command by sending a signal.
    *
    * Sends the specified signal (default: SIGTERM), then escalates to SIGKILL
-   * after the timeout expires. Destroys the subcontainer after the process exits.
+   * after the timeout expires, and awaits the process's exit. Does not touch
+   * the SubContainer — its lifecycle is owned by {@link Daemon} (`stop`/`term`).
    *
    * @param options.signal - The signal to send (default: SIGTERM)
    * @param options.timeout - Milliseconds before escalating to SIGKILL

--- a/projects/start-sdk/lib/mainFn/Daemon.ts
+++ b/projects/start-sdk/lib/mainFn/Daemon.ts
@@ -14,10 +14,12 @@ const MAX_TIMEOUT_MS = 30000
  * A managed long-running process wrapper around {@link CommandController}.
  *
  * When started, the daemon automatically restarts its underlying command on
- * failure with exponential backoff (up to 30 seconds). When stopped, the
- * command is terminated gracefully. While the daemon is running, it holds a
- * use-token (`subcontainer.hold()`) on its SubContainer so the container is
- * not destroyed out from under it. The hold is released on `term()`.
+ * failure with exponential backoff (up to 30 seconds). While the daemon is
+ * running, it holds a use-token (`subcontainer.hold()`) on its SubContainer
+ * so the container is not destroyed out from under it. There are two ways to
+ * bring it down: {@link stop} releases the hold but leaves the SubContainer
+ * intact so a later {@link start} can resume in it (a restartable pause);
+ * {@link term} additionally destroys the SubContainer (genuine teardown).
  *
  * @typeParam Manifest - The service manifest type
  * @typeParam C - The subcontainer type, or `null` for JS-only daemons
@@ -97,9 +99,9 @@ export class Daemon<
    * Start the daemon. If it is already running, this is a no-op.
    *
    * Takes a `hold()` on the daemon's SubContainer (if any) so the container
-   * is kept alive while the daemon runs. The hold is released on
-   * {@link term}. The daemon will automatically restart on failure with
-   * increasing backoff until `term` is called.
+   * is kept alive while the daemon runs. The hold is released by {@link stop}
+   * (a restartable pause) or {@link term} (teardown). The daemon automatically
+   * restarts on failure with increasing backoff until `stop`/`term` is called.
    */
   async start() {
     if (this.loop) {
@@ -172,20 +174,27 @@ export class Daemon<
   }
 
   /**
-   * Terminate the daemon, stopping its underlying command, releasing the
-   * SubContainer hold taken at {@link start}, and requesting the
-   * SubContainer's destruction (`destroy()` is idempotent and defers to
-   * the last hold release, so other daemons sharing the same SubContainer
-   * keep it alive until they also term).
+   * Stop the daemon's process and restart loop and release the SubContainer
+   * hold taken at {@link start}, **without** destroying the SubContainer.
+   * A subsequent {@link start} re-takes the hold and resumes in the same
+   * container.
    *
-   * Sends the configured signal (default SIGTERM) and waits for the
-   * process to exit.
+   * This is the non-destroying counterpart to {@link term}: use it for a
+   * temporary stop where the daemon is expected to start again — e.g. a
+   * dependency going not-ready. Releasing the hold without requesting
+   * destruction leaves the SubContainer alive (its leader keeps `proc/1`),
+   * so the restart is cheaper than a destroy + recreate and — as long as
+   * nothing else has requested destruction — the next `start()`'s `hold()`
+   * succeeds rather than throwing `already destroyed`.
+   *
+   * Sends the configured signal (default SIGTERM) and waits for the process
+   * to exit. Idempotent, and a no-op when the daemon is not running.
    *
    * @param termOptions Optional termination settings
    * @param termOptions.signal The signal to send (default `SIGTERM`)
    * @param termOptions.timeout Milliseconds to wait before escalating to `SIGKILL` (default = `Daemon`'s configured `sigtermTimeout`, ultimately `DEFAULT_SIGTERM_TIMEOUT`)
    */
-  async term(termOptions?: {
+  async stop(termOptions?: {
     signal?: NodeJS.Signals | undefined
     timeout?: number | undefined
   }) {
@@ -209,6 +218,31 @@ export class Daemon<
       this.releaseSubcontainerHold = null
       await release().catch(logErrorOnce)
     }
+  }
+
+  /**
+   * Terminate the daemon: {@link stop} it (stop the process, abort the
+   * restart loop, release the SubContainer hold taken at {@link start}) and
+   * then request the SubContainer's destruction.
+   *
+   * `destroy()` is idempotent and defers to the last hold release, so other
+   * daemons sharing the same SubContainer keep it alive until they also
+   * term. Unlike {@link stop}, this is a one-way teardown — a `start()`
+   * after `term()` throws `already destroyed`; use {@link stop} for a
+   * restartable pause.
+   *
+   * Sends the configured signal (default SIGTERM) and waits for the
+   * process to exit.
+   *
+   * @param termOptions Optional termination settings
+   * @param termOptions.signal The signal to send (default `SIGTERM`)
+   * @param termOptions.timeout Milliseconds to wait before escalating to `SIGKILL` (default = `Daemon`'s configured `sigtermTimeout`, ultimately `DEFAULT_SIGTERM_TIMEOUT`)
+   */
+  async term(termOptions?: {
+    signal?: NodeJS.Signals | undefined
+    timeout?: number | undefined
+  }) {
+    await this.stop(termOptions)
 
     // Request the SubContainer's destruction. Idempotent + hold-aware:
     // if another daemon still holds this SubContainer, destroy waits for

--- a/projects/start-sdk/lib/mainFn/HealthDaemon.ts
+++ b/projects/start-sdk/lib/mainFn/HealthDaemon.ts
@@ -3,6 +3,7 @@ import { defaultTrigger } from '../trigger/defaultTrigger'
 import { Ready } from './Daemons'
 import { Daemon } from './Daemon'
 import { SetHealth, Effects, SDKManifest } from '@start9labs/start-core/types'
+import { asError } from '@start9labs/start-core/util/asError'
 
 export const EXIT_SUCCESS = 'EXIT_SUCCESS' as const
 
@@ -17,6 +18,7 @@ export class HealthDaemon<Manifest extends SDKManifest> {
   private _health: HealthCheckResult = { result: 'waiting', message: null }
   private healthWatchers: Array<() => unknown> = []
   private running = false
+  private transition: Promise<void> = Promise.resolve()
   private started?: number
   private resolveReady: (() => void) | undefined
   private resolvedReady: boolean = false
@@ -62,7 +64,23 @@ export class HealthDaemon<Manifest extends SDKManifest> {
     return Object.freeze(this._health)
   }
 
-  private async changeRunning(newStatus: boolean) {
+  // updateStatus() runs fire-and-forget from dependency watchers, so several
+  // invocations can overlap. A transition both flips `running` and awaits
+  // stop()/start(); if a resume's start() ran while the preceding pause's stop()
+  // were still draining the process, start() would no-op against the not-yet
+  // cleared run loop (see Daemon.start's `if (this.loop) return`) and leave the
+  // daemon stopped while we believe it is running — until the next flap. Apply
+  // transitions on an in-order promise chain so pause always finishes before the
+  // following resume re-holds and restarts.
+  private changeRunning(newStatus: boolean): Promise<void> {
+    const next = this.transition
+      .catch(() => {})
+      .then(() => this.applyRunning(newStatus))
+    this.transition = next
+    return next
+  }
+
+  private async applyRunning(newStatus: boolean) {
     if (this.running === newStatus) return
 
     this.running = newStatus
@@ -70,12 +88,26 @@ export class HealthDaemon<Manifest extends SDKManifest> {
     if (newStatus) {
       console.debug(`Launching ${this.id}...`)
       this.startSession()
-      this.daemon?.start()
       this.started = performance.now()
+      // Await + catch start(): its hold() on the (possibly re-held) SubContainer
+      // can throw `already destroyed`. Surfacing that as a health failure keeps
+      // an un-awaited rejection from becoming an unhandled rejection that wedges
+      // the daemon permanently.
+      try {
+        await this.daemon?.start()
+      } catch (e) {
+        await this.setHealth({
+          result: 'failure',
+          message: `${this.id} daemon failed to start: ${asError(e).message}`,
+        })
+      }
     } else {
       console.debug(`Stopping ${this.id}...`)
       await this.stopSession()
-      await this.daemon?.term()
+      // A dependency-driven stop is a pause, not a teardown: stop() releases the
+      // SubContainer hold but leaves the container intact so a later start()
+      // re-holds it. Only term() (genuine teardown) destroys the SubContainer.
+      await this.daemon?.stop()
     }
   }
 

--- a/projects/start-sdk/lib/test/DaemonLifecycle.test.ts
+++ b/projects/start-sdk/lib/test/DaemonLifecycle.test.ts
@@ -1,0 +1,286 @@
+import { Daemon } from '../mainFn/Daemon'
+import { EXIT_SUCCESS, HealthDaemon } from '../mainFn/HealthDaemon'
+import * as T from '@start9labs/start-core/types'
+
+type Manifest = {
+  id: 'test'
+  volumes: ['main']
+  images: { main: { source: { dockerTag: 'x' } } }
+} & T.SDKManifest
+
+/** Minimal mock effects sufficient to construct/run daemons in unit tests. */
+const fakeEffects = (): T.Effects =>
+  ({
+    eventId: null,
+    child: () => fakeEffects(),
+    isInContext: true,
+    onLeaveContext: () => {},
+    setHealth: async () => null,
+    subcontainer: {
+      createFs: async () => ['', ''] as any,
+      destroyFs: async () => null,
+    },
+  }) as any
+
+const tick = () => new Promise<void>(resolve => setTimeout(resolve, 0))
+
+/**
+ * A stand-in for `SubContainerEager` that models exactly the hold/destroy
+ * contract the daemon relies on: `destroyFs` fires when `destroy()` has been
+ * called *and* the last hold is released, and `hold()` throws once destroyed.
+ */
+class FakeSub {
+  identity = Symbol('fake-sub')
+  holdCount = 0
+  destroyed = false
+  destroyPending = false
+  destroyFsCount = 0
+  detached = false
+
+  detach() {
+    this.detached = true
+  }
+  hold(): () => Promise<void> {
+    if (this.destroyed) {
+      throw new Error(
+        `cannot hold subcontainer ${String(this.identity.description)}: already destroyed`,
+      )
+    }
+    this.holdCount++
+    let released = false
+    return async () => {
+      if (released) return
+      released = true
+      this.holdCount--
+      if (this.holdCount === 0 && this.destroyPending) await this._destroy()
+    }
+  }
+  async destroy(): Promise<void> {
+    this.destroyPending = true
+    if (this.holdCount === 0) await this._destroy()
+  }
+  private async _destroy(): Promise<void> {
+    if (this.destroyed) return
+    this.destroyed = true
+    this.destroyFsCount++
+  }
+}
+
+// A JS-only exec that stays running until its CommandController aborts it, so
+// the daemon's run loop parks in `wait()` instead of hot-restarting.
+const blockUntilAborted = {
+  fn: (_sub: unknown, signal: AbortSignal) =>
+    new Promise<null>(resolve => {
+      if (signal.aborted) return resolve(null)
+      signal.addEventListener('abort', () => resolve(null), { once: true })
+    }),
+}
+
+describe('Daemon.stop vs Daemon.term (subcontainer lifecycle)', () => {
+  it('stop() releases the hold but does NOT destroy the subcontainer, and a later start() re-holds it', async () => {
+    const effects = fakeEffects()
+    const sub = new FakeSub()
+    const daemon = Daemon.of<Manifest>()(
+      effects,
+      sub as any,
+      blockUntilAborted as any,
+    )
+
+    await daemon.start()
+    await tick()
+    expect(sub.holdCount).toBe(1)
+
+    await daemon.stop()
+    // Hold released, but no destroy — the container survives the pause.
+    expect(sub.holdCount).toBe(0)
+    expect(sub.destroyed).toBe(false)
+    expect(sub.destroyFsCount).toBe(0)
+
+    // The regression: this second start() used to throw `already destroyed`.
+    await daemon.start()
+    await tick()
+    expect(sub.holdCount).toBe(1)
+    expect(sub.destroyed).toBe(false)
+
+    await daemon.stop()
+    expect(sub.holdCount).toBe(0)
+    expect(sub.destroyed).toBe(false)
+  })
+
+  it('term() stops the daemon AND destroys the subcontainer (one-way teardown)', async () => {
+    const effects = fakeEffects()
+    const sub = new FakeSub()
+    const daemon = Daemon.of<Manifest>()(
+      effects,
+      sub as any,
+      blockUntilAborted as any,
+    )
+
+    await daemon.start()
+    await tick()
+    expect(sub.holdCount).toBe(1)
+
+    await daemon.term()
+    expect(sub.holdCount).toBe(0)
+    expect(sub.destroyed).toBe(true)
+    expect(sub.destroyFsCount).toBe(1)
+  })
+
+  it('stop() then term() still fires destroyFs exactly once (no leak, no double-destroy)', async () => {
+    const effects = fakeEffects()
+    const sub = new FakeSub()
+    const daemon = Daemon.of<Manifest>()(
+      effects,
+      sub as any,
+      blockUntilAborted as any,
+    )
+
+    await daemon.start()
+    await tick()
+    await daemon.stop()
+    expect(sub.destroyFsCount).toBe(0)
+
+    await daemon.term()
+    expect(sub.destroyed).toBe(true)
+    expect(sub.destroyFsCount).toBe(1)
+
+    // term() is idempotent — a second term() must not double-destroy.
+    await daemon.term()
+    expect(sub.destroyFsCount).toBe(1)
+  })
+})
+
+describe('HealthDaemon dependency-driven restart cycle', () => {
+  // A fake dependency exposing just the surface HealthDaemon.updateStatus reads.
+  const fakeDep = () => ({
+    id: 'dep',
+    running: true,
+    _health: { result: 'success' as const, message: null },
+    ready: { display: 'Dep' },
+    addWatcher: () => {},
+  })
+
+  // A fake managed daemon that records which lifecycle method HealthDaemon calls.
+  const fakeDaemon = () => ({
+    start: jest.fn(async () => {}),
+    stop: jest.fn(async () => {}),
+    term: jest.fn(async () => {}),
+    onExit: jest.fn(),
+    isOneshot: () => false,
+  })
+
+  it('pauses with stop() (not term()) when a dependency flaps, then resumes with start()', async () => {
+    const effects = fakeEffects()
+    const daemon = fakeDaemon()
+    const dep = fakeDep()
+    const hd = new HealthDaemon<Manifest>(
+      daemon as any,
+      [dep] as any,
+      'dependent',
+      EXIT_SUCCESS,
+      effects,
+    )
+
+    // Dependency ready → daemon launches.
+    await hd.updateStatus()
+    expect(daemon.start).toHaveBeenCalledTimes(1)
+    expect(daemon.stop).not.toHaveBeenCalled()
+    expect(daemon.term).not.toHaveBeenCalled()
+
+    // Dependency ready-flaps to not-ready → this is a PAUSE, so the daemon is
+    // stopped without destroying its subcontainer. Calling term() here (the
+    // pre-fix behavior) is the regression, so guard against it explicitly.
+    dep.running = false
+    await hd.updateStatus()
+    expect(daemon.stop).toHaveBeenCalledTimes(1)
+    expect(daemon.term).not.toHaveBeenCalled()
+
+    // Dependency recovers → the same daemon/subcontainer is restarted.
+    dep.running = true
+    await hd.updateStatus()
+    expect(daemon.start).toHaveBeenCalledTimes(2)
+    expect(daemon.term).not.toHaveBeenCalled()
+
+    // Only a genuine teardown destroys the subcontainer.
+    await hd.term()
+    expect(daemon.term).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces a failed start() as a health failure instead of an unhandled rejection', async () => {
+    const effects = fakeEffects()
+    const daemon = fakeDaemon()
+    daemon.start.mockRejectedValueOnce(
+      new Error('cannot hold subcontainer sub: already destroyed'),
+    )
+    const dep = fakeDep()
+    const hd = new HealthDaemon<Manifest>(
+      daemon as any,
+      [dep] as any,
+      'dependent',
+      EXIT_SUCCESS,
+      effects,
+    )
+
+    // updateStatus must resolve (not reject) even though start() threw.
+    await expect(hd.updateStatus()).resolves.toBeUndefined()
+    expect(hd.health.result).toBe('failure')
+
+    await hd.term()
+  })
+
+  it('serializes transitions so a fast flap (ready before stop() drains) resumes cleanly', async () => {
+    const effects = fakeEffects()
+    // stop() parks until released, modelling a process that takes time to drain.
+    const order: string[] = []
+    let releaseStop: () => void = () => {}
+    const daemon = {
+      start: jest.fn(async () => {
+        order.push('start')
+      }),
+      stop: jest.fn(async () => {
+        order.push('stop:begin')
+        await new Promise<void>(resolve => (releaseStop = resolve))
+        order.push('stop:end')
+      }),
+      term: jest.fn(async () => {}),
+      onExit: jest.fn(),
+      isOneshot: () => false,
+    }
+    const dep = fakeDep()
+    const hd = new HealthDaemon<Manifest>(
+      daemon as any,
+      [dep] as any,
+      'dependent',
+      EXIT_SUCCESS,
+      effects,
+    )
+
+    // Dependency ready → daemon launches.
+    await hd.updateStatus()
+    expect(daemon.start).toHaveBeenCalledTimes(1)
+
+    // Dependency flaps not-ready: the pause's stop() begins but parks.
+    dep.running = false
+    const pausing = hd.updateStatus()
+    await tick()
+    expect(order).toEqual(['start', 'stop:begin'])
+
+    // Dependency flaps back to ready BEFORE stop() finishes. The resume must wait
+    // for the in-flight pause — starting now would no-op against the still-running
+    // loop and strand the daemon stopped-but-believed-running. Without
+    // serialization start() would be called a second time here.
+    dep.running = true
+    const resuming = hd.updateStatus()
+    await tick()
+    expect(daemon.start).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['start', 'stop:begin'])
+
+    // Let the pause finish; the queued resume then restarts — strictly in order.
+    releaseStop()
+    await pausing
+    await resuming
+    expect(order).toEqual(['start', 'stop:begin', 'stop:end', 'start'])
+    expect(daemon.start).toHaveBeenCalledTimes(2)
+    expect(daemon.term).not.toHaveBeenCalled()
+  })
+})

--- a/projects/start-sdk/package-lock.json
+++ b/projects/start-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",

--- a/projects/start-sdk/package.json
+++ b/projects/start-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/shared-libs/crates/start-core/src/system/mod.rs
+++ b/shared-libs/crates/start-core/src/system/mod.rs
@@ -30,7 +30,6 @@ use crate::util::serde::{HandlerExtSerde, WithIoFormat, display_serializable};
 use crate::util::sync::Watch;
 use crate::{MAIN_DATA, PACKAGE_DATA};
 
-
 pub fn experimental<C: Context>() -> ParentHandler<C> {
     ParentHandler::new()
         .subcommand(


### PR DESCRIPTION
## Problem

Since start-sdk **2.0.0**'s hold/release refactor, `Daemon.term()` unconditionally destroyed the daemon's `SubContainer`, and `HealthDaemon` calls `term()` **every time a dependency goes not-ready** (a *pause*, not a teardown). When the dependency's health recovered, `HealthDaemon.changeRunning(true)` called the daemon's `start()`, whose `hold()` on the already-destroyed subcontainer threw `cannot hold subcontainer …: already destroyed`.

Because that `start()` was **un-awaited**, the throw surfaced as an unhandled promise rejection and the daemon never recovered — the health check reported "not ready" / "daemon crashed" indefinitely, curable only by a full package restart. Any service with a dependency-gated daemon was exposed (e.g. `c-lightning`'s and BTCPay's web UIs).

The 2.0.0 refactor had removed the old `destroySubcontainer` flag that kept the subcontainer alive across a stop, collapsing "pause" and "teardown" into one destroying `term()`.

## Fix

1. **Restore the pause/teardown distinction in `Daemon`.** Split the destroying `term()` into:
   - a non-destroying **`stop()`** — aborts the restart loop, terminates the process, releases the `SubContainer` hold, but leaves the container intact so a later `start()` re-holds it (a restartable pause);
   - **`term()`** — now `stop()` + destroy the `SubContainer` (genuine teardown, one-way).
2. **`HealthDaemon` pauses with `stop()`.** `changeRunning(false)` (a dependency going not-ready) now calls `stop()` instead of `term()`. `HealthDaemon.term()` / `Daemons.term()` still route to the destroying `term()` for real teardown.
3. **Await + catch `start()`.** `changeRunning(true)` now awaits and catches `start()`, so a start failure becomes a health failure instead of a silent unhandled-rejection wedge.
4. **Serialize pause/resume transitions.** `updateStatus()` runs fire-and-forget from dependency watchers, so a fast readiness flap (not-ready → ready before the pause's `stop()` finished draining) could run the resume's `start()` while the previous run loop was still winding down. Because `Daemon.start()` is a no-op while `this.loop` is set, that `start()` would silently do nothing and strand the daemon *stopped-but-believed-running* until the next flap — the same wedge class. Transitions now apply on an in-order promise chain, so a resume always waits for the in-flight pause to finish before re-holding and restarting.

Bumps `@start9labs/start-sdk` to **2.0.3** (+ CHANGELOG entry).

## Adversarial review

Ran a multi-lens adversarial review (concurrency, hold/release invariants, API/call-site consistency, test rigor, docs) with refutation-based verification. Actioned findings:

- Closed the **fast-flap serialization race** above (item 4) — added a regression test proven to fail without the fix (`start()` fires a 2nd time inside the stop window) and pass with it.
- Fixed two stale doc-comments this change touches: `Daemon.start()`'s JSDoc (hold is released by `stop()` too now, not only `term()`) and `CommandController.term()`'s JSDoc (it never destroyed the subcontainer).

## Testing

- New `projects/start-sdk/lib/test/DaemonLifecycle.test.ts` (6 tests): `stop()` vs `term()` subcontainer lifecycle, resume re-holds a live subcontainer (the exact `already destroyed` regression), pause uses `stop()` not `term()`, failed `start()` → health failure (not unhandled rejection), and fast-flap serialization.
- `tsc --noEmit` clean, Prettier clean, **77/77** jest tests pass.

Scope is confined to `projects/start-sdk/lib/mainFn` + its tests; no Rust, OS-bindings, or `dist/` changes.
