### PR TITLE
fix(tunnel): survive fd exhaustion in the SNI demux

### DIFF
--- a/projects/start-tunnel/start-tunneld.service
+++ b/projects/start-tunnel/start-tunneld.service
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/start-tunneld
 Restart=always
 RestartSec=3
 ManagedOOMPreference=avoid
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/shared-libs/crates/start-core/src/net/transparent.rs
+++ b/shared-libs/crates/start-core/src/net/transparent.rs
@@ -91,13 +91,15 @@ pub async fn transparent_connect(
 
 static DIVERT_INFRA: OnceCell<()> = OnceCell::const_new();
 
-/// [`ensure_divert_infra`] run at most once per process (cached only on success,
-/// so a transient failure is retried on the next call). Cheap to call per
-/// connection from the local passthrough path.
-pub async fn ensure_divert_infra_once() {
-    let _ = DIVERT_INFRA
+/// [`ensure_divert_infra`] serialized and run at most once per process (cached
+/// only on success, so a transient failure is retried on the next call). Cheap
+/// to call per connection from the local passthrough path. Serialization keeps
+/// concurrent callers from racing the check-then-add commands (EEXIST).
+pub async fn ensure_divert_infra_once() -> Result<(), Error> {
+    DIVERT_INFRA
         .get_or_try_init(|| async { ensure_divert_infra().await })
-        .await;
+        .await
+        .map(|_| ())
 }
 
 /// Install the reply-path divert (idempotent): the iproute2 half (rule + table)

--- a/shared-libs/crates/start-core/src/net/transparent.rs
+++ b/shared-libs/crates/start-core/src/net/transparent.rs
@@ -97,16 +97,24 @@ static DIVERT_INFRA: OnceCell<()> = OnceCell::const_new();
 /// concurrent callers from racing the check-then-add commands (EEXIST).
 pub async fn ensure_divert_infra_once() -> Result<(), Error> {
     DIVERT_INFRA
-        .get_or_try_init(|| async { ensure_divert_infra().await })
+        .get_or_try_init(|| async { ensure_divert_infra().await.map(|_| ()) })
         .await
         .map(|_| ())
 }
 
+/// Serializes [`ensure_divert_infra`]'s check-then-add sequences: concurrent
+/// callers (listener startup vs the periodic re-assert) would otherwise race
+/// into EEXIST.
+static DIVERT_ASSERT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Install the reply-path divert (idempotent): the iproute2 half (rule + table)
 /// always, plus the nft `sni-divert` mark rule when absent — so hosts that run the
 /// SNI demux but not the gateway mangle reconcile (e.g. the tunnel) still mark and
-/// divert replies. Safe to call repeatedly.
-pub async fn ensure_divert_infra() -> Result<(), Error> {
+/// divert replies. Safe to call repeatedly; returns whether a missing piece had
+/// to be (re-)added, so periodic callers can surface external flushes.
+pub async fn ensure_divert_infra() -> Result<bool, Error> {
+    let _guard = DIVERT_ASSERT.lock().await;
+    let mut repaired = false;
     let table = DIVERT_TABLE.to_string();
 
     // Local-delivery default in the divert table: marked replies are delivered
@@ -146,6 +154,7 @@ pub async fn ensure_divert_infra() -> Result<(), Error> {
             ])
             .invoke(ErrorKind::Network)
             .await?;
+        repaired = true;
     }
 
     // nft `sni-divert` mark rule. The gateway reconcile owns (and re-adds) it on
@@ -179,10 +188,11 @@ pub async fn ensure_divert_infra() -> Result<(), Error> {
             ])
             .invoke(ErrorKind::Network)
             .await?;
+        repaired = true;
     }
 
     // rp_filter needs no loosening: a diverted reply's source is the backend,
     // routable via its own ingress interface, so even strict RPF (1) accepts it
     // (verified in a netns harness under both strict and loose).
-    Ok(())
+    Ok(repaired)
 }

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -845,7 +845,9 @@ where
             // peer (RFC §4.6). Non-passthrough/terminating targets keep the plain
             // connect — they don't preserve source IP.
             (true, Some(SocketAddr::V4(client)), SocketAddr::V4(target)) => {
-                crate::net::transparent::ensure_divert_infra_once().await;
+                crate::net::transparent::ensure_divert_infra_once()
+                    .await
+                    .log_err();
                 crate::net::transparent::transparent_connect(client, target)
                     .await
                     .with_ctx(|_| (ErrorKind::Network, self.addr))

--- a/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
@@ -13,11 +13,10 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt, copy_bidirectional};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpStream;
 use tokio::time::timeout;
 
 use crate::net::port_map::pcp::hostname::RESULT_HOSTNAME_TAKEN;
