### PR TITLE
fix(build): detect a dirty tree with git status, not stat-only diff-i…

### DIFF
--- a/build/env/check-git-hash.sh
+++ b/build/env/check-git-hash.sh
@@ -3,7 +3,10 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [ "$GIT_BRANCH_AS_HASH" != 1 ]; then
-    GIT_HASH="$(git rev-parse HEAD)$(if ! git diff-index --quiet HEAD --; then echo '-modified'; fi)"
+    # git status (not diff-index): builds touch tracked files (e.g. the make
+    # recipe for package-lock.json) without changing content, and stat-only
+    # diff-index misreads that as a dirty tree. status compares content.
+    GIT_HASH="$(git rev-parse HEAD)$(if [ -n "$(git status --porcelain --untracked-files=no)" ]; then echo '-modified'; fi)"
 else
     GIT_HASH="@$(git rev-parse --abbrev-ref HEAD)"
 fi

--- a/projects/start-wrt/backend/ctrl/build.rs
+++ b/projects/start-wrt/backend/ctrl/build.rs
@@ -24,10 +24,14 @@ fn main() {
                 .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
                 .unwrap_or_else(|| "unknown".into());
 
+            // git status (not diff-index): stat-only diff-index misreads a
+            // touched-but-unchanged tracked file as dirty. status compares content.
             let dirty = Command::new("git")
-                .args(["diff-index", "--quiet", "HEAD", "--"])
-                .status()
-                .map(|s| !s.success())
+                .args(["status", "--porcelain", "--untracked-files=no"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| !o.stdout.is_empty())
                 .unwrap_or(false);
 
             if dirty {

--- a/projects/start-wrt/build/build-rust.sh
+++ b/projects/start-wrt/build/build-rust.sh
@@ -20,7 +20,12 @@ RUST_ARCH=${RUST_ARCH:-riscv64gc}
 PROFILE=${PROFILE:-release}
 if [ -z "$STARTWRT_GIT_HASH" ]; then
     STARTWRT_GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
-    git diff-index --quiet HEAD -- 2>/dev/null || STARTWRT_GIT_HASH="${STARTWRT_GIT_HASH}-dirty"
+    # git status (not diff-index): the make run touches the tracked
+    # package-lock.json before this script runs, and stat-only diff-index
+    # misreads that as a dirty tree. status compares content.
+    if [ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+        STARTWRT_GIT_HASH="${STARTWRT_GIT_HASH}-dirty"
+    fi
 fi
 export STARTWRT_GIT_HASH
 

--- a/projects/start-wrt/build/env/check-git-hash.sh
+++ b/projects/start-wrt/build/env/check-git-hash.sh
@@ -3,7 +3,10 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 if [ "$GIT_BRANCH_AS_HASH" != 1 ]; then
-    GIT_HASH="$(git rev-parse HEAD)$(if ! git diff-index --quiet HEAD --; then echo '-modified'; fi)"
+    # git status (not diff-index): builds touch tracked files (e.g. the make
+    # recipe for package-lock.json) without changing content, and stat-only
+    # diff-index misreads that as a dirty tree. status compares content.
+    GIT_HASH="$(git rev-parse HEAD)$(if [ -n "$(git status --porcelain --untracked-files=no)" ]; then echo '-modified'; fi)"
 else
     GIT_HASH="@$(git rev-parse --abbrev-ref HEAD)"
 fi

--- a/shared-libs/crates/start-core/src/s9pk/git_hash.rs
+++ b/shared-libs/crates/start-core/src/s9pk/git_hash.rs
@@ -30,15 +30,16 @@ impl GitHash {
         while hash.ends_with(|c: char| c.is_whitespace()) {
             hash.pop();
         }
-        if Command::new("git")
-            .arg("diff-index")
-            .arg("--quiet")
-            .arg("HEAD")
-            .arg("--")
+        // git status (not diff-index): stat-only diff-index misreads a
+        // touched-but-unchanged tracked file as dirty. status compares content.
+        if !Command::new("git")
+            .arg("status")
+            .arg("--porcelain")
+            .arg("--untracked-files=no")
             .current_dir(&path)
             .invoke(ErrorKind::Git)
-            .await
-            .is_err()
+            .await?
+            .is_empty()
         {
             hash += "-modified";
         }
@@ -57,16 +58,13 @@ impl GitHash {
         while hash.ends_with(|c: char| c.is_whitespace()) {
             hash.pop();
         }
-        if !std::process::Command::new("git")
-            .arg("diff-index")
-            .arg("--quiet")
-            .arg("HEAD")
-            .arg("--")
+        let status = std::process::Command::new("git")
+            .arg("status")
+            .arg("--porcelain")
+            .arg("--untracked-files=no")
             .output()
-            .ok()?
-            .status
-            .success()
-        {
+            .ok()?;
+        if !status.status.success() || !status.stdout.is_empty() {
             hash += "-modified";
         }
 


### PR DESCRIPTION
…ndex

Builds touch tracked files without changing content — the make recipe for package-lock.json ends in `touch` (shared-libs/ts-modules/build.mk), which runs before the product binaries compile. `git diff-index` trusts cached stat data and reports such files as dirty, so every CI-built startwrt branded its version string -dirty (start-wrt v1.0.0 shipped as `d557594-dirty` in `startwrt-cli verify` while the web UI, stamped at make parse time before the touch, showed clean). `git status --porcelain --untracked-files=no` compares content, keeps diff-index's tracked-only scope, and still flags real modifications.

Converted everywhere the monorepo derives a hash dirty-marker: the GIT_HASH.txt stamp scripts (root + start-wrt), start-wrt's build-rust.sh and ctrl/build.rs fallback, and s9pk packaging's GitHash (start-cli/SDK pack builds can touch tracked files the same way).