### PR TITLE
chore(start-wrt): cut v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7924,7 +7924,7 @@ dependencies = [
 
 [[package]]
 name = "startwrt-core"
-version = "0.1.0-beta.4"
+version = "1.0.0"
 dependencies = [
  "arc-swap",
  "async_cell",

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
+First stable release of StartWRT — Start9's OpenWrt-based router OS for home
+self-hosting, built around per-device Security Profiles (assigned by Ethernet
+port, WiFi password, or inbound VPN), with inbound/outbound WireGuard VPNs and
+VPN chaining, WiFi schedules, dynamic DNS, and published-port forwarding.
+Ships as a flashable image for the SpaceMiT K1 (BananaPi-F3), with OTA updates
+delivered through the Start9 registry.
+
 ## [0.1.0-beta.4]
 
 ### Added

--- a/projects/start-wrt/backend/ctrl/Cargo.toml
+++ b/projects/start-wrt/backend/ctrl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "startwrt-core"
-version = "0.1.0-beta.4"
+version = "1.0.0"
 
 [lib]
 name = "startwrt"


### PR DESCRIPTION
Bump backend/ctrl to 1.0.0 and cut the changelog's [Unreleased] into an explicit [1.0.0] section (release pre-check requires it). First stable release; no functional changes on top of the soaked beta line.