### PR TITLE
fix(ci): retry add-mirror on dropped connections

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,10 +332,24 @@ jobs:
           REGISTRY="${{ inputs.RELEASE_REGISTRY }}"
           TAG="${{ inputs.TAG || github.ref_name }}"
           GH_URL="${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG}"
+          # add-mirror downloads the whole s9pk to verify every file hash, so on a large
+          # package this is a multi-hundred-MB stream that GitHub's CDN sometimes drops.
+          ATTEMPTS=3
           for s9pk in *.s9pk; do
             if [ -f .gh_release_files ] && grep -qxF "$s9pk" .gh_release_files; then
               echo "Adding GitHub mirror for ${s9pk}..."
-              start-cli --registry "$REGISTRY" registry package add-mirror "$s9pk" "${GH_URL}/${s9pk}"
+              for attempt in $(seq 1 "$ATTEMPTS"); do
+                if start-cli --registry "$REGISTRY" registry package add-mirror "$s9pk" "${GH_URL}/${s9pk}"; then
+                  break
+                fi
+                if [ "$attempt" -eq "$ATTEMPTS" ]; then
+                  echo "::error::add-mirror failed for ${s9pk} after ${ATTEMPTS} attempts"
+                  exit 1
+                fi
+                backoff=$((attempt * 30))
+                echo "::warning::add-mirror failed for ${s9pk} (attempt ${attempt}/${ATTEMPTS}); retrying in ${backoff}s"
+                sleep "$backoff"
+              done
             fi
           done
         shell: bash

--- a/shared-libs/crates/start-core/src/s9pk/merkle_archive/source/http.rs
+++ b/shared-libs/crates/start-core/src/s9pk/merkle_archive/source/http.rs
@@ -30,6 +30,10 @@ impl HttpSource {
             .with_kind(ErrorKind::Network)?
             .error_for_status()
             .with_kind(ErrorKind::Network)?;
+        // Range requests are disabled unconditionally: GitHub's release-asset CDN
+        // performs badly under them, and walking an archive's TOC issues many small
+        // reads. `HttpReader::Rangeless` streams the body once and skips forward
+        // instead, pooling open readers by position.
         let range_support = head
             .headers()
             .get(ACCEPT_RANGES)


### PR DESCRIPTION
## Summary

`hermes-agent-startos`'s release job [failed](https://github.com/Start9-Community/hermes-agent-startos/actions/runs/29031061474) at **Add GitHub release mirrors**, after the package had already been tagged, built, released, and published to the registry:

```
Network Error: registry.package.add-mirror: error sending request for url
(.../releases/download/v2026.7.1_1/hermes-agent_x86_64.s9pk):
client error (SendRequest): connection closed before message completed
```

`registry package add-mirror` downloads the **entire** s9pk and hashes every file body (`serialize(sink, verify: true)` → `serialize_body(w, hash.filter(|_| verify))`) to prove the mirror serves an intact package. For `hermes-agent` that's ~750 MB per arch in one un-retried HTTP body, pulled from GitHub's release-asset CDN. The aarch64 mirror went through; x86_64's connection was closed mid-stream.

It's throughput-bound, not a timeout — the *same* aarch64 asset took 13.5s in the prior release and 27.2s in this one. There is no retry anywhere in the step, so a single dropped connection fails the whole release.

This adds 3 attempts with linear backoff (30s, 60s) around `add-mirror`.

## Why not `--no-verify`

It would halve the transfer, but it's not safe. The registry's own `add_mirror` handler resolves the s9pk via `S9pk::deserialize` → `S9pk::archive`, which fetches only `MAGIC_AND_VERSION.len() + header_size()` bytes from offset 0 — **the header/TOC only**. It validates the root sighash and never reads a file body. A truncated or corrupted upload would sail past server-side validation and get registered as a mirror. The client-side verify download is the only thing that catches that, so it has to stay — which means it has to be retried instead.

## Drive-by

Documented why range requests are disabled in `HttpSource::new`. The `&& false` reads as dead code and invites removal, but `fd7c2fbe9` introduced it together with the entire `HttpReader::Rangeless` reader-pool path — it's a deliberate workaround for GitHub's poor range-request performance, not a leftover. Comment only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)