### PR TITLE
fix(ci): stop iso deploy skipping when dispatched

### DIFF
--- a/.github/workflows/startos-iso.yaml
+++ b/.github/workflows/startos-iso.yaml
@@ -352,7 +352,11 @@ jobs:
   deploy:
     name: Deploy
     needs: [image]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy != 'NONE'
+    # Explicit status check so the skipped PR-only `changes` job can't poison
+    # the implicit success() through the needs chain (actions/runner#2205).
+    if: >-
+      !cancelled() && needs.image.result == 'success'
+      && github.event_name == 'workflow_dispatch' && github.event.inputs.deploy != 'NONE'
     runs-on: ubuntu-latest
     env:
       REGISTRY: >-


### PR DESCRIPTION
Since #3438 added the PR-only `changes` job, every `workflow_dispatch` of the ISO workflow has skipped Deploy regardless of the `deploy` input (runs 29044877451, 29055695324, 29106888895 — the last one dispatched via `gh workflow run -f deploy=alpha`, so the input provably arrived).

The mechanism is [actions/runner#2205](https://github.com/actions/runner/issues/2205): a job-level `if` with no status-check function gets an implicit `success()`, and that evaluates over the **transitive** needs chain. `changes` skips on dispatch (it is PR-only), `image` overrides with `!cancelled()` and succeeds, but `deploy` had no override of its own — so the skipped ancestor poisoned its implicit `success()` and it skipped before its condition mattered.

Reproduced and fix validated in [run 29121946280](https://github.com/Start9Labs/start-technologies/actions/runs/29121946280): a byte-shaped copy of the current condition skips, the same condition prefixed with `!cancelled() && needs.image.result == 'success'` runs. The explicit `needs.image.result == 'success'` preserves the existing behavior of not deploying when any image leg fails.

A scan of the other workflows found no further instances of the pattern (start-registry's `create-image` cascade-skips only on draft PRs, which is intended).