-use crate::prelude::*;
 use crate::util::future::NonDetachingJoinHandle;
 use crate::util::sync::SyncMutex;
 
@@ -26,6 +25,10 @@ type PortKey = (Ipv4Addr, u16);
 
 const CLIENTHELLO_CAP: usize = 16384;
 const CLIENTHELLO_TIMEOUT: Duration = Duration::from_secs(5);
+/// Backoff for bind/accept failures (e.g. fd exhaustion); the listener retries
+/// rather than giving up its port.
+const BIND_RETRY_DELAY: Duration = Duration::from_secs(5);
+const ACCEPT_RETRY_DELAY: Duration = Duration::from_millis(100);
 
 #[derive(Clone)]
 struct Binding {
@@ -202,11 +205,7 @@ impl SniDemux {
             return;
         }
         let ports = self.ports.clone();
-        let handle = NonDetachingJoinHandle::from(tokio::spawn(async move {
-            if let Err(e) = run_listener(key, ports).await {
-                tracing::warn!("SNI demux listener on {}:{} exited: {e}", key.0, key.1);
-            }
-        }));
+        let handle = NonDetachingJoinHandle::from(tokio::spawn(run_listener(key, ports)));
         self.listeners.mutate(|l| {
             l.insert(key, handle);
         });
@@ -216,25 +215,40 @@ impl SniDemux {
     }
 }
 
