### PR TITLE
fix(ui): render update progress circle on the updates tab

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/portal/routes/updates/item.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/updates/item.component.ts
@@ -171,7 +171,7 @@ import UpdatesComponent from './updates.component'
     }
 
     tui-progress-circle {
-      display: inline-block;
+      display: inline-flex;
       vertical-align: middle;
     }
 


### PR DESCRIPTION
## Summary

While a service is updating from Marketplace → **Updates**, its row now shows the progress circle again.

The per-row `tui-progress-circle` was styled `display: inline-block`, which suppressed its SVG paint entirely — the element sat in the DOM at the correct 40×40 size with a valid blue stroke and geometry, but rendered **zero visible pixels at every progress value, including 100%**. So updating a service from the Updates tab left a blank action cell with no loading indicator (a beta.10 regression — the circle never appeared, not even for a frame, on mock or live). Switching the host to `inline-flex` — an inline-level flex formatting context, so it still sits inline in the table cell (`vertical-align: middle` preserved) — restores the paint; the circle renders and animates 0→100% through the download/install.

Verified against the mock update flow in a browser: with `inline-block` the circle paints 0 pixels at value 100; toggling only `display` to `inline-flex` flips it to a rendered, animating arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
