### PR TITLE
feat(packaging): clone the full monorepo, publish the agent context, correct the SDK docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the layout and [CONTRIBUTING.md](CONT
 
 **Keep these docs current.** Every scope carries `AGENTS.md` / `ARCHITECTURE.md` / `CONTRIBUTING.md` / `README.md` (with `CLAUDE.md` a one-line `@AGENTS.md` import). When a change alters structure, conventions, the build/test/release flow, or product context, update the matching doc(s) in the **same change** — never defer. These docs are **hierarchical**: each scope's docs cover only what is specific to it and must not repeat anything already stated at a higher scope (e.g. commit/PR conventions live only in this root `CONTRIBUTING.md`).
 
-**A product's user docs and changelog ship with the code.** Any change that alters user-visible behavior **must** update that product's user-facing documentation book (its `docs/` directory — e.g. `projects/start-os/docs/`, `projects/start-tunnel/docs/`, `projects/start-sdk/docs/`) in the **same change**, and **must** add a `CHANGELOG.md` entry for that product (a version bump always pairs with its changelog). Don't land code and defer its docs or changelog to a follow-up.
+**A product's user docs and changelog ship with the code.** Any change that alters user-visible behavior **must** update that product's user-facing documentation book (its `docs/` directory — e.g. `projects/start-os/docs/`, `projects/start-tunnel/docs/`, `projects/start-sdk/docs/`) in the **same change**, and **must** add a `CHANGELOG.md` entry for that product (a version bump always pairs with its changelog). Don't land code and defer its docs or changelog to a follow-up. The conventions for authoring **any** of those books — mdBook versions, admonitions, tabs, `SUMMARY.md`, the shared `theme/` — live in [`projects/start-docs/AGENTS.md`](projects/start-docs/AGENTS.md) and its `CONTRIBUTING.md`. That project is a sibling, not an ancestor, so nothing loads it for you: read it before editing book pages anywhere in the repo.
 
 **Read [CONTRIBUTING.md](CONTRIBUTING.md) before making _any_ code changes.** It carries the build/test/format workflow and the commit/PR conventions every change must follow — read it first, before you touch code. This is hierarchical like `AGENTS.md`: if a subdirectory you touch carries its own `CONTRIBUTING.md`, read that one too — and any further nested `CONTRIBUTING.md` on the way down to the files you're editing — before changing anything there.
 
@@ -72,8 +72,8 @@ Already enforced or checked elsewhere (listed here for completeness; documented 
 - [`projects/start-registry/AGENTS.md`](projects/start-registry/AGENTS.md) — registry server wrapper
 - [`projects/start-tunnel/AGENTS.md`](projects/start-tunnel/AGENTS.md) — tunnel server + UI
 - [`projects/start-wrt/AGENTS.md`](projects/start-wrt/AGENTS.md) — OpenWrt-based router OS (Rust backend + Angular UI in the root workspace + pinned-upstream OpenWrt image build)
-- [`projects/start-sdk/AGENTS.md`](projects/start-sdk/AGENTS.md) — TypeScript service-packaging SDK (packaging mdbook: [`docs/AGENTS.md`](projects/start-sdk/docs/AGENTS.md))
+- [`projects/start-sdk/AGENTS.md`](projects/start-sdk/AGENTS.md) — TypeScript service-packaging SDK, plus the packaging mdbook in `docs/`
 - [`projects/brochure-marketplace/AGENTS.md`](projects/brochure-marketplace/AGENTS.md) — public marketplace site
-- [`projects/start-docs/AGENTS.md`](projects/start-docs/AGENTS.md) — documentation website
+- [`projects/start-docs/AGENTS.md`](projects/start-docs/AGENTS.md) — documentation website; also the authoring conventions for every product book
 - [`shared-libs/AGENTS.md`](shared-libs/AGENTS.md) — shared libs container: [`crates/start-core`](shared-libs/crates/start-core/AGENTS.md) (Rust backend), [`web`](shared-libs/ts-modules/AGENTS.md) (Angular workspace + UI/setup-wizard/shared libs)
 - `shared-libs/crates/patch-db/` — first-party crate (maintained in-tree; the standalone `Start9Labs/patch-db` repo is being retired)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7709,7 +7709,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "start-cli"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "start-core",
  "tracing",

--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -11,6 +11,33 @@ or the CLI's externally observable behavior.
 
 ## [Unreleased]
 
+## [1.0.2]
+
+### Changed
+
+- **`s9pk init-workspace` clones the whole monorepo, not just the guide.** The checkout is no
+  longer sparse or shallow, so a packager has the SDK and StartOS source on hand when the guide
+  can't settle a question — and a repo they can open a fix PR from. `--filter=blob:none` keeps it
+  cheap: a few seconds and roughly 75 MB, with `git log`, `blame`, and rebase all working normally.
+  An existing workspace keeps its narrow checkout. Widen it in place by running
+  `sparse-checkout disable` in `start-technologies/`, plus `fetch --unshallow` if you want history.
+- **`init-workspace` uses an existing `start-technologies` if you point at one.** Symlink it into
+  the workspace before running, and the clone is skipped.
+- **`s9pk init-workspace` links `AGENTS.md` to the guide's Agent Context page.** The workspace
+  context file moved to `projects/start-sdk/docs/src/agent-context.md`, so it publishes with the
+  rest of the packaging guide instead of being reachable only by scaffolding a workspace or
+  browsing the monorepo. A `start-technologies/` that is a symlink to a monorepo checkout you
+  maintain yourself is now a supported layout, and the guide says so.
+- **The scaffolded `AGENTS.local.md` explains what belongs in it.** The stub now names the split:
+  your box, your registry, your packages, and any departure from the scaffolded layout go there,
+  while anything that would help every packager belongs upstream in the guide.
+
+### Fixed
+
+- `init-workspace` repoints a workspace `AGENTS.md` left over from an earlier release. Those
+  symlinks target a path that no longer exists; re-running `init-workspace` in such a workspace
+  replaces the dangling link. Everything else it finds is still left untouched.
+
 ## [1.0.1]
 
 - **`s9pk init-package` initializes a git repository in the new package.** Packages are
@@ -76,5 +103,7 @@ init-workspace`), so an existing package repo is one command away from building.
 - `ws_continuation` honors `--root-ca` / `--insecure` (#3274).
 - `choose` falls back to a generic non-tty prompt instead of failing when stdin isn't a terminal (#3265).
 
-[Unreleased]: https://github.com/Start9Labs/start-technologies/compare/v0.4.0-beta.10...HEAD
-[0.4.0-beta.10]: https://github.com/Start9Labs/start-technologies/releases/tag/v0.4.0-beta.10
+[Unreleased]: https://github.com/Start9Labs/start-technologies/compare/start-cli/v1.0.2...HEAD
+[1.0.2]: https://github.com/Start9Labs/start-technologies/releases/tag/start-cli/v1.0.2
+[1.0.1]: https://github.com/Start9Labs/start-technologies/releases/tag/start-cli/v1.0.1
+[1.0.0]: https://github.com/Start9Labs/start-technologies/releases/tag/start-cli/v1.0.0

--- a/projects/start-cli/Cargo.toml
+++ b/projects/start-cli/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-cli"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "1.0.1"                                               # VERSION_BUMP
+version = "1.0.2"                                               # VERSION_BUMP
 
 [[bin]]
 name = "start-cli"

--- a/projects/start-sdk/AGENTS.md
+++ b/projects/start-sdk/AGENTS.md
@@ -10,7 +10,7 @@ The TypeScript SDK (`@start9labs/start-sdk`) for building StartOS service packag
 - `dist/` — build output (generated; what publishes to npm). It bundles `@start9labs/start-core` (via npm `bundleDependencies`) so it stays self-contained. **Container-runtime consumes the built `dist/`, not the source.**
 - `Makefile` — build orchestration for the SDK itself.
 - `s9pk.mk`, `tsconfig.base.json` — build plumbing shipped _inside_ the published package for service packages to `include`/`extends`. Marked DO NOT EDIT in the consuming-package contract; edits here change the contract for every package.
-- `docs/` — the "Service Packaging" mdbook (`book.toml`), published at docs.start9.com/packaging. Has its own `docs/AGENTS.md`.
+- `docs/` — the "Service Packaging" mdbook (`book.toml`), published at docs.start9.com/packaging. Also carries `package-template/` and the workspace agent context. See [Docs](#the-docs-mdbook).
 - `CHANGELOG.md` — Keep a Changelog style, headings `## <sdk-version> — StartOS <os-version> (<date>)`.
 
 ## Build & test (run from `projects/start-sdk/`)
@@ -41,3 +41,12 @@ Tests are jest + ts-jest, Node only (no browser). Test files use `.test.ts`. The
 ## Docs
 
 `README.md` (overview + quickstart), `ARCHITECTURE.md` (modules + data flow), `CONTRIBUTING.md` (build/test/contribute), `CHANGELOG.md`, this file. The packaging mdbook in `docs/` is the developer-facing reference — update it when you change the SDK's developer surface. Keep all of these current in the same change that alters structure, conventions, build, or surface.
+
+### The `docs/` mdbook
+
+Authoring conventions shared by every book in the monorepo — mdBook/mdbook-tabs versions, admonitions, tabs, `SUMMARY.md`, the shared `theme/` symlink, cross-book links — live in [`projects/start-docs/AGENTS.md`](../start-docs/AGENTS.md) and its `CONTRIBUTING.md`. Read those before editing pages. What is specific to _this_ book:
+
+- **`docs/src/agent-context.md` ships to every packager.** `start-cli s9pk init-workspace` symlinks it in as each workspace's `AGENTS.md` (the `AGENTS_SYMLINK_TARGET` const in [`shared-libs/crates/start-core/src/s9pk/init.rs`](../../shared-libs/crates/start-core/src/s9pk/init.rs)), so an edit reaches every workspace on its next guide sync. It is an always-on context file first and a book page second: keep it a lean map that points at pages, never a place to inline detail. **Moving or renaming it breaks every existing workspace symlink** — update the const in the same change.
+- **`docs/package-template/` is live code, not an illustration.** `s9pk init-package` copies it verbatim, interpolating `{{id}}` and `{{name}}` (escaped for TypeScript string literals in `.ts` files) and skipping `node_modules/`, `.git/`, and `javascript/`. Keep it buildable; a broken template breaks every new package. Its `.github/workflows/` are a hand-maintained mirror — see the repo-root `AGENTS.md` § Coupled changes.
+- **Recipes name constructs; reference pages teach them.** Code examples belong on reference pages. A new `recipe-*.md` needs an entry in the intent table in `docs/src/recipes.md`, not just in `SUMMARY.md`.
+- **Verify SDK claims against `lib/`, not against the prose.** This guide has shipped confidently-worded semantics that were wrong. Before documenting what a call does, read it.

--- a/projects/start-sdk/docs/package-template/AGENTS.md
+++ b/projects/start-sdk/docs/package-template/AGENTS.md
@@ -6,6 +6,12 @@ Develop it inside a StartOS packaging workspace created by `start-cli s9pk init-
 which provides the packaging guide and agent context one level up. If you're reading this in a
 bare clone with no workspace, the full guide is at <https://docs.start9.com/packaging>.
 
+**Start every task at the recipe index** — `../start-technologies/projects/start-sdk/docs/src/recipes.md`
+(or <https://docs.start9.com/packaging/recipes.html>). It maps an intent ("prompt the user to create
+admin credentials", "expose a web UI") to the constructs, the reference pages, and a named production
+package to copy. Find the recipe before you read this package's neighbours: a package you reach by
+grepping may be non-conformant, and the recipe outranks it.
+
 Work this package's `TODO.md` from top to bottom. Keep `README.md` (architecture, for developers and LLMs) and `instructions.md` (end-user docs) in sync with your changes.
 
 ## Inspecting a running install

--- a/projects/start-sdk/docs/src/SUMMARY.md
+++ b/projects/start-sdk/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Environment Setup](environment-setup.md)
 - [Quick Start](quick-start.md)
 - [Development Workflow](workflow.md)
+- [Agent Context](agent-context.md)
 
 # Recipes
 

--- a/projects/start-sdk/docs/src/actions.md
+++ b/projects/start-sdk/docs/src/actions.md
@@ -128,7 +128,7 @@ Actions can be surfaced to users as tasks — notifications that prompt them to 
 
 ### Auto-Generate Passwords
 
-The standard shape for password actions: the handler generates the password with `utils.getDefaultString()`, writes it where the service reads it from, and returns it as a masked, copyable result. Server-side generation produces strong passwords and means the same action covers first-set and rotation. The primary example above (`setAdminPassword`) is the canonical shape — see also the [Reset a Password](./recipe-reset-password.md) recipe for variants that apply the new password through the upstream service's CLI or API.
+The standard shape for password actions: the handler generates the password with `utils.getDefaultString({ charset, len })`, writes it where the service reads it from, and returns it as a masked, copyable result. Server-side generation produces strong passwords and means the same action covers first-set and rotation. The primary example above (`setAdminPassword`) is the canonical shape — see also the [Reset a Password](./recipe-reset-password.md) recipe for variants that apply the new password through the upstream service's CLI or API.
 
 ### Registration-Gated Services
 
@@ -221,6 +221,25 @@ export const configure = sdk.Action.withInput(
 
 The five arguments to `withInput` are: action ID, metadata (static object or async function), input spec, prefill function, and handler.
 
+### Generating Values in a Form
+
+When a form field holds a secret, don't generate it in package code. `Value.text` accepts a `RandomString` spec — `{ charset, len }` — in two places, and StartOS does the generating:
+
+```typescript
+password: Value.text({
+  name: i18n('Password'),
+  description: i18n('Leave as generated, or choose your own'),
+  required: true,
+  masked: true,
+  // Pre-fill the field with a fresh random value each time the form opens
+  default: { charset: 'a-z,A-Z,0-9', len: 32 },
+  // …and/or render a "generate" button that refills it on demand
+  generate: { charset: 'a-z,A-Z,0-9', len: 32 },
+}),
+```
+
+`default` also takes a plain string when you want a fixed literal. The same `RandomString` shape is what [`utils.getDefaultString`](recipe-admin-credentials.md#never-roll-your-own-password-rng) resolves in a `withoutInput` handler — between the two, package code never needs its own random-string generator.
+
 ## Conventions
 
 ### Wrap User-Facing Strings in `i18n()`
@@ -228,6 +247,20 @@ The five arguments to `withInput` are: action ID, metadata (static object or asy
 Every string that a user will see — action `name`, `description`, `warning`, `reason` on tasks, messages on health checks and action results — must be wrapped in `i18n()`. Raw strings bypass translation and leak English into non-English locales. The existing examples on this page illustrate the pattern: `name: i18n('Configure SMTP')`, not `name: 'Configure SMTP'`.
 
 Thrown errors are the exception. `throw new Error(...)` messages are developer-facing diagnostics that surface in logs and stack traces, not translated UI copy — leave them as plain strings and do **not** wrap them in `i18n()`.
+
+### Don't `as const` What the SDK Already Types
+
+Action metadata and results are contextually typed by the SDK's own signatures — `version: '1'` is declared as the literal `'1'`, and `visibility`, `allowedStatuses`, `access`, and `type` are unions, not `string`. Write the literal and stop:
+
+```typescript
+// GOOD — the SDK narrows these for you
+return { version: '1', title: i18n('Login Credentials'), ... }
+
+// NOISE — asserts something the compiler already knows
+return { version: '1' as const, ... }
+```
+
+`tsc` passes either way, which is why the assertions spread by copy-paste. They aren't load-bearing anywhere in an action file; drop them when you see them. (Distinct from an `as` **cast**, which claims the compiler is wrong — reach for that only when it actually is.)
 
 ### Mirror File-Model Keys in InputSpec When Appropriate
 

--- a/projects/start-sdk/docs/src/agent-context.md
+++ b/projects/start-sdk/docs/src/agent-context.md
@@ -1,5 +1,8 @@
 # StartOS Packaging — Agent Context
 
+> [!NOTE]
+> This page is the `AGENTS.md` that `start-cli s9pk init-workspace` links into every packaging workspace. Your workspace copy is a symlink to this file, so syncing the guide keeps it current.
+
 You are an AI assistant working in a **StartOS packaging workspace**. You help create, maintain, and update `.s9pk` service packages for StartOS. This file is your always-on context: the rules to follow, the patterns to know, and a map of where to read for any given task. The substance lives in the packaging guide under `start-technologies/projects/start-sdk/docs/` — read those pages locally, on demand, as the task requires. Do not load everything at once.
 
 ## Workspace layout
@@ -7,14 +10,16 @@ You are an AI assistant working in a **StartOS packaging workspace**. You help c
 ```
 <workspace>/
 ├── .startos/              ← workspace marker: build-key (signs your packages) + config.yaml (hosts, registries)
-├── AGENTS.md              ← this file (symlink → start-technologies/projects/start-sdk/docs/AGENTS.md)
+├── AGENTS.md              ← this file (symlink → start-technologies/projects/start-sdk/docs/src/agent-context.md)
 ├── AGENTS.local.md        ← your workspace-specific notes (never overwritten by a sync)
 ├── CLAUDE.md              ← loads AGENTS.md + AGENTS.local.md (Claude Code bridge)
-├── start-technologies/    ← sparse checkout of the Start9 monorepo (the packaging guide; SDK + OS source on demand)
+├── start-technologies/    ← checkout of the Start9 monorepo: the packaging guide, plus the SDK and OS source
 └── <id>-startos/ …        ← one or more package repos
 ```
 
 Each package repo holds: `README.md` (what it is / how it differs from upstream), `instructions.md` (end-user docs shown in StartOS), `UPDATING.md` (upstream-version tracking), `TODO.md` (pending work), and `startos/` (the SDK code).
+
+**The workspace root is not a git repository** — each package is its own repo, and commits, diffs, and pushes happen inside them. Files at the workspace root (`AGENTS.local.md`, `.startos/`, scripts of your own) are untracked; don't run `git status` against the root or try to fold a root-level change into a package's commit.
 
 ## Keeping the workspace current
 
@@ -24,7 +29,11 @@ The guide, the package template, and this file all live in `start-technologies/`
 git -C start-technologies pull --ff-only
 ```
 
-To track a different source (e.g. a fork), repoint `start-technologies`'s remote first — the sync follows whatever remote is configured. Keep workspace-specific notes in `AGENTS.local.md`; a sync never touches it.
+To track a different source (e.g. a fork), repoint `start-technologies`'s remote first — the sync follows whatever remote is configured.
+
+Keep workspace-specific notes in `AGENTS.local.md`; a sync never touches it. That file is for what is true of _your_ setup — your box, your registry, your packages, any departure from the scaffolded layout. Anything that would help **every** packager belongs in the guide instead: open a PR against `start-technologies` rather than letting it drift in one workspace.
+
+If `start-technologies/` is a **symlink** to a checkout maintained outside this workspace, skip the sync: that repo has its own branches and its own work in progress, so its state is the owner's to manage, not this workspace's.
 
 ## How to use the guide (local-first)
 
@@ -66,15 +75,11 @@ Read pages from your local checkout (`start-technologies/projects/start-sdk/docs
 
 ## Reading the SDK and OS source (last resort)
 
-`start-technologies/` is a sparse checkout of the full Start9 monorepo, so beyond the guide you also have the complete **SDK source** (`start-technologies/projects/start-sdk/lib`) and **StartOS source** (`start-technologies/projects/start-os`, plus the shared core in `start-technologies/shared-libs/`) on hand.
+`start-technologies/` is a checkout of the whole Start9 monorepo, so beyond the guide you already have the **SDK source** (`start-technologies/projects/start-sdk/lib`) and the **StartOS source** (`start-technologies/projects/start-os`, plus the shared core in `start-technologies/shared-libs/`) on disk. Nothing to fetch.
 
-Reach for them **only when the recipes, reference pages, real packages, and the installed SDK types (`node_modules/@start9labs/start-sdk/**/\*.d.ts`) don't answer the question\*\* — e.g. to confirm exactly what an SDK call does or how an OS effect behaves. Open one file to settle one question; don't browse the monorepo to "understand the system."
+Reach for them **only when the recipes, reference pages, real packages, and the installed SDK types (`node_modules/@start9labs/start-sdk`) don't answer the question** — e.g. to confirm exactly what an SDK call does, or how an OS effect behaves. Open one file to settle one question; don't browse the monorepo to "understand the system."
 
-Only the guide is checked out by default — fetch a source path you need on demand:
-
-```
-git -C start-technologies sparse-checkout add projects/start-sdk/lib   # or projects/start-os, shared-libs/ …
-```
+If what you find there is a bug, say so. You are standing in a git repo you can branch from and open a pull request against.
 
 ## Key patterns
 
@@ -84,19 +89,21 @@ Understand these before writing any code (full detail on the pages above):
 - **Oneshots** run a command to completion before dependent daemons start — file ownership (`chown`), migrations, wallet unlocks, config generation. Chained with `.addOneshot()` alongside `.addDaemon()` in `setupMain()`. (`recipe-oneshot.md`, `main.md`)
 - **Health checks** come in two forms: the `ready` property on every daemon, and standalone `.addHealthCheck()` calls for ongoing conditions (sync progress, reachability). (`main.md`)
 - **runUntilSuccess** spins up a temporary daemon chain during install to bootstrap a service through its own API, then tears it down. (`recipe-run-until-success.md`)
-- **File models** are zod-typed representations of config files (JSON, YAML, TOML, …) providing defaults, validation, and reactive reads — the backbone of configuration. (`file-models.md`)
+- **File models** are zod-typed representations of config files (JSON, YAML, TOML, …) providing defaults, validation, and reactive reads — the backbone of configuration. `merge(effects, {})` fills missing fields from their `.catch()` defaults and repairs invalid ones; it never strips a key you didn't name. It is not a way to clean or regenerate a config. (`file-models.md`)
+- **Interfaces** declare what your service exposes; the **user** decides where it's reachable. `type` (`'ui'`/`'api'`/`'p2p'`) is a label, not a control, and Tor is a service the user installs and enables per interface. Never claim a service is on Tor or the public internet. (`interfaces.md`)
 
 ## Golden rules
 
 - **Start from intent, not from API.** Find the recipe before diving into reference pages.
 - **Code lives in reference pages and packages, not recipes.** Recipes describe the pattern; reference pages have the API; real packages have production implementations.
-- **Match existing patterns.** All packages follow identical conventions — read a package's code before introducing a new pattern.
+- **Match existing patterns — but a neighbouring package is not the authority.** Read a package's code before introducing a new pattern. Then check it against the recipe: the fleet is mid-migration, so the package you happened to grep may itself be non-conformant. "It matches the package next door" is not a quality bar. A recipe and its named reference implementation outrank a package you found by searching.
 
 ## Working discipline (every task)
 
 The full rules are in `start-technologies/projects/start-sdk/docs/src/workflow.md`; this is the digest.
 
 - **Verify facts; don't assert from memory.** Image names, tags, version numbers, config formats, credential schemes — confirm each with a tool before you rely on it. "I know that X" is a cue to check X, not to write it down. Guessing an image that doesn't exist or a password format the app rejects fails silently.
+- **A comment is not evidence.** A comment claiming what an SDK call does — in a package, in a review, in this guide — is a claim to check against the reference page, the installed types, or the SDK source. Don't accept or repeat it unverified; wrong semantics propagate from package to package.
 - **Compiling is not working.** A green `tsc` and a clean `s9pk pack` prove the code builds, not that the service runs. Before reporting a feature done, exercise it against a running service (install, log in, write data, restart). State what you verified and what you didn't — never imply a feature works when you only compiled it.
 - **Don't fabricate; verify or flag.** Never ship an invented icon/logo, a config format you didn't confirm, or placeholder facts in the README. Fetch the real thing, or leave it and flag the gap in `TODO.md`.
 - **Search before declaring impossible.** Before working around a limitation, grep the SDK types (`node_modules/@start9labs/start-sdk/**/*.d.ts`) and existing packages. "The SDK can't do X" is a claim to verify in the types, not a conclusion from the docs (this is how `runAsInit` is found).

--- a/projects/start-sdk/docs/src/environment-setup.md
+++ b/projects/start-sdk/docs/src/environment-setup.md
@@ -143,7 +143,7 @@ curl -fsSL https://start9.com/start-cli/install.sh | sh
 
 ## Git
 
-[Git](https://git-scm.com/) is used by `start-cli s9pk init-workspace` to fetch the packaging guide, and to keep it up to date afterward.
+[Git](https://git-scm.com/) is used by `start-cli s9pk init-workspace` to fetch the Start9 monorepo — the packaging guide, and the SDK and OS source behind it — and to keep it up to date afterward.
 
 {{#tabs global="platform"}}
 
@@ -214,22 +214,39 @@ StartOS packaging is designed to be done with an AI coding agent. `start-cli` sc
 ### Create the workspace
 
 ```sh
-start-cli s9pk init-workspace my-workspace
-cd my-workspace
+start-cli s9pk init-workspace start9-workspace
+cd start9-workspace
 ```
 
-This clones the packaging guide into `start-technologies/` — a sparse, blobless checkout of just the `projects/start-sdk/docs/` subtree of the Start9 monorepo, not the whole repo — sets up the agent-context files (`AGENTS.md`, your own `AGENTS.local.md`, and a `CLAUDE.md` that loads both), and creates a `.startos/` directory that marks the workspace and holds your package-signing key and host/registry config:
+This clones the Start9 monorepo into `start-technologies/`, sets up the agent-context files (`AGENTS.md`, your own `AGENTS.local.md`, and a `CLAUDE.md` that loads both), and creates a `.startos/` directory that marks the workspace and holds your package-signing key and host/registry config:
 
 ```
-my-workspace/
+start9-workspace/
 ├── .startos/              ← workspace marker: build-key (signs your packages) + config.yaml (hosts, registries)
-├── AGENTS.md              ← agent context (symlink into start-technologies/projects/start-sdk/docs), read by AI assistants
+├── AGENTS.md              ← agent context (symlink to the guide's Agent Context page), read by AI assistants
 ├── AGENTS.local.md        ← your own notes, kept across guide updates
 ├── CLAUDE.md              ← loads AGENTS.md + AGENTS.local.md (Claude Code)
-└── start-technologies/    ← sparse monorepo checkout; the guide lives at projects/start-sdk/docs/
+└── start-technologies/    ← the monorepo: the guide, the SDK source, the OS source
 ```
 
-The context lives once, at the workspace root — it is never copied into your package repos. Open the workspace in your AI tool and it picks up `AGENTS.md` / `CLAUDE.md` automatically.
+You get the **whole** monorepo, not just the guide. That's deliberate: when the guide can't settle a question, the SDK source (`projects/start-sdk/lib`) and the StartOS source (`projects/start-os`, `shared-libs/`) are right there to read — and if you find a bug, you're already in a repo you can open a pull request from. The clone is `--filter=blob:none`, so file contents are fetched on demand: it lands in a few seconds and takes ~75 MB, while `git log`, `git blame`, and rebase all behave normally.
+
+The context lives once, at the workspace root — it is never copied into your package repos. Open the workspace in your AI tool and it picks up `AGENTS.md` / `CLAUDE.md` automatically. You can read exactly what it contains on the [Agent Context](./agent-context.md) page.
+
+### Already have the monorepo?
+
+If you already keep a `start-technologies` checkout — you work on StartOS itself, or you've cloned it for another reason — don't let the workspace clone a second copy. Point at the one you have **before** running `init-workspace`, and it will use it:
+
+```sh
+mkdir start9-workspace && cd start9-workspace
+ln -s /path/to/your/start-technologies start-technologies
+start-cli s9pk init-workspace .
+```
+
+`init-workspace` skips the clone whenever `start-technologies` already resolves to a directory, so the symlink is left alone and everything else is provisioned around it. The workspace `AGENTS.md` links through it, and `s9pk init-package` scaffolds from its package template, exactly as with a fresh clone.
+
+> [!IMPORTANT]
+> A symlinked checkout is **yours to maintain**. Skip the `git pull` in [Keep it current](#keep-it-current): that repo has its own branches and its own work in progress, and a blind pull would fast-forward whatever branch happens to be checked out rather than refresh the guide. Update it on your own schedule instead.
 
 ### Nested workspaces and config resolution
 

--- a/projects/start-sdk/docs/src/file-models.md
+++ b/projects/start-sdk/docs/src/file-models.md
@@ -196,6 +196,23 @@ await storeJson.write(effects, {
 })
 ```
 
+### What an Empty `merge()` Does
+
+Every `merge()` — including `merge(effects, {})` — reads the file, parses it through your schema, deep-merges the patch over the parsed value, re-serializes, and writes only if the result differs from what was on disk. With an empty patch, against a file that already exists:
+
+| Existing content        | Result                                                                |
+| ----------------------- | --------------------------------------------------------------------- |
+| Key present and valid   | Untouched                                                             |
+| Key missing             | Filled from its `.catch()` default                                    |
+| Key present but invalid | **Replaced** by its `.catch()` default — this is the self-healing     |
+| Key outside the schema  | Preserved (see [Unknown Key Preservation](#unknown-key-preservation)) |
+| Comments, formatting    | **Not preserved** — the file is re-serialized from the parsed value   |
+
+So `merge(effects, {})` is safe to call on every init: it seeds a fresh file, repairs a corrupted one, and does nothing to a file that already round-trips cleanly. The parse is why [every key needs `.catch()`](#every-key-should-have-catch) — a value the schema can't repair makes `merge()` throw rather than heal.
+
+> [!WARNING]
+> An empty merge is **not** a way to clean, strip, or regenerate a config. It never removes a key you didn't name — pass the key explicitly as `undefined` for that. And because it re-serializes, the first empty merge against a hand-written or upstream-generated `.toml`/`.yaml` **discards its comments**.
+
 ### Exporting Defaults from File Models
 
 When a default value from the file model is also needed elsewhere (e.g., as a placeholder or default in an action's input spec), define the value as a constant in the file model, use it in the schema, and export it:
@@ -389,7 +406,10 @@ export const confFile = FileHelper.ini(
 
 ### Unknown Key Preservation
 
-The SDK patches `z.object()` to use loose mode by default — unknown keys in the parsed data are **preserved**, not stripped. This is intentional: upstream config files often contain keys your schema doesn't model (auto-generated secrets, internal state, plugin settings, etc.), and stripping them would break the service.
+The SDK patches `z.object()` to use loose mode by default — unknown keys in the parsed data are **preserved**, not stripped, at **every nesting level**. This is intentional: upstream config files often contain keys your schema doesn't model (auto-generated secrets, internal state, plugin settings, etc.), and stripping them would break the service.
+
+> [!IMPORTANT]
+> Import `z` from `@start9labs/start-sdk` and use `z.object`. **You never need `z.looseObject`.** Plain zod's `z.object` strips unknown keys, so a reader who knows zod reaches for `looseObject` to protect a two-way-bound config file — but the SDK's `z.object` already preserves them, deeply. `z.looseObject` is still exported and still compiles; it is not the convention.
 
 This has two important consequences:
 

--- a/projects/start-sdk/docs/src/init.md
+++ b/projects/start-sdk/docs/src/init.md
@@ -431,4 +431,4 @@ export const seedFiles = sdk.setupOnInit(async effects => {
 Reach for the `kind` check only when the body needs to behave differently between install / update / restore / rebuild.
 
 > [!NOTE]
-> Always use `merge()` (not `write()`) to seed file models, even on first install. With every key in your zod schema carrying a `.catch()`, `merge(effects, {})` is enough to create the file and populate every default. See [File Models — Prefer merge() Over write()](./file-models.md#prefer-merge-over-write).
+> Always use `merge()` (not `write()`) to seed file models, even on first install. With every key in your zod schema carrying a `.catch()`, `merge(effects, {})` is enough to create the file and fill in every missing default. See [File Models — Prefer merge() Over write()](./file-models.md#prefer-merge-over-write) and [What an Empty merge() Does](./file-models.md#what-an-empty-merge-does).

--- a/projects/start-sdk/docs/src/interfaces.md
+++ b/projects/start-sdk/docs/src/interfaces.md
@@ -2,6 +2,18 @@
 
 `setupInterfaces()` defines the network interfaces your service exposes and how they are made available to the user. This function runs on service install, update, and config save.
 
+## Network Reachability
+
+Your package declares _what_ it exposes. The **user** decides _where_ it is reachable. An interface is bound to the server's [gateways](/start-os/gateways.html), and the user enables or disables each resulting address individually from the service's **Interfaces** tab. LAN addresses (the `.local` hostname, the LAN IP) are enabled by default; public IPv4 addresses are **off** by default.
+
+Two consequences worth internalizing before you write any interface code:
+
+- **`type` is a label, not a control.** `'ui'`, `'api'`, and `'p2p'` tell the user what an interface is _for_. They do not select a transport, grant public access, or imply anything about how the interface is reached.
+- **Tor is opt-in and per-interface.** Tor is not part of StartOS. The user installs the **Tor** service from the marketplace, and then explicitly adds an onion address to each interface they want on Tor — see [Tor](/start-os/tor.html). Nothing your package does provisions one.
+
+> [!WARNING]
+> Never state — in `README.md`, `instructions.md`, a comment, or a plan — that a service "is exposed on Tor" or "is published to the internet." Your package cannot know: no binding type, and no value of `type`, causes an onion or a clearnet address to exist. Describe what the interface serves and let the user decide how to reach it.
+
 ## Single Interface
 
 For a service with one web interface:

--- a/projects/start-sdk/docs/src/quick-start.md
+++ b/projects/start-sdk/docs/src/quick-start.md
@@ -18,7 +18,7 @@ start-cli s9pk init-package "Hello World"
 Your workspace now looks like:
 
 ```
-my-workspace/
+start9-workspace/
 ├── .startos/
 ├── AGENTS.md
 ├── AGENTS.local.md

--- a/projects/start-sdk/docs/src/recipe-admin-credentials.md
+++ b/projects/start-sdk/docs/src/recipe-admin-credentials.md
@@ -4,7 +4,21 @@ Most services need admin credentials before the user can sign in. The standard p
 
 ## Solution
 
-In `setupOnInit`, read the file model where the admin password lives. When it is unset, call `sdk.action.createOwnTask()` with severity `'critical'` pointing to the `setAdminPassword` action. The action is `sdk.Action.withoutInput`, `visibility: 'enabled'` so users can reach it for rotation, and its handler calls `utils.getDefaultString()`, writes the result to the store, and returns it as a group result (username unmasked + copyable, password masked + copyable).
+In `setupOnInit`, read the file model where the admin password lives. When it is unset, call `sdk.action.createOwnTask()` with severity `'critical'` pointing to the `setAdminPassword` action. The action is `sdk.Action.withoutInput`, `visibility: 'enabled'` so users can reach it for rotation, and its handler generates the password, writes it to the store, and returns it as a group result (username unmasked + copyable, password masked + copyable).
+
+## Never roll your own password RNG
+
+The random string comes from the SDK, always. It is not a top-level export — it lives under the `utils` namespace, and it takes a spec:
+
+```typescript
+import { utils } from '@start9labs/start-sdk'
+
+const adminPassword = utils.getDefaultString({ charset: 'a-z,A-Z,0-9', len: 32 })
+```
+
+`getDefaultString()` with no argument **throws** — it resolves a `DefaultString`, which is either a literal string or a `RandomString` spec (`{ charset, len }`). If you find yourself reaching for `crypto.randomInt` and a hand-written alphabet, you are looking at the wrong name: it is `utils.getDefaultString`, not `getRandomString`.
+
+When the credential is a field on an action **form** rather than something the handler mints, don't generate it in package code at all — hand the spec to the OS. `Value.text` takes a `RandomString` on `default` (pre-filled) or on `generate` (adds a "generate" button); see [Actions](actions.md#generating-values-in-a-form).
 
 The shape gives you:
 

--- a/projects/start-sdk/docs/src/recipe-config-files.md
+++ b/projects/start-sdk/docs/src/recipe-config-files.md
@@ -4,7 +4,7 @@ Most services read their configuration from files (YAML, TOML, INI, JSON, ENV). 
 
 ## Solution
 
-Define a `FileHelper` (`.json()`, `.yaml()`, `.toml()`, etc.) with a zod schema where every field has `.catch()` for self-healing defaults. Use `.merge()` to write (preserves unknown keys), `.read().const(effects)` for reactive reads that restart the daemon on change, and `.read().once()` for one-time reads. Seed defaults on install with `fileModel.merge(effects, {})` — the empty merge applies all `.catch()` defaults.
+Define a `FileHelper` (`.json()`, `.yaml()`, `.toml()`, etc.) with a zod schema where every field has `.catch()` for self-healing defaults. Use `.merge()` to write (preserves unknown keys), `.read().const(effects)` for reactive reads that restart the daemon on change, and `.read().once()` for one-time reads. Seed defaults on install with `fileModel.merge(effects, {})` — the empty merge fills every missing field from its `.catch()` default. It does not strip or regenerate what's already there; see [What an Empty merge() Does](file-models.md#what-an-empty-merge-does).
 
 **Reference:** [File Models](file-models.md) · [Main](main.md)
 

--- a/projects/start-sdk/docs/src/recipe-install-init.md
+++ b/projects/start-sdk/docs/src/recipe-install-init.md
@@ -4,7 +4,7 @@ Fresh installs often need one-time bootstrapping — generating passwords, seedi
 
 ## Solution
 
-In `setupOnInit`, check `kind === 'install'` and run one-time setup: generate passwords with `utils.getDefaultString()`, seed config file defaults with `fileModel.merge(effects, {})` (empty merge applies all `.catch()` defaults), and create tasks for user actions. For setup that should run on both install and restore but not container rebuild, check `kind !== null`. The four init kinds are `'install'`, `'update'`, `'restore'`, and `null`.
+In `setupOnInit`, check `kind === 'install'` and run one-time setup: generate passwords with `utils.getDefaultString({ charset, len })`, seed config file defaults with `fileModel.merge(effects, {})` (an empty merge fills every missing field from its `.catch()` default), and create tasks for user actions. For setup that should run on both install and restore but not container rebuild, check `kind !== null`. The four init kinds are `'install'`, `'update'`, `'restore'`, and `null`.
 
 **Reference:** [Initialization](init.md) · [File Models](file-models.md)
 

--- a/projects/start-sdk/docs/src/recipe-internal-secrets.md
+++ b/projects/start-sdk/docs/src/recipe-internal-secrets.md
@@ -4,7 +4,7 @@ Many services need passwords or tokens that are generated once and used internal
 
 ## Solution
 
-In `setupOnInit`, check for `kind === 'install'` and generate random strings with `utils.getDefaultString()`. Write them to store.json via a file model. These secrets are consumed in `setupMain` as env vars or config file values — they are never shown to the user.
+In `setupOnInit`, check for `kind === 'install'` and generate random strings with `utils.getDefaultString({ charset, len })`. Write them to store.json via a file model. These secrets are consumed in `setupMain` as env vars or config file values — they are never shown to the user.
 
 **Reference:** [Initialization](init.md) · [File Models](file-models.md)
 

--- a/projects/start-sdk/docs/src/recipe-reset-password.md
+++ b/projects/start-sdk/docs/src/recipe-reset-password.md
@@ -4,7 +4,7 @@ When users lose their admin password, they need a way to generate a new one. A r
 
 ## Solution
 
-Create an action with `sdk.Action.withoutInput()` that generates a new password using `utils.getDefaultString()`. Use `sdk.SubContainer.withTemp()` to spin up a temporary container, exec the app's password-reset command with `sub.execFail()`, then return the password as a masked, copyable result. For multi-user apps, use `sdk.Action.withInput()` with `Value.dynamicSelect` to query the running app for admin users and let the user choose which to reset.
+Create an action with `sdk.Action.withoutInput()` that generates a new password using `utils.getDefaultString({ charset, len })`. Use `sdk.SubContainer.withTemp()` to spin up a temporary container, exec the app's password-reset command with `sub.execFail()`, then return the password as a masked, copyable result. For multi-user apps, use `sdk.Action.withInput()` with `Value.dynamicSelect` to query the running app for admin users and let the user choose which to reset.
 
 **Reference:** [Actions](actions.md)
 

--- a/projects/start-sdk/docs/src/recipe-web-ui.md
+++ b/projects/start-sdk/docs/src/recipe-web-ui.md
@@ -6,9 +6,18 @@ Every service with a browser interface needs at least one HTTP interface. This i
 
 In `setupInterfaces()`, create a `MultiHost` with `sdk.MultiHost.of(effects, 'ui')`, bind an HTTP port with `multi.bindPort(port, { protocol: 'http', preferredExternalPort: 80 })`, create a `'ui'` type interface with `sdk.createInterface()` setting `masked: false`, and export it. Return the receipt array.
 
-If the app has no login of its own, gate it at the edge with `addSsl.auth` instead of building auth into the service — see [Authenticating at the Proxy](interfaces.md#authenticating-at-the-proxy).
-
 **Reference:** [Interfaces](interfaces.md)
+
+## Authentication
+
+**StartOS does not authenticate a bound port.** Binding an interface exposes it; nothing gates it unless you say so. There are exactly two ways to gate it, and they are not interchangeable.
+
+**Prefer the app's own login.** When upstream ships one, feed it the credential it expects — an env var (`SALTED_PASS`, `QBT_PW_HASH`) or its config file — and **persist only the hash**. Follow [Prompt User to Create Admin Credentials](recipe-admin-credentials.md): the action is the sole writer of the credential, it returns the value rather than storing it in cleartext, and the user rotates it by re-running the action. Reference implementations: [qbittorrent](https://github.com/Start9Labs/qbittorrent-startos) (`QBT_PW_HASH`) and [changedetection](https://github.com/Start9-Community/changedetection-startos) (`SALTED_PASS`).
+
+**Fall back to the OS gate only when the app has no auth of its own.** [`addSsl.auth`](interfaces.md#authenticating-at-the-proxy) makes the OS reverse proxy challenge every request to that binding's port, so REST endpoints, RSS feeds, and webhooks are gated along with the browser UI, and any client that can't send an `Authorization` header is locked out. Reference implementation: [searxng](https://github.com/Start9Labs/searxng-startos).
+
+> [!WARNING]
+> **Do not derive an app-native login from `searxng-startos`.** It is the OS-gate reference _only_. It stores the password in cleartext because the reverse proxy needs the cleartext to configure basic auth, and it takes the credential `withInput` because the user is choosing public-vs-private. Neither property transfers to an app-native login — copying them puts a plaintext password at rest. Searching for `addSsl.auth` lands you in searxng first; that answers "how does StartOS gate a port," not "how do I wire up the app's own login."
 
 ## Examples
 

--- a/projects/start-sdk/docs/src/workflow.md
+++ b/projects/start-sdk/docs/src/workflow.md
@@ -53,11 +53,19 @@ When you can't verify something, surface it as an open question or a `TODO.md` i
 
 Before concluding the SDK can't do what you need — or working around a limitation you've assumed — grep the installed type definitions: `node_modules/@start9labs/start-sdk/**/*.d.ts`. The SDK exposes far more than the recipes show, and the option you want is often a field on a type you're already using (this is how `runAsInit` is found, for example). "The SDK doesn't support X" is a claim to verify in the types, not a conclusion to reach from the docs alone. If it genuinely isn't there, say so and explain the workaround — don't silently route around a capability that exists.
 
+## A comment is not evidence
+
+A comment asserting what an SDK call does — in a package you're reading, in a code review, in this guide's own prose — is a claim, not a fact. Confirm it against the reference page, the installed types, or the SDK source before you accept it, repeat it, or write code that depends on it. Wrong claims about semantics propagate: one plausible sentence gets copied into the next package, then quoted in a review, then built into a plan.
+
+`merge(effects, {})` is the standing example. It has variously been described as rewriting the file, as cleaning or stripping it, and as a no-op against an existing one. Every reading was plausible; none was correct — see [What an Empty merge() Does](./file-models.md#what-an-empty-merge-does).
+
 ## Read the monorepo source only when the guide can't answer
 
-Your workspace's `start-technologies/` is a sparse checkout of the Start9 monorepo — by default only the packaging guide (`projects/start-sdk/docs`) is materialized, but the full **SDK source** (`projects/start-sdk/lib`) and **StartOS source** (`projects/start-os`, and the shared core in `shared-libs/`) are one command away when you need them — past the recipes, reference pages, real packages, and the installed `@start9labs/start-sdk` types.
+Your workspace's `start-technologies/` is a checkout of the whole Start9 monorepo, so the **SDK source** (`projects/start-sdk/lib`) and the **StartOS source** (`projects/start-os`, and the shared core in `shared-libs/`) are already on disk — behind the recipes, the reference pages, real packages, and the installed `@start9labs/start-sdk` types.
 
-This is a **last resort, not a starting point.** Drop into the source only to answer a specific question those layers can't — exactly what an SDK call does, how an OS effect behaves — and read the one file that settles it instead of browsing. Fetch a path that isn't checked out with `git -C start-technologies sparse-checkout add <path>`.
+This is a **last resort, not a starting point.** Drop into the source only to answer a specific question those layers can't — exactly what an SDK call does, how an OS effect behaves — and read the one file that settles it instead of browsing.
+
+When the answer turns out to be a bug rather than a misunderstanding, fix it there: that checkout is a full git repo, so you can branch, commit, and open a pull request without leaving the workspace.
 
 ## Don't create unnecessary version files
 

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -142,11 +142,11 @@ bins.tunnel.error-updating-webserver-bind:
 
 # s9pk/init.rs
 s9pk.init.cloning-guide:
-  en_US: "Cloning the packaging guide…"
-  de_DE: "Paketierungsleitfaden wird geklont…"
-  es_ES: "Clonando la guía de empaquetado…"
-  fr_FR: "Clonage du guide d'empaquetage…"
-  pl_PL: "Klonowanie przewodnika pakowania…"
+  en_US: "Cloning the Start9 monorepo (packaging guide, SDK and OS source)…"
+  de_DE: "Start9-Monorepo wird geklont (Paketierungsleitfaden, SDK- und OS-Quellcode)…"
+  es_ES: "Clonando el monorepo de Start9 (guía de empaquetado, código fuente del SDK y del SO)…"
+  fr_FR: "Clonage du monorepo Start9 (guide d'empaquetage, sources du SDK et de l'OS)…"
+  pl_PL: "Klonowanie monorepo Start9 (przewodnik pakowania, kod źródłowy SDK i OS)…"
 
 s9pk.init.installing-deps:
   en_US: "Installing dependencies (npm install)…"

--- a/shared-libs/crates/start-core/src/s9pk/AGENTS.local.md.template
+++ b/shared-libs/crates/start-core/src/s9pk/AGENTS.local.md.template
@@ -1,0 +1,19 @@
+# AGENTS.local.md — your workspace preferences
+
+<!--
+Notes and preferences for AI assistants working in this workspace. CLAUDE.md loads this file
+alongside AGENTS.md, and syncing the guide never overwrites it — so it is the right home for
+anything true of *your* setup rather than of packaging in general:
+
+  - the StartOS box you install to, and the registry you publish to
+  - the packages you maintain, and where they live
+  - conventions your team follows that the guide doesn't mandate
+  - any way your workspace departs from the scaffolded layout — for example, a
+    start-technologies/ symlinked to a monorepo checkout you maintain yourself
+
+Rule of thumb: if a note would help *every* packager, it does not belong here. Open a PR
+against start-technologies so it lands in the guide — otherwise it stays trapped in one
+workspace and drifts out of date.
+
+Delete this comment once you have something to say.
+-->

--- a/shared-libs/crates/start-core/src/s9pk/init.rs
+++ b/shared-libs/crates/start-core/src/s9pk/init.rs
@@ -66,26 +66,7 @@ const TEMPLATE_SUBPATH: &str = "projects/start-sdk/docs/package-template";
 const CLAUDE_MD_CONTENTS: &str = "@AGENTS.md\n@AGENTS.local.md\n";
 
 /// Created once and never overwritten by a sync — the user's own context.
-const AGENTS_LOCAL_STUB: &str = r#"# AGENTS.local.md — your workspace preferences
-
-<!--
-Notes and preferences for AI assistants working in this workspace. CLAUDE.md loads this file
-alongside AGENTS.md, and syncing the guide never overwrites it — so it is the right home for
-anything true of *your* setup rather than of packaging in general:
-
-  - the StartOS box you install to, and the registry you publish to
-  - the packages you maintain, and where they live
-  - conventions your team follows that the guide doesn't mandate
-  - any way your workspace departs from the scaffolded layout — for example, a
-    start-technologies/ symlinked to a monorepo checkout you maintain yourself
-
-Rule of thumb: if a note would help *every* packager, it does not belong here. Open a PR
-against start-technologies so it lands in the guide — otherwise it stays trapped in one
-workspace and drifts out of date.
-
-Delete this comment once you have something to say.
--->
-"#;
+const AGENTS_LOCAL_STUB: &str = include_str!("AGENTS.local.md.template");
 
 #[derive(Deserialize, Serialize, Parser)]
 #[group(skip)]

--- a/shared-libs/crates/start-core/src/s9pk/init.rs
+++ b/shared-libs/crates/start-core/src/s9pk/init.rs
@@ -39,20 +39,25 @@ registry:
 /// a package repo.
 const DOCS_URL: &str = "https://docs.start9.com/packaging/environment-setup.html";
 
-/// Default source for the packaging guide (which also carries the package
-/// template). The guide lives in the start-technologies monorepo; the clone is
-/// sparse (see GUIDE_SUBPATH) so packagers don't pull the whole repo. Re-point the
-/// `start-technologies` remote afterward to track a fork; the session-start sync
-/// follows whatever remote is configured.
+/// Default source for the packaging guide (which also carries the package template).
+/// The guide lives in the start-technologies monorepo, and the clone takes the whole
+/// tree: past the guide, packagers get the SDK and StartOS source to answer questions
+/// the guide can't, and a repo they can open a fix PR from. `--filter=blob:none` keeps
+/// it cheap (blobs fetch on demand) while leaving full history, so `log`/`blame`/rebase
+/// all work. Re-point the `start-technologies` remote afterward to track a fork; the
+/// session-start sync follows whatever remote is configured.
 const MONOREPO_URL: &str = "https://github.com/Start9Labs/start-technologies.git";
-/// Workspace-relative path to the sparse monorepo checkout that carries the guide.
+/// Workspace-relative path to the monorepo checkout that carries the guide.
 const MONOREPO_DIR: &str = "start-technologies";
-/// Monorepo subtree holding the packaging guide + package template; the clone is
-/// sparse-checked-out to just this path.
-const GUIDE_SUBPATH: &str = "projects/start-sdk/docs";
 /// Symlink target for the workspace `AGENTS.md` — the guide's canonical copy, so
-/// a sync keeps the workspace context current with no extra step.
-const AGENTS_SYMLINK_TARGET: &str = "start-technologies/projects/start-sdk/docs/AGENTS.md";
+/// a sync keeps the workspace context current with no extra step. It is also a page
+/// of the published guide, so packagers can read it without scaffolding a workspace.
+const AGENTS_SYMLINK_TARGET: &str =
+    "start-technologies/projects/start-sdk/docs/src/agent-context.md";
+/// Where the workspace `AGENTS.md` pointed before the context became a guide page. Nothing
+/// lives there now, so a workspace scaffolded by an older start-cli has a dangling link;
+/// a re-run repoints it.
+const LEGACY_AGENTS_SYMLINK_TARGET: &str = "start-technologies/projects/start-sdk/docs/AGENTS.md";
 /// Path to the package template inside the cloned guide (joined onto MONOREPO_DIR).
 const TEMPLATE_SUBPATH: &str = "projects/start-sdk/docs/package-template";
 
@@ -64,9 +69,21 @@ const CLAUDE_MD_CONTENTS: &str = "@AGENTS.md\n@AGENTS.local.md\n";
 const AGENTS_LOCAL_STUB: &str = r#"# AGENTS.local.md — your workspace preferences
 
 <!--
-Notes and preferences for AI assistants working in this workspace. This file is yours;
-syncing the guide never overwrites it. Put anything you want always in scope here — the
-registry you publish to, the packages you're focused on, local conventions, and so on.
+Notes and preferences for AI assistants working in this workspace. CLAUDE.md loads this file
+alongside AGENTS.md, and syncing the guide never overwrites it — so it is the right home for
+anything true of *your* setup rather than of packaging in general:
+
+  - the StartOS box you install to, and the registry you publish to
+  - the packages you maintain, and where they live
+  - conventions your team follows that the guide doesn't mandate
+  - any way your workspace departs from the scaffolded layout — for example, a
+    start-technologies/ symlinked to a monorepo checkout you maintain yourself
+
+Rule of thumb: if a note would help *every* packager, it does not belong here. Open a PR
+against start-technologies so it lands in the guide — otherwise it stays trapped in one
+workspace and drifts out of date.
+
+Delete this comment once you have something to say.
 -->
 "#;
 
@@ -122,39 +139,20 @@ pub async fn init_workspace(
     // `.startos/`, so a nested workspace transparently overrides an outer one — no need
     // to look at, or refuse, an enclosing workspace here.
 
-    // Provision the guide. Clone only when absent — refreshing is the session-start
-    // sync's job, not this command's, so an existing checkout is left untouched. A
-    // blobless, sparse, depth-1 clone fetches only GUIDE_SUBPATH, not the whole monorepo.
+    // Provision the guide. Clone only when absent — refreshing is the session-start sync's
+    // job, not this command's — so an existing checkout is left untouched. `exists()`
+    // follows symlinks, so pointing `start-technologies` at a checkout you already maintain
+    // skips the clone entirely.
     let docs = root.join(MONOREPO_DIR);
     if !docs.exists() {
         eprintln!("{}", t!("s9pk.init.cloning-guide"));
         Command::new("git")
             .arg("clone")
             .arg("--filter=blob:none")
-            .arg("--no-checkout")
-            .arg("--depth")
-            .arg("1")
             .arg("--branch")
             .arg("master")
             .arg(MONOREPO_URL)
             .arg(&docs)
-            .capture(false)
-            .invoke(ErrorKind::Git)
-            .await?;
-        Command::new("git")
-            .arg("-C")
-            .arg(&docs)
-            .arg("sparse-checkout")
-            .arg("set")
-            .arg("--no-cone")
-            .arg(GUIDE_SUBPATH)
-            .capture(false)
-            .invoke(ErrorKind::Git)
-            .await?;
-        Command::new("git")
-            .arg("-C")
-            .arg(&docs)
-            .arg("checkout")
             .capture(false)
             .invoke(ErrorKind::Git)
             .await?;
@@ -163,6 +161,14 @@ pub async fn init_workspace(
     // Symlink (not a copy) so a guide sync keeps the workspace AGENTS.md current.
     // symlink_metadata treats a broken link as present, so a re-run never clobbers.
     let agents = root.join("AGENTS.md");
+    if tokio::fs::read_link(&agents)
+        .await
+        .is_ok_and(|target| target == Path::new(LEGACY_AGENTS_SYMLINK_TARGET))
+    {
+        tokio::fs::remove_file(&agents)
+            .await
+            .with_ctx(|_| (ErrorKind::Filesystem, agents.display().to_string()))?;
+    }
     if tokio::fs::symlink_metadata(&agents).await.is_err() {
         tokio::fs::symlink(AGENTS_SYMLINK_TARGET, &agents)
             .await


### PR DESCRIPTION
## Summary

Three related changes to how a packaging workspace is provisioned and what the guide tells an agent, plus a batch of doc corrections that were each verified against the SDK source rather than the surrounding prose.

### `init-workspace` clones the whole monorepo

The clone was sparse, shallow, and limited to `projects/start-sdk/docs`. It is now the full tree, so a packager has the SDK source (`projects/start-sdk/lib`) and the StartOS source on hand when the guide can't settle a question — and is standing in a repo they can open a fix PR from. `--filter=blob:none` keeps it cheap: measured at ~4s and 25 MB of `.git` (75 MB with the worktree), with full history, so `log` / `blame` / `rebase` all behave normally.

Symlinking an existing `start-technologies` checkout into the workspace before running `init-workspace` skips the clone. That already worked (`Path::exists()` follows symlinks) but was undocumented; `environment-setup.md` now has an **Already have the monorepo?** section with the commands and the caveat that such a checkout is yours to maintain, so skip the session-start sync.

The old `sparse-checkout add` guidance is removed from `workflow.md` and the agent context, since nothing needs fetching anymore.

### The agent context is now a page of the guide

`docs/AGENTS.md` — the file symlinked into every workspace — moves to `docs/src/agent-context.md`. It builds as [Agent Context] in the published book, so it can be read without scaffolding a workspace or browsing the monorepo. `AGENTS_SYMLINK_TARGET` moves with it, and `init-workspace` repoints symlinks left behind by earlier releases (they now dangle rather than silently resolving to the wrong file).

That frees `docs/AGENTS.md` to become the mdbook's *own* scope doc. Along the way: the conventions shared by every book in the repo (mdBook versions, admonitions, tabs, `SUMMARY.md`, the shared `theme/`) live in `projects/start-docs/AGENTS.md`, which is a **sibling**, not an ancestor — so nothing loads it for you. The root `AGENTS.md` now says so explicitly.

The scaffolded `AGENTS.local.md` stub now states what belongs in it, and that anything which would help every packager belongs upstream in the guide instead of drifting in one workspace.

### Doc corrections

Each of these was checked against `projects/start-sdk/lib`, the installed types, or the StartOS docs — not against neighbouring prose.

- **`interfaces.md`** — Tor is opt-in and per-interface (`projects/start-os/docs/src/tor.md`: *"Tor is not included in StartOS by default"*), `type` is a label rather than a control, and a package can never assert it is reachable on Tor or the public internet. The word "tor" previously appeared **zero** times on this page.
- **`file-models.md`** — what an empty `merge()` actually does, per `fileHelper.ts:400-424`: it fills missing keys, replaces invalid ones with their `.catch()` default, re-serializes (dropping comments), and writes only if the output differs. It does not strip. Also: the SDK's `z.object` is *deep*-loose, verified empirically, so `z.looseObject` is never needed.
- **`recipe-web-ui.md`** — prefer the app's own login. `searxng-startos` is the OS-gate reference **only**; it stores plaintext because the reverse proxy needs it, and that does not transfer. Naming it beside the app-native packages is the anchoring path that has produced a plaintext-at-rest bug.
- **`recipe-admin-credentials.md`** — `utils.getDefaultString` takes a required `DefaultString`. The bare `utils.getDefaultString()` written in five recipes **throws** (`TypeError`). Adds the import line and the rule that packages never roll their own password RNG.
- **`actions.md`** — `Value.text` accepts a `RandomString` on `default` and on `generate`, so the OS can mint the secret; neither was documented anywhere. Snippet typechecked against the real SDK inside `hello-world-startos`. Also: don't `as const` what the SDK already types (`setupActions.d.ts:10` declares `version: '1'`).
- **`workflow.md`** — new "A comment is not evidence" section. Four of the corrections above began life as confidently-worded prose that was simply wrong.
- **`package-template/AGENTS.md`** — `recipes.md` promoted to the first pointer, framed as the entry point.

### Also

- Bumps `start-cli` to **1.0.2** with a changelog entry. Fixes the changelog's link definitions, which pointed at `v0.4.0-beta.10` — a tag that has never existed in any form.
- The `cloning-guide` i18n string now names what is actually cloned, in all five locales.

## Verification

- `mdbook build` clean; every new anchor and relative link across the changed pages resolves.
- `npx prettier --check` clean.
- The `Value.text` / `getDefaultString` snippet typechecks (`tsc --noEmit`) inside a real package.
- Clone strategies measured against the real repo; `sparse-checkout disable` confirmed to widen an existing workspace in place (98 → 3078 files, 3s).
- Rust is a `&str` const, a six-line legacy-symlink repoint, and the stub text; the `read_link` / `PathBuf == &Path` idiom was compile-checked standalone. Leaving the full `cargo check -p start-core` to CI.

[Agent Context]: https://docs.start9.com/packaging/agent-context.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)