### PR TITLE
fix(net): expose the whole host when a public domain is added

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/gateway.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/gateway.component.ts
@@ -274,7 +274,6 @@ export class GatewayComponent {
       fqdn,
       gateway: gatewayId,
       acme: !authority || authority === 'local' ? null : authority,
-      internalPort: iface?.addressInfo.internalPort || 80,
     }
 
     return this.tasks.run(async () => {

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -10,6 +10,7 @@ use ts_rs::TS;
 use crate::GatewayId;
 use crate::context::{CliContext, RpcContext};
 use crate::db::model::DatabaseModel;
+use crate::db::model::public::IpInfo;
 use crate::hostname::ServerHostname;
 use crate::net::acme::AcmeProvider;
 use crate::net::dns::QueryDnsRes;
@@ -17,6 +18,7 @@ use crate::net::gateway::{
     CheckDnsParams, CheckPortParams, CheckPortRes, CheckPortV6Res, check_dns, check_port,
     check_port_v6,
 };
+use crate::net::host::binding::DerivedAddressInfo;
 use crate::net::host::{HostApiKind, all_hosts};
 use crate::net::service_interface::HostnameMetadata;
 use crate::prelude::*;
@@ -232,6 +234,81 @@ pub struct AddPublicDomainRes {
     pub port_v6: Option<CheckPortV6Res>,
 }
 
+/// Enable a public domain across one binding-or-range address set. A public
+/// domain exposes the host as a whole, so `add_public_domain` runs this on every
+/// binding and every range. Domains are enabled-by-default, so "enabling" one is
+/// just clearing any `disabled` override. For a non-SSL row there is no SNI, so
+/// the domain shares the bare WAN IP's packets — the matching WAN IPv4 (and, when
+/// `ip_info` is supplied, the co-located IPv6 GUA) is force-enabled too, so the
+/// operator-facing toggle honestly reflects that the IP is now reachable. Port
+/// ranges are IPv4-only and pass `ip_info: None` (no GUA).
+fn enable_domain_on_addresses(
+    addresses: &mut DerivedAddressInfo,
+    fqdn: &InternedString,
+    gateway: &GatewayId,
+    ip_info: Option<&IpInfo>,
+) {
+    // A domain is served unless explicitly disabled — clear every domain row
+    // (SSL and non-SSL) for this fqdn+gateway from the disable set.
+    let domain_ports: BTreeSet<u16> = addresses
+        .available
+        .iter()
+        .filter_map(|a| match &a.metadata {
+            HostnameMetadata::PublicDomain { gateway: gw }
+                if &a.hostname == fqdn && gw == gateway =>
+            {
+                a.port
+            }
+            _ => None,
+        })
+        .collect();
+    for port in domain_ports {
+        addresses.disabled.remove(&(fqdn.clone(), port));
+    }
+
+    // The non-SSL domain resolves to `<wan-ip>:<port>` with no SNI, so exposing
+    // the domain necessarily exposes the bare WAN IP on that port. Find it.
+    let Some(dp) = addresses.available.iter().find_map(|a| match &a.metadata {
+        HostnameMetadata::PublicDomain { gateway: gw }
+            if !a.ssl && a.public && &a.hostname == fqdn && gw == gateway =>
+        {
+            a.port
+        }
+        _ => None,
+    }) else {
+        return;
+    };
+
+    for a in &addresses.available {
+        if a.ssl || !a.public {
+            continue;
+        }
+        if let HostnameMetadata::Ipv4 { gateway: gw } = &a.metadata {
+            if gw == gateway {
+                if let Some(sa) = a.to_socket_addr() {
+                    if sa.port() == dp {
+                        addresses.enabled.insert(sa);
+                    }
+                }
+            }
+        }
+    }
+
+    // No SNI on v6 either: the domain reaches v6 only via the bare GUA, which is
+    // directly routable (no NAT). Expose it like the WAN IPv4 above.
+    if let Some(ip_info) = ip_info {
+        for subnet in &ip_info.subnets {
+            if let IpAddr::V6(ip) = subnet.addr() {
+                if !crate::net::utils::ipv6_is_local(ip) {
+                    let gua = SocketAddrV6::new(ip, dp, 0, 0);
+                    addresses.gua_wan.insert(gua);
+                    addresses.enabled.insert(SocketAddr::V6(gua));
+                }
+            }
+        }
+    }
+}
+
 pub async fn add_public_domain<Kind: HostApiKind>(
     ctx: RpcContext,
     AddPublicDomainParams {
@@ -291,85 +368,22 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                 .and_then(|a| a.port)
                 .ok_or_else(|| Error::new(eyre!("no public address found for {fqdn} on port {internal_port}"), ErrorKind::NotFound))?;
 
-            // On the target binding, enable the WAN IPv4 and all
-            // public domains on the same gateway+port (no SNI without SSL).
+            // A public domain exposes the host as a whole, so enable it on every
+            // binding *and* every range — each is reachable via the domain on its
+            // own external port. For non-SSL rows there is no SNI, so the domain
+            // shares the bare WAN IP's packets; `enable_domain_on_addresses`
+            // force-enables that IP too, keeping the operator-facing toggle honest.
+            let ip_info = gateways.get(&gateway).and_then(|g| g.ip_info.as_deref());
             host.as_bindings_mut().mutate(|b| {
-                if let Some(bind) = b.get_mut(&internal_port) {
-                    let non_ssl_port = bind.addresses.available.iter().find_map(|a| {
-                        if a.ssl || !a.public || a.hostname != fqdn {
-                            return None;
-                        }
-                        if let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata {
-                            if *gw == gateway {
-                                return a.port;
-                            }
-                        }
-                        None
-                    });
-                    if let Some(dp) = non_ssl_port {
-                        for a in &bind.addresses.available {
-                            if a.ssl || !a.public {
-                                continue;
-                            }
-                            if let HostnameMetadata::Ipv4 { gateway: gw } = &a.metadata {
-                                if *gw == gateway {
-                                    if let Some(sa) = a.to_socket_addr() {
-                                        if sa.port() == dp {
-                                            bind.addresses.enabled.insert(sa);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        // No SNI without SSL, so the domain reaches v6 only via
-                        // the bare GUA — expose it like the WAN IPv4 above (v6 has
-                        // no NAT; the GUA is directly routable).
-                        if let Some(ip_info) =
-                            gateways.get(&gateway).and_then(|g| g.ip_info.as_ref())
-                        {
-                            for subnet in &ip_info.subnets {
-                                if let IpAddr::V6(ip) = subnet.addr() {
-                                    if !crate::net::utils::ipv6_is_local(ip) {
-                                        let gua = SocketAddrV6::new(ip, dp, 0, 0);
-                                        bind.addresses.gua_wan.insert(gua);
-                                        bind.addresses.enabled.insert(SocketAddr::V6(gua));
-                                    }
-                                }
-                            }
-                        }
-                        for a in &bind.addresses.available {
-                            if a.ssl {
-                                continue;
-                            }
-                            if let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata {
-                                if *gw == gateway && a.port == Some(dp) {
-                                    bind.addresses.disabled.remove(&(a.hostname.clone(), dp));
-                                }
-                            }
-                        }
-                    }
+                for bind in b.values_mut() {
+                    enable_domain_on_addresses(&mut bind.addresses, &fqdn, &gateway, ip_info);
                 }
-
-                // Disable the domain on all other bindings
-                for (&port, bind) in b.iter_mut() {
-                    if port == internal_port {
-                        continue;
-                    }
-                    let has_addr = bind
-                        .addresses
-                        .available
-                        .iter()
-                        .any(|a| a.public && a.hostname == fqdn);
-                    if has_addr {
-                        let other_ext = bind
-                            .addresses
-                            .available
-                            .iter()
-                            .find(|a| a.public && a.hostname == fqdn)
-                            .and_then(|a| a.port)
-                            .unwrap_or(ext_port);
-                        bind.addresses.disabled.insert((fqdn.clone(), other_ext));
-                    }
+                Ok(())
+            })?;
+            // Ranges are IPv4-only and non-SSL, so they never carry a v6 GUA.
+            host.as_binding_ranges_mut().mutate(|ranges| {
+                for range in ranges.values_mut() {
+                    enable_domain_on_addresses(&mut range.addresses, &fqdn, &gateway, None);
                 }
                 Ok(())
             })?;
@@ -524,4 +538,104 @@ pub async fn list_addresses<Kind: HostApiKind>(
         .de()?
         .addresses()
         .collect())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::net::service_interface::{HostnameInfo, HostnameMetadata};
+
+    const FQDN: &str = "turn.start9.dev";
+
+    fn gw() -> GatewayId {
+        GatewayId::from(InternedString::intern("wg1"))
+    }
+
+    fn domain(ssl: bool, port: u16) -> HostnameInfo {
+        HostnameInfo {
+            ssl,
+            public: true,
+            hostname: InternedString::intern(FQDN),
+            port: Some(port),
+            metadata: HostnameMetadata::PublicDomain { gateway: gw() },
+        }
+    }
+
+    fn wan_ip(ssl: bool, port: u16) -> HostnameInfo {
+        HostnameInfo {
+            ssl,
+            public: true,
+            hostname: InternedString::intern("64.23.194.12"),
+            port: Some(port),
+            metadata: HostnameMetadata::Ipv4 { gateway: gw() },
+        }
+    }
+
+    /// The core of the fix: enabling a non-SSL domain un-disables the domain row
+    /// and force-enables the bare WAN IP on the same port (no SNI on plain
+    /// ports). This is what makes a range's WAN toggle honest instead of lying.
+    #[test]
+    fn non_ssl_domain_exposes_and_reflects_the_wan_ip() {
+        let fqdn = InternedString::intern(FQDN);
+        let mut addrs = DerivedAddressInfo::default();
+        addrs.available.insert(domain(false, 42000));
+        addrs.available.insert(wan_ip(false, 42000));
+        // Pretend a prior "disable the domain on siblings" pass had turned it off.
+        addrs.disabled.insert((fqdn.clone(), 42000));
+
+        enable_domain_on_addresses(&mut addrs, &fqdn, &gw(), None);
+
+        assert!(
+            !addrs.disabled.contains(&(fqdn.clone(), 42000)),
+            "domain should be re-enabled (removed from `disabled`)"
+        );
+        assert!(
+            addrs.enabled.contains(&"64.23.194.12:42000".parse().unwrap()),
+            "bare WAN IP must be enabled so the toggle reflects the exposure"
+        );
+    }
+
+    /// An SSL binding carries its own SNI, so enabling its domain must NOT expose
+    /// the bare WAN IP — public IPs stay opt-in there.
+    #[test]
+    fn ssl_domain_does_not_expose_the_bare_ip() {
+        let fqdn = InternedString::intern(FQDN);
+        let mut addrs = DerivedAddressInfo::default();
+        addrs.available.insert(domain(true, 5349));
+        addrs.available.insert(wan_ip(true, 5349));
+
+        enable_domain_on_addresses(&mut addrs, &fqdn, &gw(), None);
+
+        assert!(
+            addrs.enabled.is_empty(),
+            "SSL row must not force-enable the bare WAN IP"
+        );
+    }
+
+    /// A binding unrelated to this domain/gateway is left untouched.
+    #[test]
+    fn unrelated_gateway_is_untouched() {
+        let fqdn = InternedString::intern(FQDN);
+        let other_gw = GatewayId::from(InternedString::intern("eth0"));
+        let mut addrs = DerivedAddressInfo::default();
+        addrs.available.insert(HostnameInfo {
+            metadata: HostnameMetadata::Ipv4 {
+                gateway: other_gw.clone(),
+            },
+            ..wan_ip(false, 42000)
+        });
+        addrs.available.insert(HostnameInfo {
+            metadata: HostnameMetadata::PublicDomain {
+                gateway: other_gw.clone(),
+            },
+            ..domain(false, 42000)
+        });
+
+        enable_domain_on_addresses(&mut addrs, &fqdn, &gw(), None);
+
+        assert!(
+            addrs.enabled.is_empty(),
+            "a domain on gateway wg1 must not enable an IP on gateway eth0"
+        );
+    }
 }

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -221,8 +221,6 @@ pub struct AddPublicDomainParams {
     pub acme: Option<AcmeProvider>,
     #[arg(help = "help.arg.gateway-id")]
     pub gateway: GatewayId,
-    #[arg(help = "help.arg.internal-port")]
-    pub internal_port: u16,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, TS)]
@@ -315,7 +313,6 @@ pub async fn add_public_domain<Kind: HostApiKind>(
         fqdn,
         acme,
         gateway,
-        internal_port,
     }: AddPublicDomainParams,
     inheritance: Kind::Inheritance,
 ) -> Result<AddPublicDomainRes, Error> {
@@ -355,18 +352,20 @@ pub async fn add_public_domain<Kind: HostApiKind>(
             let host = Kind::host_for(&inheritance, db)?;
             host.update_addresses(&hostname, &gateways, &available_ports)?;
 
-            // Find the external port for the target binding
+            // The domain exposes the whole host; pick a representative external
+            // port for the reachability check — its port on any public binding.
             let bindings = host.as_bindings().de()?;
-            let target_bind = bindings
-                .get(&internal_port)
-                .ok_or_else(|| Error::new(eyre!("binding not found for internal port {internal_port}"), ErrorKind::NotFound))?;
-            let ext_port = target_bind
-                .addresses
-                .available
-                .iter()
+            let ext_port = bindings
+                .values()
+                .flat_map(|b| b.addresses.available.iter())
                 .find(|a| a.public && a.hostname == fqdn)
                 .and_then(|a| a.port)
-                .ok_or_else(|| Error::new(eyre!("no public address found for {fqdn} on port {internal_port}"), ErrorKind::NotFound))?;
+                .ok_or_else(|| {
+                    Error::new(
+                        eyre!("no public address found for {fqdn}"),
+                        ErrorKind::NotFound,
+                    )
+                })?;
 
             // A public domain exposes the host as a whole, so enable it on every
             // binding *and* every range — each is reachable via the domain on its

--- a/shared-libs/ts-modules/start-core/lib/osBindings/AddPublicDomainParams.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/AddPublicDomainParams.ts
@@ -6,5 +6,4 @@ export type AddPublicDomainParams = {
   fqdn: string
   acme: AcmeProvider | null
   gateway: GatewayId
-  internalPort: number
 }


### PR DESCRIPTION
## Problem

Adding a public domain to a host is meant to expose that host as a unit — every binding and range reachable via the domain on its own external port. Instead, `add_public_domain` (`net/host/address.rs`):

- enabled the domain only on the **target** single-port binding,
- **disabled** it on every *other* single-port binding, and
- never touched **port ranges** at all.

Because domains are enabled-by-default (opt-out), a range's synthesized `PublicDomain` address stayed live, so any range on a host that had a domain was silently WAN-forwarded (the `mod.rs` range-forward loop) while the range's own WAN toggle read `disabled` — i.e. the toggle lied. Concretely: attaching `turn.start9.dev` to the coturn `turn` binding invisibly forwarded the 42000–42499 relay range.

## Fix

Replace the target-only enable + sibling-disable cleanup with a single helper, `enable_domain_on_addresses`, applied to **every binding and every range** on the host:

- clear the domain from `disabled` (domains are on-unless-disabled);
- for non-SSL rows — no SNI, so domain packets are indistinguishable from bare-IP packets — force-enable the matching WAN IPv4 and, on bindings, the IPv6 GUA;
- ranges pass `ip_info: None` (they are IPv4-only, non-SSL).

Standalone public-IP defaults are unchanged (still opt-in). The only behavioral change is the sibling/range handling on domain-add.

## Result

Adding a domain now exposes the host as a unit and reflects it honestly. For coturn, `turn.start9.dev` lights up `turn:` 3478, `turns:` 5349, and the relay range 42000–42499 together on a single host, with the range's WAN toggle showing enabled instead of lying.

## Tests

Added unit tests for `enable_domain_on_addresses`:
- non-SSL domain re-enables the domain and force-enables its bare WAN IP;
- SSL domain does **not** expose the bare IP (SNI);
- a domain on one gateway does not touch addresses on another.

`cargo test -p start-core net::host` → 30 passed. `cargo check -p start-core` clean.

## Known follow-up (not in this PR)

`remove_public_domain` does not tear down the force-enabled WAN IPs, so removing a domain leaves the host's bare WAN IPs enabled/forwarding. This was pre-existing (previously only the target binding); this PR extends it to all bindings/ranges. A symmetric teardown on remove — disable the WAN IPs on the removed domain's non-SSL port unless another domain still uses that gateway+port — is worth a follow-up.