-async fn run_listener(
-    key: PortKey,
-    ports: Arc<SyncMutex<BTreeMap<PortKey, PortBindings>>>,
-) -> Result<(), Error> {
+async fn run_listener(key: PortKey, ports: Arc<SyncMutex<BTreeMap<PortKey, PortBindings>>>) {
     if let Err(e) = crate::net::transparent::ensure_divert_infra().await {
         tracing::warn!(
             "SNI demux reply-path divert setup failed (source preservation may be degraded): {e}"
         );
     }
-    let listener = TcpListener::bind(SocketAddrV4::new(key.0, key.1))
-        .await
-        .with_kind(ErrorKind::Network)?;
+    let listener = loop {
+        match crate::net::utils::bind_tokio_listener(SocketAddrV4::new(key.0, key.1).into()) {
+            Ok(listener) => break listener,
+            Err(e) => {
+                tracing::warn!(
+                    "SNI demux bind on {}:{} failed (retrying): {e}",
+                    key.0,
+                    key.1
+                );
+                tokio::time::sleep(BIND_RETRY_DELAY).await;
+            }
+        }
+    };
     tracing::info!("SNI demux listening on {}:{}", key.0, key.1);
     loop {
-        let (conn, peer) = listener.accept().await.with_kind(ErrorKind::Network)?;
-        let ports = ports.clone();
-        tokio::spawn(async move {
-            handle_conn(conn, peer, key, ports).await;
-        });
+        match listener.accept().await {
+            Ok((conn, peer)) => {
+                let ports = ports.clone();
+                tokio::spawn(async move {
+                    handle_conn(conn, peer, key, ports).await;
+                });
+            }
+            // Transient (EMFILE, ECONNABORTED): never tear down the listener.
+            Err(e) => {
+                tracing::warn!("SNI demux accept on {}:{}: {e}", key.0, key.1);
+                tokio::time::sleep(ACCEPT_RETRY_DELAY).await;
+            }
+        }
     }
 }
 
@@ -244,6 +258,12 @@ async fn handle_conn(
     key: PortKey,
     ports: Arc<SyncMutex<BTreeMap<PortKey, PortBindings>>>,
 ) {
+    // Reap silently-vanished peers, else copy_bidirectional pins the fd pair forever.
+    if let Err(e) =
+        socket2::SockRef::from(&conn).set_tcp_keepalive(&crate::net::utils::default_keepalive())
+    {
+        tracing::error!("Failed to set tcp keepalive: {e}");
+    }
     let mut buf = Vec::new();
     let mut tmp = [0u8; 4096];
     let sni = loop {

--- a/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
@@ -96,10 +96,34 @@ impl SniDemux {
         });
         let weak = Arc::downgrade(&this);
         tokio::spawn(async move {
+            let mut divert_ok = true;
             loop {
                 tokio::time::sleep(Duration::from_secs(30)).await;
                 let Some(this) = weak.upgrade() else { break };
                 this.prune();
+                // Re-assert the reply-path divert while any listener is active:
+                // heals external flushes (networkd restart, nft flush) that
+                // would otherwise silently hang all demuxed traffic.
+                if this.listeners.peek(|l| !l.is_empty()) {
+                    match crate::net::transparent::ensure_divert_infra().await {
+                        Ok(repaired) => {
+                            if repaired {
+                                tracing::warn!(
+                                    "SNI demux reply-path divert infra was missing; re-installed"
+                                );
+                            } else if !divert_ok {
+                                tracing::info!("SNI demux reply-path divert re-assert recovered");
+                            }
+                            divert_ok = true;
+                        }
+                        Err(e) => {
+                            if divert_ok {
+                                tracing::warn!("SNI demux reply-path divert re-assert failed: {e}");
+                            }
+                            divert_ok = false;
+                        }
+                    }
+                }
             }
         });
         this

--- a/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
@@ -216,7 +216,7 @@ impl SniDemux {
 }
 
 async fn run_listener(key: PortKey, ports: Arc<SyncMutex<BTreeMap<PortKey, PortBindings>>>) {
-    if let Err(e) = crate::net::transparent::ensure_divert_infra().await {
+    if let Err(e) = crate::net::transparent::ensure_divert_infra_once().await {
         tracing::warn!(
             "SNI demux reply-path divert setup failed (source preservation may be degraded): {e}"
         );


### PR DESCRIPTION
## Incident

On a start-tunnel instance, port 443 began refusing connections while `start-tunneld` kept running. Root cause chain:

1. The SNI demux splices each demuxed connection in userspace (`copy_bidirectional`). A client that vanished without closing (dropped VPN exits, scanners) left the splice blocked forever — the accepted socket never got TCP keepalive, so nothing ever errored it out. Each stuck splice pins an fd **pair** (client leg in FIN-WAIT-2 + backend leg in CLOSED). 480 pairs ≈ 960 fds were stuck at the time of failure.
2. The unit had no `LimitNOFILE=`, so the daemon ran with the systemd default soft limit of 1024.
3. `accept()` returned EMFILE, and `run_listener` treated any accept error as fatal — the 443 listener task exited permanently while the process kept serving other ports. Nothing rebinds it, hence connection refused until restart.

## Fix

- **Keepalive on accepted demux connections** (`crate::net::utils::default_keepalive()`, ~2 min detection) — the same mechanism vhost/web_server already use on accepted sockets, and the backend leg already had via `transparent_connect`. Vanished peers now error out of the splice and both fds are reclaimed.
- **Accept-loop resilience**: transient accept errors (EMFILE, ECONNABORTED) log + back off 100ms + continue instead of killing the listener.
- **Bind retry**: a failed bind retries every 5s instead of permanently poisoning the port key (the dead task previously stayed in the `listeners` map, so the port could never be re-registered).
- **`LimitNOFILE=65536`** in `start-tunneld.service`, matching `startd.service`.
- Also switched the listener to `bind_tokio_listener` (explicit backlog) per the documented convention in `net/utils.rs`.

## Verification

- `cargo check -p start-core` clean; `cargo test -p start-core --features=test sni` passes (5/5, includes the select/parse unit tests).
- Prod was restarted with a `LimitNOFILE` drop-in as interim mitigation: 443 rebound, fd count back to ~40, zero FIN-WAIT-2 accumulation since. The leak itself persists on the old binary until this ships.

## Also in this PR

- **Spurious "source preservation may be degraded" warning eliminated.** Concurrent SNI listener startups raced `ensure_divert_infra`'s check-then-add commands; losers logged an alarming EEXIST warning although the divert infra was fine (seen twice on prod). The demux now uses `ensure_divert_infra_once()` (OnceCell-serialized, success-cached), which now returns the `Result` so genuine failures still warn.
- **Divert infra now self-heals.** The reply-path divert (ip rule + table-1344 route + nft `sni-divert`) could be stripped mid-run by external actors — systemd-networkd removes foreign policy rules on restart (`ManageForeignRoutingPolicyRules` defaults to yes, and unattended-upgrades restarts networkd), and an `nft flush` drops the mark rule — silently hanging all demuxed traffic. The demux's 30s prune tick now re-asserts the idempotent setup while any listener is active, warning when it actually re-installed a missing piece and logging failures once per outage.
