### PR TITLE
fix(net): reconcile public-domain exposure on sibling bindings and ranges

### DIFF
--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -259,14 +259,21 @@ fn reconcile_domain_on_sibling(
             disable.push(port);
             continue;
         }
-        // Non-SSL: honor an already-enabled co-located WAN IPv4 (same gateway +
-        // port) — without SNI it is the same packets as the bare IP.
+        // Non-SSL: honor an already-enabled co-located public WAN address on the
+        // same gateway + port — IPv4 or a WAN IPv6 GUA. Without SNI the domain
+        // and this bare IP are the same packets, so the two must stay in sync.
         let wan_enabled = addresses.available.iter().any(|b| {
             !b.ssl
                 && b.public
-                && matches!(&b.metadata, HostnameMetadata::Ipv4 { gateway: gw2 } if gw2 == gateway)
-                && b.to_socket_addr()
-                    .map_or(false, |sa| sa.port() == port && addresses.enabled.contains(&sa))
+                && matches!(
+                    &b.metadata,
+                    HostnameMetadata::Ipv4 { gateway: gw2 }
+                        | HostnameMetadata::Ipv6 { gateway: gw2, .. }
+                    if gw2 == gateway
+                )
+                && b.to_socket_addr().map_or(false, |sa| {
+                    sa.port() == port && addresses.enabled.contains(&sa)
+                })
         });
         if wan_enabled {
             enable.push(port);
@@ -307,6 +314,17 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                 }
             }
 
+            // Adding a domain that is already present is a no-op for exposure:
+            // we re-affirm the config below, but skip the target force-enable and
+            // the sibling/range reconcile so a re-add can't re-isolate a binding
+            // whose WAN IP the operator has since enabled, or clobber any other
+            // per-address choice. Enabling an existing domain on a binding is done
+            // through set-address-enabled, not by re-adding it.
+            let is_new = !Kind::host_for(&inheritance, db)?
+                .as_public_domains()
+                .keys()?
+                .contains(&fqdn);
+
             Kind::host_for(&inheritance, db)?
                 .as_public_domains_mut()
                 .insert(
@@ -328,7 +346,10 @@ pub async fn add_public_domain<Kind: HostApiKind>(
             let host = Kind::host_for(&inheritance, db)?;
             host.update_addresses(&hostname, &gateways, &available_ports)?;
 
-            // Find the external port for the target binding
+            // Find the external port for the target binding to health-check.
+            // Prefer the SSL (vhost) port over the plaintext one: a domain is
+            // normally reached over TLS, so that is the forward the operator
+            // wants validated.
             let bindings = host.as_bindings().de()?;
             let target_bind = bindings
                 .get(&internal_port)
@@ -337,92 +358,98 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                 .addresses
                 .available
                 .iter()
-                .find(|a| a.public && a.hostname == fqdn)
+                .filter(|a| a.public && a.hostname == fqdn)
+                .max_by_key(|a| a.ssl)
                 .and_then(|a| a.port)
                 .ok_or_else(|| Error::new(eyre!("no public address found for {fqdn} on port {internal_port}"), ErrorKind::NotFound))?;
 
-            // On the target binding, enable the WAN IPv4 and all
-            // public domains on the same gateway+port (no SNI without SSL).
-            host.as_bindings_mut().mutate(|b| {
-                if let Some(bind) = b.get_mut(&internal_port) {
-                    let non_ssl_port = bind.addresses.available.iter().find_map(|a| {
-                        if a.ssl || !a.public || a.hostname != fqdn {
-                            return None;
-                        }
-                        if let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata {
-                            if *gw == gateway {
-                                return a.port;
+            // A NEW domain gets force-enabled on its target binding and
+            // reconciled across the rest of the host; re-adding an existing one
+            // leaves every binding's/range's exposure exactly as it is.
+            if is_new {
+                // On the target binding, enable the WAN IPv4 and all
+                // public domains on the same gateway+port (no SNI without SSL).
+                host.as_bindings_mut().mutate(|b| {
+                    if let Some(bind) = b.get_mut(&internal_port) {
+                        let non_ssl_port = bind.addresses.available.iter().find_map(|a| {
+                            if a.ssl || !a.public || a.hostname != fqdn {
+                                return None;
                             }
-                        }
-                        None
-                    });
-                    if let Some(dp) = non_ssl_port {
-                        for a in &bind.addresses.available {
-                            if a.ssl || !a.public {
-                                continue;
-                            }
-                            if let HostnameMetadata::Ipv4 { gateway: gw } = &a.metadata {
+                            if let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata {
                                 if *gw == gateway {
-                                    if let Some(sa) = a.to_socket_addr() {
-                                        if sa.port() == dp {
-                                            bind.addresses.enabled.insert(sa);
+                                    return a.port;
+                                }
+                            }
+                            None
+                        });
+                        if let Some(dp) = non_ssl_port {
+                            for a in &bind.addresses.available {
+                                if a.ssl || !a.public {
+                                    continue;
+                                }
+                                if let HostnameMetadata::Ipv4 { gateway: gw } = &a.metadata {
+                                    if *gw == gateway {
+                                        if let Some(sa) = a.to_socket_addr() {
+                                            if sa.port() == dp {
+                                                bind.addresses.enabled.insert(sa);
+                                            }
                                         }
                                     }
                                 }
                             }
-                        }
-                        // No SNI without SSL, so the domain reaches v6 only via
-                        // the bare GUA — expose it like the WAN IPv4 above (v6 has
-                        // no NAT; the GUA is directly routable).
-                        if let Some(ip_info) =
-                            gateways.get(&gateway).and_then(|g| g.ip_info.as_ref())
-                        {
-                            for subnet in &ip_info.subnets {
-                                if let IpAddr::V6(ip) = subnet.addr() {
-                                    if !crate::net::utils::ipv6_is_local(ip) {
-                                        let gua = SocketAddrV6::new(ip, dp, 0, 0);
-                                        bind.addresses.gua_wan.insert(gua);
-                                        bind.addresses.enabled.insert(SocketAddr::V6(gua));
+                            // No SNI without SSL, so the domain reaches v6 only via
+                            // the bare GUA — expose it like the WAN IPv4 above (v6 has
+                            // no NAT; the GUA is directly routable).
+                            if let Some(ip_info) =
+                                gateways.get(&gateway).and_then(|g| g.ip_info.as_ref())
+                            {
+                                for subnet in &ip_info.subnets {
+                                    if let IpAddr::V6(ip) = subnet.addr() {
+                                        if !crate::net::utils::ipv6_is_local(ip) {
+                                            let gua = SocketAddrV6::new(ip, dp, 0, 0);
+                                            bind.addresses.gua_wan.insert(gua);
+                                            bind.addresses.enabled.insert(SocketAddr::V6(gua));
+                                        }
+                                    }
+                                }
+                            }
+                            for a in &bind.addresses.available {
+                                if a.ssl {
+                                    continue;
+                                }
+                                if let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata {
+                                    if *gw == gateway && a.port == Some(dp) {
+                                        bind.addresses.disabled.remove(&(a.hostname.clone(), dp));
                                     }
                                 }
                             }
                         }
-                        for a in &bind.addresses.available {
-                            if a.ssl {
-                                continue;
-                            }
-                            if let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata {
-                                if *gw == gateway && a.port == Some(dp) {
-                                    bind.addresses.disabled.remove(&(a.hostname.clone(), dp));
-                                }
-                            }
+                    }
+
+                    // Every other binding: isolate the domain by default, but honor
+                    // an already-enabled non-SSL WAN IP by enabling the domain there
+                    // to match (no SNI — the same packets as the bare IP).
+                    for (&port, bind) in b.iter_mut() {
+                        if port == internal_port {
+                            continue;
                         }
+                        reconcile_domain_on_sibling(&mut bind.addresses, &fqdn, &gateway);
                     }
-                }
+                    Ok(())
+                })?;
 
-                // Every other binding: isolate the domain by default, but honor
-                // an already-enabled non-SSL WAN IP by enabling the domain there
-                // to match (no SNI — the same packets as the bare IP).
-                for (&port, bind) in b.iter_mut() {
-                    if port == internal_port {
-                        continue;
+                // Same reconciliation for every port range (parity with the sibling
+                // bindings above). Ranges are IPv4-only and non-SSL, so a domain is
+                // disabled on a range unless the range's own WAN IP is already
+                // enabled — in which case the domain is enabled to match, since
+                // without SNI it is reachable via that same forward anyway.
+                host.as_binding_ranges_mut().mutate(|ranges| {
+                    for range in ranges.values_mut() {
+                        reconcile_domain_on_sibling(&mut range.addresses, &fqdn, &gateway);
                     }
-                    reconcile_domain_on_sibling(&mut bind.addresses, &fqdn, &gateway);
-                }
-                Ok(())
-            })?;
-
-            // Same reconciliation for every port range (parity with the sibling
-            // bindings above). Ranges are IPv4-only and non-SSL, so a domain is
-            // disabled on a range unless the range's own WAN IP is already
-            // enabled — in which case the domain is enabled to match, since
-            // without SNI it is reachable via that same forward anyway.
-            host.as_binding_ranges_mut().mutate(|ranges| {
-                for range in ranges.values_mut() {
-                    reconcile_domain_on_sibling(&mut range.addresses, &fqdn, &gateway);
-                }
-                Ok(())
-            })?;
+                    Ok(())
+                })?;
+            }
 
             // Re-project: the gua_wan change above must flow into the GUA's
             // HostnameInfo.public so it is treated as WAN-exposed.
@@ -611,6 +638,20 @@ mod test {
         }
     }
 
+    // A WAN-exposed IPv6 GUA (public=true, projected from gua_wan).
+    fn gua(port: u16, gateway: &str) -> HostnameInfo {
+        HostnameInfo {
+            ssl: false,
+            public: true,
+            hostname: InternedString::intern("2001:db8::1"),
+            port: Some(port),
+            metadata: HostnameMetadata::Ipv6 {
+                gateway: gw(gateway),
+                scope_id: 0,
+            },
+        }
+    }
+
     fn domain_disabled(a: &DerivedAddressInfo, port: u16) -> bool {
         a.disabled.contains(&(InternedString::intern(FQDN), port))
     }
@@ -634,6 +675,24 @@ mod test {
         );
     }
 
+    /// The domain must equally follow an enabled WAN IPv6 GUA (no SNI over v6
+    /// either), not just an enabled IPv4 WAN address.
+    #[test]
+    fn non_ssl_domain_follows_enabled_gua() {
+        let fqdn = InternedString::intern(FQDN);
+        let mut a = DerivedAddressInfo::default();
+        a.available.insert(domain(false, 42000, "wg1"));
+        a.available.insert(gua(42000, "wg1"));
+        a.enabled.insert("[2001:db8::1]:42000".parse().unwrap());
+
+        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+
+        assert!(
+            !domain_disabled(&a, 42000),
+            "domain must be enabled to match the already-enabled public GUA"
+        );
+    }
+
     /// Default isolate behavior: WAN IP not enabled -> domain disabled.
     #[test]
     fn non_ssl_domain_disabled_when_wan_ip_off() {
@@ -644,7 +703,10 @@ mod test {
 
         reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
 
-        assert!(domain_disabled(&a, 42000), "domain must be isolated by default");
+        assert!(
+            domain_disabled(&a, 42000),
+            "domain must be isolated by default"
+        );
     }
 
     /// SSL rows have their own SNI, so they are always isolated regardless of IP.

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -18,7 +18,7 @@ use crate::net::gateway::{
     check_port_v6,
 };
 use crate::net::host::binding::{DerivedAddressInfo, set_nonssl_wan_group};
-use crate::net::host::{HostApiKind, all_hosts};
+use crate::net::host::{Host, HostApiKind, all_hosts};
 use crate::net::service_interface::HostnameMetadata;
 use crate::prelude::*;
 use crate::util::serde::{HandlerExtSerde, display_serializable};
@@ -283,6 +283,60 @@ fn reconcile_domain_on_sibling(
                 })
         });
         set_nonssl_wan_group(addresses, gateway, port, wan_enabled);
+    }
+}
+
+impl Model<Host> {
+    /// The host's public domains as `(fqdn, gateway)` pairs.
+    fn domain_gateways(&self) -> Result<Vec<(InternedString, GatewayId)>, Error> {
+        Ok(self
+            .as_public_domains()
+            .de()?
+            .into_iter()
+            .map(|(fqdn, cfg)| (fqdn, cfg.gateway))
+            .collect())
+    }
+
+    /// Reconcile a newly-bound single-port binding against the host's existing
+    /// public domains — a domain added earlier must not silently leak onto a
+    /// binding added afterwards. A fresh binding is always a sibling (never a
+    /// domain's target), so this isolates each domain unless the binding's own
+    /// WAN address is already enabled. Call after `update_addresses` has
+    /// synthesized the domain rows, then re-run `update_addresses` so the port
+    /// forwards reflect the isolation. Only run for a genuinely new binding —
+    /// re-running it on a re-bind would clobber a domain's target binding.
+    pub fn reconcile_domains_on_new_binding(&mut self, internal_port: u16) -> Result<(), Error> {
+        let domains = self.domain_gateways()?;
+        if domains.is_empty() {
+            return Ok(());
+        }
+        self.as_bindings_mut().mutate(|b| {
+            if let Some(bind) = b.get_mut(&internal_port) {
+                for (fqdn, gateway) in &domains {
+                    reconcile_domain_on_sibling(&mut bind.addresses, fqdn, gateway);
+                }
+            }
+            Ok(())
+        })
+    }
+
+    /// Range counterpart of [`Self::reconcile_domains_on_new_binding`].
+    pub fn reconcile_domains_on_new_range(
+        &mut self,
+        internal_start_port: u16,
+    ) -> Result<(), Error> {
+        let domains = self.domain_gateways()?;
+        if domains.is_empty() {
+            return Ok(());
+        }
+        self.as_binding_ranges_mut().mutate(|ranges| {
+            if let Some(range) = ranges.get_mut(&internal_start_port) {
+                for (fqdn, gateway) in &domains {
+                    reconcile_domain_on_sibling(&mut range.addresses, fqdn, gateway);
+                }
+            }
+            Ok(())
+        })
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -17,7 +17,7 @@ use crate::net::gateway::{
     CheckDnsParams, CheckPortParams, CheckPortRes, CheckPortV6Res, check_dns, check_port,
     check_port_v6,
 };
-use crate::net::host::binding::DerivedAddressInfo;
+use crate::net::host::binding::{DerivedAddressInfo, set_nonssl_wan_group};
 use crate::net::host::{HostApiKind, all_hosts};
 use crate::net::service_interface::HostnameMetadata;
 use crate::prelude::*;
@@ -235,18 +235,19 @@ pub struct AddPublicDomainRes {
 
 /// Reconcile a public domain on a *sibling* binding or range — one the domain
 /// was not directly added to. A public domain is scoped to its target binding,
-/// so by default it is disabled here (kept off the sibling). The exception is
-/// the non-SSL case: with no SNI, a non-SSL domain shares the bare WAN IP's
-/// packets, so if the co-located WAN IPv4 (same gateway + port) is already
-/// enabled on this sibling we honor that and enable the domain to match, keeping
-/// the two in lockstep. SSL rows carry their own SNI and are always isolated.
+/// so by default it is isolated here. The exception is the non-SSL case: with no
+/// SNI, the domain shares the bare WAN IP's packets, so if a co-located public
+/// WAN address (IPv4 or a WAN IPv6 GUA, same gateway + port) is already enabled
+/// we honor it and move the whole {domain, IPv4, GUA} group on together — a
+/// dual-stack domain links the v4 and v6 sides. SSL rows carry their own SNI and
+/// are always isolated.
 fn reconcile_domain_on_sibling(
     addresses: &mut DerivedAddressInfo,
     fqdn: &InternedString,
     gateway: &GatewayId,
 ) {
-    let mut enable = Vec::new();
-    let mut disable = Vec::new();
+    let mut ssl_ports = Vec::new();
+    let mut nonssl_ports = Vec::new();
     for a in &addresses.available {
         let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata else {
             continue;
@@ -256,12 +257,18 @@ fn reconcile_domain_on_sibling(
         }
         let Some(port) = a.port else { continue };
         if a.ssl {
-            disable.push(port);
-            continue;
+            ssl_ports.push(port);
+        } else if !nonssl_ports.contains(&port) {
+            nonssl_ports.push(port);
         }
-        // Non-SSL: honor an already-enabled co-located public WAN address on the
-        // same gateway + port — IPv4 or a WAN IPv6 GUA. Without SNI the domain
-        // and this bare IP are the same packets, so the two must stay in sync.
+    }
+    // SSL rows are isolated to the target (SNI distinguishes them from the IP).
+    for port in ssl_ports {
+        addresses.disabled.insert((fqdn.clone(), port));
+    }
+    // Non-SSL: honor an already-enabled co-located WAN address (IPv4 or GUA) and
+    // move the whole {domain, IPv4, GUA} group to match; otherwise isolate it.
+    for port in nonssl_ports {
         let wan_enabled = addresses.available.iter().any(|b| {
             !b.ssl
                 && b.public
@@ -275,17 +282,7 @@ fn reconcile_domain_on_sibling(
                     sa.port() == port && addresses.enabled.contains(&sa)
                 })
         });
-        if wan_enabled {
-            enable.push(port);
-        } else {
-            disable.push(port);
-        }
-    }
-    for port in enable {
-        addresses.disabled.remove(&(fqdn.clone(), port));
-    }
-    for port in disable {
-        addresses.disabled.insert((fqdn.clone(), port));
+        set_nonssl_wan_group(addresses, gateway, port, wan_enabled);
     }
 }
 
@@ -691,6 +688,32 @@ mod test {
             !domain_disabled(&a, 42000),
             "domain must be enabled to match the already-enabled public GUA"
         );
+    }
+
+    /// Transitive dual-stack link: enabling the WAN IPv4 on a non-SSL sibling
+    /// that has a domain also publishes the co-located GUA (the domain is
+    /// dual-stack, so v4 and v6 must move together).
+    #[test]
+    fn enabling_v4_with_domain_publishes_gua() {
+        let fqdn = InternedString::intern(FQDN);
+        let mut a = DerivedAddressInfo::default();
+        a.available.insert(domain(false, 42000, "wg1"));
+        a.available.insert(wan_ip(42000, "wg1"));
+        a.available.insert(gua(42000, "wg1")); // GUA present, not yet published
+        a.enabled.insert("64.23.194.12:42000".parse().unwrap()); // only v4 enabled
+
+        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+
+        let gua_v6: std::net::SocketAddrV6 = "[2001:db8::1]:42000".parse().unwrap();
+        assert!(
+            a.gua_wan.contains(&gua_v6),
+            "the GUA must be published to WAN (gua_wan) when v4 + a domain are on"
+        );
+        assert!(
+            a.enabled.contains(&"[2001:db8::1]:42000".parse().unwrap()),
+            "the GUA must be enabled"
+        );
+        assert!(!domain_disabled(&a, 42000), "domain enabled");
     }
 
     /// Default isolate behavior: WAN IP not enabled -> domain disabled.

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -17,7 +17,7 @@ use crate::net::gateway::{
     CheckDnsParams, CheckPortParams, CheckPortRes, CheckPortV6Res, check_dns, check_port,
     check_port_v6,
 };
-use crate::net::host::binding::{DerivedAddressInfo, set_nonssl_wan_group};
+use crate::net::host::binding::{DerivedAddressInfo, set_nonssl_lan_group, set_nonssl_wan_group};
 use crate::net::host::{Host, HostApiKind, all_hosts};
 use crate::net::service_interface::HostnameMetadata;
 use crate::prelude::*;
@@ -283,6 +283,45 @@ fn reconcile_public_domain_on_sibling(
                 })
         });
         set_nonssl_wan_group(addresses, gateway, port, wan_enabled);
+    }
+}
+
+/// Reconcile a private domain on a binding or range. Unlike a public domain, a
+/// private domain stays on by default — LAN is trusted, so it is not isolated.
+/// The exception: if the binding's own bare LAN IPv4 at this gateway+port has
+/// been disabled, honor that and take the whole {private domain, LAN IPv4,
+/// GUA-as-local} group down too. SSL private domains carry their own SNI and are
+/// left on.
+fn reconcile_private_domain_on_sibling(
+    addresses: &mut DerivedAddressInfo,
+    fqdn: &InternedString,
+    gateway: &GatewayId,
+) {
+    let mut nonssl_ports = Vec::new();
+    for a in &addresses.available {
+        if a.ssl || &a.hostname != fqdn {
+            continue;
+        }
+        let HostnameMetadata::PrivateDomain { gateways } = &a.metadata else {
+            continue;
+        };
+        if !gateways.contains(gateway) {
+            continue;
+        }
+        let Some(port) = a.port else { continue };
+        if !nonssl_ports.contains(&port) {
+            nonssl_ports.push(port);
+        }
+    }
+    for port in nonssl_ports {
+        // On unless the bare LAN IPv4 at this gateway+port is explicitly disabled.
+        let lan_disabled = addresses.available.iter().any(|b| {
+            !b.ssl
+                && b.port == Some(port)
+                && matches!(&b.metadata, HostnameMetadata::Ipv4 { gateway: gw2 } if !b.public && gw2 == gateway)
+                && addresses.disabled.contains(&(b.hostname.clone(), port))
+        });
+        set_nonssl_lan_group(addresses, gateway, port, !lan_disabled);
     }
 }
 
@@ -599,6 +638,11 @@ pub async fn add_private_domain<Kind: HostApiKind>(
 ) -> Result<bool, Error> {
     ctx.db
         .mutate(|db| {
+            let is_new = !Kind::host_for(&inheritance, db)?
+                .as_private_domains()
+                .de()?
+                .get(&fqdn)
+                .is_some_and(|gws| gws.contains(&gateway));
             Kind::host_for(&inheritance, db)?
                 .as_private_domains_mut()
                 .upsert(&fqdn, || Ok(BTreeSet::new()))?
@@ -612,7 +656,28 @@ pub async fn add_private_domain<Kind: HostApiKind>(
                 .as_gateways()
                 .de()?;
             let ports = db.as_private().as_available_ports().de()?;
-            Kind::host_for(&inheritance, db)?.update_addresses(&hostname, &gateways, &ports)
+            let host = Kind::host_for(&inheritance, db)?;
+            host.update_addresses(&hostname, &gateways, &ports)?;
+            // A private domain stays on by default, but honor it across the host:
+            // on every binding and range, take the private domain (and its LAN
+            // group) down where the operator has disabled that binding's private
+            // addresses. Only for a newly-added domain, so a re-add can't clobber.
+            if is_new {
+                host.as_bindings_mut().mutate(|b| {
+                    for bind in b.values_mut() {
+                        reconcile_private_domain_on_sibling(&mut bind.addresses, &fqdn, &gateway);
+                    }
+                    Ok(())
+                })?;
+                host.as_binding_ranges_mut().mutate(|ranges| {
+                    for range in ranges.values_mut() {
+                        reconcile_private_domain_on_sibling(&mut range.addresses, &fqdn, &gateway);
+                    }
+                    Ok(())
+                })?;
+                Kind::host_for(&inheritance, db)?.update_addresses(&hostname, &gateways, &ports)?;
+            }
+            Ok(())
         })
         .await
         .result?;
@@ -817,6 +882,45 @@ mod test {
         assert!(
             domain_disabled(&a, 42000),
             "an enabled IP on a different gateway must not honor the domain"
+        );
+    }
+
+    #[test]
+    fn private_domain_stays_on_but_honors_disabled_lan() {
+        let fqdn = InternedString::intern("priv.local");
+        let mut a = DerivedAddressInfo::default();
+        a.available.insert(HostnameInfo {
+            ssl: false,
+            public: false,
+            hostname: fqdn.clone(),
+            port: Some(42000),
+            metadata: HostnameMetadata::PrivateDomain {
+                gateways: BTreeSet::from([gw("wg1")]),
+            },
+        });
+        a.available.insert(HostnameInfo {
+            ssl: false,
+            public: false,
+            hostname: InternedString::intern("10.0.0.5"),
+            port: Some(42000),
+            metadata: HostnameMetadata::Ipv4 { gateway: gw("wg1") },
+        });
+        let priv_key = (fqdn.clone(), 42000u16);
+
+        // Default: the bare LAN IPv4 is on, so the private domain stays ON.
+        reconcile_private_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+        assert!(
+            !a.disabled.contains(&priv_key),
+            "a private domain is on by default (LAN is not isolated)"
+        );
+
+        // Operator disables the bare LAN IPv4 -> the private domain is honored off.
+        a.disabled
+            .insert((InternedString::intern("10.0.0.5"), 42000));
+        reconcile_private_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+        assert!(
+            a.disabled.contains(&priv_key),
+            "a disabled LAN IPv4 takes the private domain down too"
         );
     }
 }

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -17,6 +17,7 @@ use crate::net::gateway::{
     CheckDnsParams, CheckPortParams, CheckPortRes, CheckPortV6Res, check_dns, check_port,
     check_port_v6,
 };
+use crate::net::host::binding::DerivedAddressInfo;
 use crate::net::host::{HostApiKind, all_hosts};
 use crate::net::service_interface::HostnameMetadata;
 use crate::prelude::*;
@@ -232,6 +233,55 @@ pub struct AddPublicDomainRes {
     pub port_v6: Option<CheckPortV6Res>,
 }
 
+/// Reconcile a public domain on a *sibling* binding or range — one the domain
+/// was not directly added to. A public domain is scoped to its target binding,
+/// so by default it is disabled here (kept off the sibling). The exception is
+/// the non-SSL case: with no SNI, a non-SSL domain shares the bare WAN IP's
+/// packets, so if the co-located WAN IPv4 (same gateway + port) is already
+/// enabled on this sibling we honor that and enable the domain to match, keeping
+/// the two in lockstep. SSL rows carry their own SNI and are always isolated.
+fn reconcile_domain_on_sibling(
+    addresses: &mut DerivedAddressInfo,
+    fqdn: &InternedString,
+    gateway: &GatewayId,
+) {
+    let mut enable = Vec::new();
+    let mut disable = Vec::new();
+    for a in &addresses.available {
+        let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata else {
+            continue;
+        };
+        if gw != gateway || !a.public || &a.hostname != fqdn {
+            continue;
+        }
+        let Some(port) = a.port else { continue };
+        if a.ssl {
+            disable.push(port);
+            continue;
+        }
+        // Non-SSL: honor an already-enabled co-located WAN IPv4 (same gateway +
+        // port) — without SNI it is the same packets as the bare IP.
+        let wan_enabled = addresses.available.iter().any(|b| {
+            !b.ssl
+                && b.public
+                && matches!(&b.metadata, HostnameMetadata::Ipv4 { gateway: gw2 } if gw2 == gateway)
+                && b.to_socket_addr()
+                    .map_or(false, |sa| sa.port() == port && addresses.enabled.contains(&sa))
+        });
+        if wan_enabled {
+            enable.push(port);
+        } else {
+            disable.push(port);
+        }
+    }
+    for port in enable {
+        addresses.disabled.remove(&(fqdn.clone(), port));
+    }
+    for port in disable {
+        addresses.disabled.insert((fqdn.clone(), port));
+    }
+}
+
 pub async fn add_public_domain<Kind: HostApiKind>(
     ctx: RpcContext,
     AddPublicDomainParams {
@@ -350,53 +400,26 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                     }
                 }
 
-                // Disable the domain on all other bindings
+                // Every other binding: isolate the domain by default, but honor
+                // an already-enabled non-SSL WAN IP by enabling the domain there
+                // to match (no SNI — the same packets as the bare IP).
                 for (&port, bind) in b.iter_mut() {
                     if port == internal_port {
                         continue;
                     }
-                    let has_addr = bind
-                        .addresses
-                        .available
-                        .iter()
-                        .any(|a| a.public && a.hostname == fqdn);
-                    if has_addr {
-                        let other_ext = bind
-                            .addresses
-                            .available
-                            .iter()
-                            .find(|a| a.public && a.hostname == fqdn)
-                            .and_then(|a| a.port)
-                            .unwrap_or(ext_port);
-                        bind.addresses.disabled.insert((fqdn.clone(), other_ext));
-                    }
+                    reconcile_domain_on_sibling(&mut bind.addresses, &fqdn, &gateway);
                 }
                 Ok(())
             })?;
 
-            // Parity with the sibling-binding cleanup above: a public domain
-            // targets one binding, so it must also stay disabled on every port
-            // range on the same host. Ranges are otherwise enabled-by-default
-            // (like domains), which would silently forward the whole range;
-            // instead a range is WAN-exposed only when the operator enables the
-            // range's own public address via set-range-address-enabled.
+            // Same reconciliation for every port range (parity with the sibling
+            // bindings above). Ranges are IPv4-only and non-SSL, so a domain is
+            // disabled on a range unless the range's own WAN IP is already
+            // enabled — in which case the domain is enabled to match, since
+            // without SNI it is reachable via that same forward anyway.
             host.as_binding_ranges_mut().mutate(|ranges| {
                 for range in ranges.values_mut() {
-                    let has_addr = range
-                        .addresses
-                        .available
-                        .iter()
-                        .any(|a| a.public && a.hostname == fqdn);
-                    if has_addr {
-                        let ext = range
-                            .addresses
-                            .available
-                            .iter()
-                            .find(|a| a.public && a.hostname == fqdn)
-                            .and_then(|a| a.port)
-                            .unwrap_or(range.external_start_port);
-                        range.addresses.disabled.insert((fqdn.clone(), ext));
-                    }
+                    reconcile_domain_on_sibling(&mut range.addresses, &fqdn, &gateway);
                 }
                 Ok(())
             })?;
@@ -551,4 +574,107 @@ pub async fn list_addresses<Kind: HostApiKind>(
         .de()?
         .addresses()
         .collect())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::net::service_interface::{HostnameInfo, HostnameMetadata};
+
+    const FQDN: &str = "turn.start9.dev";
+
+    fn gw(name: &str) -> GatewayId {
+        GatewayId::from(InternedString::intern(name))
+    }
+
+    fn domain(ssl: bool, port: u16, gateway: &str) -> HostnameInfo {
+        HostnameInfo {
+            ssl,
+            public: true,
+            hostname: InternedString::intern(FQDN),
+            port: Some(port),
+            metadata: HostnameMetadata::PublicDomain {
+                gateway: gw(gateway),
+            },
+        }
+    }
+
+    fn wan_ip(port: u16, gateway: &str) -> HostnameInfo {
+        HostnameInfo {
+            ssl: false,
+            public: true,
+            hostname: InternedString::intern("64.23.194.12"),
+            port: Some(port),
+            metadata: HostnameMetadata::Ipv4 {
+                gateway: gw(gateway),
+            },
+        }
+    }
+
+    fn domain_disabled(a: &DerivedAddressInfo, port: u16) -> bool {
+        a.disabled.contains(&(InternedString::intern(FQDN), port))
+    }
+
+    /// The edge case that motivated this: a sibling whose non-SSL WAN IP is
+    /// already enabled must keep the domain ENABLED (in lockstep), not disable
+    /// it — otherwise the domain reads "disabled" while still reachable.
+    #[test]
+    fn non_ssl_domain_follows_enabled_wan_ip() {
+        let fqdn = InternedString::intern(FQDN);
+        let mut a = DerivedAddressInfo::default();
+        a.available.insert(domain(false, 42000, "wg1"));
+        a.available.insert(wan_ip(42000, "wg1"));
+        a.enabled.insert("64.23.194.12:42000".parse().unwrap());
+
+        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+
+        assert!(
+            !domain_disabled(&a, 42000),
+            "domain must be enabled to match the already-enabled WAN IP"
+        );
+    }
+
+    /// Default isolate behavior: WAN IP not enabled -> domain disabled.
+    #[test]
+    fn non_ssl_domain_disabled_when_wan_ip_off() {
+        let fqdn = InternedString::intern(FQDN);
+        let mut a = DerivedAddressInfo::default();
+        a.available.insert(domain(false, 42000, "wg1"));
+        a.available.insert(wan_ip(42000, "wg1"));
+
+        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+
+        assert!(domain_disabled(&a, 42000), "domain must be isolated by default");
+    }
+
+    /// SSL rows have their own SNI, so they are always isolated regardless of IP.
+    #[test]
+    fn ssl_domain_is_always_isolated() {
+        let fqdn = InternedString::intern(FQDN);
+        let mut a = DerivedAddressInfo::default();
+        a.available.insert(domain(true, 5349, "wg1"));
+        a.available.insert(wan_ip(5349, "wg1"));
+        a.enabled.insert("64.23.194.12:5349".parse().unwrap());
+
+        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+
+        assert!(domain_disabled(&a, 5349), "SSL domain must stay isolated");
+    }
+
+    /// An enabled WAN IP on a *different* gateway must not enable the domain.
+    #[test]
+    fn enabled_wan_ip_on_other_gateway_is_not_honored() {
+        let fqdn = InternedString::intern(FQDN);
+        let mut a = DerivedAddressInfo::default();
+        a.available.insert(domain(false, 42000, "wg1"));
+        a.available.insert(wan_ip(42000, "eth0"));
+        a.enabled.insert("64.23.194.12:42000".parse().unwrap());
+
+        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+
+        assert!(
+            domain_disabled(&a, 42000),
+            "an enabled IP on a different gateway must not honor the domain"
+        );
+    }
 }

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -241,7 +241,7 @@ pub struct AddPublicDomainRes {
 /// we honor it and move the whole {domain, IPv4, GUA} group on together — a
 /// dual-stack domain links the v4 and v6 sides. SSL rows carry their own SNI and
 /// are always isolated.
-fn reconcile_domain_on_sibling(
+fn reconcile_public_domain_on_sibling(
     addresses: &mut DerivedAddressInfo,
     fqdn: &InternedString,
     gateway: &GatewayId,
@@ -288,7 +288,7 @@ fn reconcile_domain_on_sibling(
 
 impl Model<Host> {
     /// The host's public domains as `(fqdn, gateway)` pairs.
-    fn domain_gateways(&self) -> Result<Vec<(InternedString, GatewayId)>, Error> {
+    fn public_domain_gateways(&self) -> Result<Vec<(InternedString, GatewayId)>, Error> {
         Ok(self
             .as_public_domains()
             .de()?
@@ -305,34 +305,37 @@ impl Model<Host> {
     /// synthesized the domain rows, then re-run `update_addresses` so the port
     /// forwards reflect the isolation. Only run for a genuinely new binding —
     /// re-running it on a re-bind would clobber a domain's target binding.
-    pub fn reconcile_domains_on_new_binding(&mut self, internal_port: u16) -> Result<(), Error> {
-        let domains = self.domain_gateways()?;
-        if domains.is_empty() {
+    pub fn reconcile_public_domains_on_new_binding(
+        &mut self,
+        internal_port: u16,
+    ) -> Result<(), Error> {
+        let public_domains = self.public_domain_gateways()?;
+        if public_domains.is_empty() {
             return Ok(());
         }
         self.as_bindings_mut().mutate(|b| {
             if let Some(bind) = b.get_mut(&internal_port) {
-                for (fqdn, gateway) in &domains {
-                    reconcile_domain_on_sibling(&mut bind.addresses, fqdn, gateway);
+                for (fqdn, gateway) in &public_domains {
+                    reconcile_public_domain_on_sibling(&mut bind.addresses, fqdn, gateway);
                 }
             }
             Ok(())
         })
     }
 
-    /// Range counterpart of [`Self::reconcile_domains_on_new_binding`].
-    pub fn reconcile_domains_on_new_range(
+    /// Range counterpart of [`Self::reconcile_public_domains_on_new_binding`].
+    pub fn reconcile_public_domains_on_new_range(
         &mut self,
         internal_start_port: u16,
     ) -> Result<(), Error> {
-        let domains = self.domain_gateways()?;
-        if domains.is_empty() {
+        let public_domains = self.public_domain_gateways()?;
+        if public_domains.is_empty() {
             return Ok(());
         }
         self.as_binding_ranges_mut().mutate(|ranges| {
             if let Some(range) = ranges.get_mut(&internal_start_port) {
-                for (fqdn, gateway) in &domains {
-                    reconcile_domain_on_sibling(&mut range.addresses, fqdn, gateway);
+                for (fqdn, gateway) in &public_domains {
+                    reconcile_public_domain_on_sibling(&mut range.addresses, fqdn, gateway);
                 }
             }
             Ok(())
@@ -484,7 +487,7 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                         if port == internal_port {
                             continue;
                         }
-                        reconcile_domain_on_sibling(&mut bind.addresses, &fqdn, &gateway);
+                        reconcile_public_domain_on_sibling(&mut bind.addresses, &fqdn, &gateway);
                     }
                     Ok(())
                 })?;
@@ -496,7 +499,7 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                 // without SNI it is reachable via that same forward anyway.
                 host.as_binding_ranges_mut().mutate(|ranges| {
                     for range in ranges.values_mut() {
-                        reconcile_domain_on_sibling(&mut range.addresses, &fqdn, &gateway);
+                        reconcile_public_domain_on_sibling(&mut range.addresses, &fqdn, &gateway);
                     }
                     Ok(())
                 })?;
@@ -718,7 +721,7 @@ mod test {
         a.available.insert(wan_ip(42000, "wg1"));
         a.enabled.insert("64.23.194.12:42000".parse().unwrap());
 
-        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+        reconcile_public_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
 
         assert!(
             !domain_disabled(&a, 42000),
@@ -736,7 +739,7 @@ mod test {
         a.available.insert(gua(42000, "wg1"));
         a.enabled.insert("[2001:db8::1]:42000".parse().unwrap());
 
-        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+        reconcile_public_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
 
         assert!(
             !domain_disabled(&a, 42000),
@@ -756,7 +759,7 @@ mod test {
         a.available.insert(gua(42000, "wg1")); // GUA present, not yet published
         a.enabled.insert("64.23.194.12:42000".parse().unwrap()); // only v4 enabled
 
-        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+        reconcile_public_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
 
         let gua_v6: std::net::SocketAddrV6 = "[2001:db8::1]:42000".parse().unwrap();
         assert!(
@@ -778,7 +781,7 @@ mod test {
         a.available.insert(domain(false, 42000, "wg1"));
         a.available.insert(wan_ip(42000, "wg1"));
 
-        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+        reconcile_public_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
 
         assert!(
             domain_disabled(&a, 42000),
@@ -795,7 +798,7 @@ mod test {
         a.available.insert(wan_ip(5349, "wg1"));
         a.enabled.insert("64.23.194.12:5349".parse().unwrap());
 
-        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+        reconcile_public_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
 
         assert!(domain_disabled(&a, 5349), "SSL domain must stay isolated");
     }
@@ -809,7 +812,7 @@ mod test {
         a.available.insert(wan_ip(42000, "eth0"));
         a.enabled.insert("64.23.194.12:42000".parse().unwrap());
 
-        reconcile_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
+        reconcile_public_domain_on_sibling(&mut a, &fqdn, &gw("wg1"));
 
         assert!(
             domain_disabled(&a, 42000),

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -374,6 +374,33 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                 Ok(())
             })?;
 
+            // Parity with the sibling-binding cleanup above: a public domain
+            // targets one binding, so it must also stay disabled on every port
+            // range on the same host. Ranges are otherwise enabled-by-default
+            // (like domains), which would silently forward the whole range;
+            // instead a range is WAN-exposed only when the operator enables the
+            // range's own public address via set-range-address-enabled.
+            host.as_binding_ranges_mut().mutate(|ranges| {
+                for range in ranges.values_mut() {
+                    let has_addr = range
+                        .addresses
+                        .available
+                        .iter()
+                        .any(|a| a.public && a.hostname == fqdn);
+                    if has_addr {
+                        let ext = range
+                            .addresses
+                            .available
+                            .iter()
+                            .find(|a| a.public && a.hostname == fqdn)
+                            .and_then(|a| a.port)
+                            .unwrap_or(range.external_start_port);
+                        range.addresses.disabled.insert((fqdn.clone(), ext));
+                    }
+                }
+                Ok(())
+            })?;
+
             // Re-project: the gua_wan change above must flow into the GUA's
             // HostnameInfo.public so it is treated as WAN-exposed.
             Kind::host_for(&inheritance, db)?

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -20,7 +20,7 @@ use crate::net::vhost::AlpnInfo;
 use crate::prelude::*;
 use crate::util::FromStrParser;
 use crate::util::serde::{CliFromJsonString, HandlerExtSerde, display_serializable};
-use crate::{HostId, ServiceInterfaceId};
+use crate::{GatewayId, HostId, ServiceInterfaceId};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, TS)]
 #[ts(export)]
@@ -541,10 +541,88 @@ pub struct BindingSetAddressEnabledParams {
     enabled: Option<bool>,
 }
 
+/// Is there a non-SSL public domain at this `gateway` + `port`? A public domain
+/// is what links the WAN IPv4 and IPv6 GUA at a non-SSL port (see
+/// [`set_nonssl_wan_group`]); without one they toggle independently.
+pub(crate) fn has_nonssl_domain(
+    addresses: &DerivedAddressInfo,
+    gateway: &GatewayId,
+    port: u16,
+) -> bool {
+    addresses.available.iter().any(|a| {
+        !a.ssl
+            && a.port == Some(port)
+            && matches!(&a.metadata, HostnameMetadata::PublicDomain { gateway: gw } if gw == gateway)
+    })
+}
+
+/// Set the whole non-SSL WAN group at `gateway` + `port` — the public domain(s),
+/// the bare WAN IPv4, and the WAN IPv6 GUA — to `enabled` together. On a non-SSL
+/// port there is no SNI, so all three share the same packets, and a public domain
+/// is assumed dual-stack, so it ties the v4 and v6 sides. They must move as one:
+/// enabling the IPv4 (or the domain) publishes the GUA, and vice versa. Callers
+/// gate this on a domain being present ([`has_nonssl_domain`]) — without one the
+/// v4 and GUA are independent.
+pub(crate) fn set_nonssl_wan_group(
+    addresses: &mut DerivedAddressInfo,
+    gateway: &GatewayId,
+    port: u16,
+    enabled: bool,
+) {
+    let mut domain_keys = Vec::new();
+    let mut ipv4 = Vec::new();
+    let mut guas = Vec::new();
+    for a in &addresses.available {
+        if a.ssl || a.port != Some(port) {
+            continue;
+        }
+        match &a.metadata {
+            HostnameMetadata::PublicDomain { gateway: gw } if gw == gateway => {
+                domain_keys.push((a.hostname.clone(), port));
+            }
+            HostnameMetadata::Ipv4 { gateway: gw } if a.public && gw == gateway => {
+                if let Some(sa) = a.to_socket_addr() {
+                    ipv4.push(sa);
+                }
+            }
+            HostnameMetadata::Ipv6 { gateway: gw, .. } if gw == gateway => {
+                if let Some(g) = a.gua() {
+                    guas.push(g);
+                }
+            }
+            _ => {}
+        }
+    }
+    for k in domain_keys {
+        if enabled {
+            addresses.disabled.remove(&k);
+        } else {
+            addresses.disabled.insert(k);
+        }
+    }
+    for sa in ipv4 {
+        if enabled {
+            addresses.enabled.insert(sa);
+        } else {
+            addresses.enabled.remove(&sa);
+        }
+    }
+    for g in guas {
+        if enabled {
+            addresses.gua_wan.insert(g);
+            addresses.enabled.insert(SocketAddr::V6(g));
+        } else {
+            addresses.gua_wan.remove(&g);
+            addresses.enabled.remove(&SocketAddr::V6(g));
+        }
+    }
+}
+
 /// Toggle one address on/off for a binding's `DerivedAddressInfo`. Public IPs
 /// live in the `enabled` set (keyed by `SocketAddr`); domains and private IPs
-/// live in the `disabled` set (keyed by `(hostname, port)`). Non-SSL Ipv4 ↔
-/// PublicDomain on the same gateway+port are cascaded so they toggle together.
+/// live in the `disabled` set (keyed by `(hostname, port)`). On a non-SSL port a
+/// dual-stack public domain links the WAN IPv4 and IPv6 GUA, so toggling any one
+/// of {IPv4, domain, GUA} moves the whole group ([`set_nonssl_wan_group`]).
 /// Shared by single-port bindings and port ranges (whose addresses all use
 /// `external_start_port` as their port, so the same keying applies).
 fn set_address_enabled_on(
@@ -565,24 +643,14 @@ fn set_address_enabled_on(
         } else {
             addresses.enabled.remove(&sa);
         }
-        // Non-SSL Ipv4: cascade to PublicDomains on same gateway
+        // Non-SSL Ipv4: a dual-stack public domain links this to the co-located
+        // GUA, so when one is present move the whole {IPv4, domain, GUA} group
+        // together (no domain => v4 and gua stay independent).
         if !address.ssl {
             if let HostnameMetadata::Ipv4 { gateway } = &address.metadata {
                 let port = sa.port();
-                for a in &addresses.available {
-                    if a.ssl {
-                        continue;
-                    }
-                    if let HostnameMetadata::PublicDomain { gateway: gw } = &a.metadata {
-                        if gw == gateway && a.port.unwrap_or(80) == port {
-                            let k = (a.hostname.clone(), a.port.unwrap_or(80));
-                            if enabled {
-                                addresses.disabled.remove(&k);
-                            } else {
-                                addresses.disabled.insert(k);
-                            }
-                        }
-                    }
+                if has_nonssl_domain(addresses, gateway, port) {
+                    set_nonssl_wan_group(addresses, gateway, port, enabled);
                 }
             }
         }
@@ -595,39 +663,11 @@ fn set_address_enabled_on(
         } else {
             addresses.disabled.insert(key);
         }
-        // Non-SSL PublicDomain: cascade to Ipv4 + other PublicDomains on same gateway
+        // Non-SSL PublicDomain: move the whole {IPv4, domain(s), GUA} group — a
+        // dual-stack domain ties the v4 and v6 sides together (no SNI here).
         if !address.ssl {
             if let HostnameMetadata::PublicDomain { gateway } = &address.metadata {
-                for a in &addresses.available {
-                    if a.ssl {
-                        continue;
-                    }
-                    match &a.metadata {
-                        HostnameMetadata::Ipv4 { gateway: gw } if a.public && gw == gateway => {
-                            if let Some(sa) = a.to_socket_addr() {
-                                if sa.port() == port {
-                                    if enabled {
-                                        addresses.enabled.insert(sa);
-                                    } else {
-                                        addresses.enabled.remove(&sa);
-                                    }
-                                }
-                            }
-                        }
-                        HostnameMetadata::PublicDomain { gateway: gw } if gw == gateway => {
-                            let dp = a.port.unwrap_or(80);
-                            if dp == port {
-                                let k = (a.hostname.clone(), dp);
-                                if enabled {
-                                    addresses.disabled.remove(&k);
-                                } else {
-                                    addresses.disabled.insert(k);
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+                set_nonssl_wan_group(addresses, gateway, port, enabled);
             }
         }
     }
@@ -777,6 +817,16 @@ pub async fn set_gua_wan<Kind: HostApiKind>(
                         addrs.gua_wan.remove(&gua);
                         addrs.enabled.remove(&sa);
                     }
+                    // A dual-stack public domain links this GUA to the co-located
+                    // WAN IPv4 (non-SSL, no SNI): if one is present, move the whole
+                    // group so the domain and v4 follow the GUA.
+                    if !address.ssl {
+                        if let HostnameMetadata::Ipv6 { gateway, .. } = &address.metadata {
+                            if has_nonssl_domain(addrs, gateway, gua.port()) {
+                                set_nonssl_wan_group(addrs, gateway, gua.port(), wan);
+                            }
+                        }
+                    }
                     Ok(())
                 })?;
             let hostname = ServerHostname::load(db.as_public().as_server_info())?;
@@ -828,6 +878,65 @@ mod test {
             ..ipv6_addr("2001:db8::1", 443)
         };
         assert!(v4.gua().is_none());
+    }
+
+    #[test]
+    fn nonssl_wan_group_moves_domain_v4_gua_together() {
+        let gw = GatewayId::from(InternedString::intern("wg1"));
+        let mk = |ssl, public, host: &str, meta| HostnameInfo {
+            ssl,
+            public,
+            hostname: InternedString::intern(host),
+            port: Some(42000),
+            metadata: meta,
+        };
+        let mut info = DerivedAddressInfo::default();
+        info.available.insert(mk(
+            false,
+            true,
+            "turn.start9.dev",
+            HostnameMetadata::PublicDomain {
+                gateway: gw.clone(),
+            },
+        ));
+        info.available.insert(mk(
+            false,
+            true,
+            "64.23.194.12",
+            HostnameMetadata::Ipv4 {
+                gateway: gw.clone(),
+            },
+        ));
+        info.available.insert(mk(
+            false,
+            false,
+            "2001:db8::1",
+            HostnameMetadata::Ipv6 {
+                gateway: gw.clone(),
+                scope_id: 0,
+            },
+        ));
+
+        assert!(has_nonssl_domain(&info, &gw, 42000));
+        assert!(!has_nonssl_domain(&info, &gw, 9999));
+
+        let v4_sa: SocketAddr = "64.23.194.12:42000".parse().unwrap();
+        let gua_v6: SocketAddrV6 = "[2001:db8::1]:42000".parse().unwrap();
+        let dom_key = (InternedString::intern("turn.start9.dev"), 42000u16);
+
+        // Enable: domain un-disabled, v4 enabled, GUA published (gua_wan+enabled).
+        set_nonssl_wan_group(&mut info, &gw, 42000, true);
+        assert!(!info.disabled.contains(&dom_key));
+        assert!(info.enabled.contains(&v4_sa));
+        assert!(info.gua_wan.contains(&gua_v6));
+        assert!(info.enabled.contains(&SocketAddr::V6(gua_v6)));
+
+        // Disable: all three off together.
+        set_nonssl_wan_group(&mut info, &gw, 42000, false);
+        assert!(info.disabled.contains(&dom_key));
+        assert!(!info.enabled.contains(&v4_sa));
+        assert!(!info.gua_wan.contains(&gua_v6));
+        assert!(!info.enabled.contains(&SocketAddr::V6(gua_v6)));
     }
 
     #[test]

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -578,25 +578,6 @@ pub(crate) fn has_nonssl_private_domain(
     })
 }
 
-/// Is the WAN level (public domain or bare WAN IPv4) currently on at
-/// `gateway`+`port`? Excludes the shared GUA (which is resolved from this).
-fn nonssl_wan_on(addresses: &DerivedAddressInfo, gateway: &GatewayId, port: u16) -> bool {
-    addresses.available.iter().any(|a| {
-        if a.ssl || a.port != Some(port) {
-            return false;
-        }
-        match &a.metadata {
-            HostnameMetadata::PublicDomain { gateway: gw } if gw == gateway => {
-                !addresses.disabled.contains(&(a.hostname.clone(), port))
-            }
-            HostnameMetadata::Ipv4 { gateway: gw } if a.public && gw == gateway => a
-                .to_socket_addr()
-                .is_some_and(|sa| addresses.enabled.contains(&sa)),
-            _ => false,
-        }
-    })
-}
-
 /// Is the LAN level (private domain or bare LAN IPv4) currently on at
 /// `gateway`+`port`? LAN addresses are opt-out (on by default). Excludes the GUA.
 fn nonssl_lan_on(addresses: &DerivedAddressInfo, gateway: &GatewayId, port: u16) -> bool {
@@ -616,12 +597,14 @@ fn nonssl_lan_on(addresses: &DerivedAddressInfo, gateway: &GatewayId, port: u16)
     })
 }
 
-/// Recompute every GUA at `gateway`+`port` from the two levels: public if the WAN
-/// level is on (public is inclusive of LAN — it wins), else local if the LAN
-/// level is on, else off. Call after any level change so the shared GUA stays
-/// consistent.
+/// Re-derive every GUA's reachability at `gateway`+`port` from its stored WAN
+/// opt-in (`gua_wan`, projected to `HostnameInfo.public`) and the LAN level. The
+/// WAN opt-in is an operator preference — this only READS it, never clobbers it,
+/// so a LAN-level change can't un-publish a GUA. A public GUA (in `gua_wan`) is
+/// reachable on WAN and LAN (public wins); otherwise it is local (on while the
+/// LAN level is up, else off). Only [`set_nonssl_wan_group`]/`set_gua_wan` write
+/// `gua_wan`.
 fn resolve_nonssl_gua(addresses: &mut DerivedAddressInfo, gateway: &GatewayId, port: u16) {
-    let wan_on = nonssl_wan_on(addresses, gateway, port);
     let lan_on = nonssl_lan_on(addresses, gateway, port);
     let guas: Vec<(SocketAddrV6, InternedString)> = addresses
         .available
@@ -641,19 +624,16 @@ fn resolve_nonssl_gua(addresses: &mut DerivedAddressInfo, gateway: &GatewayId, p
     for (g, host) in guas {
         let key = (host, port);
         let sa = SocketAddr::V6(g);
-        if wan_on {
-            // Public: WAN-exposed (and reachable on LAN).
-            addresses.gua_wan.insert(g);
+        if addresses.gua_wan.contains(&g) {
+            // Public (operator WAN opt-in): reachable on WAN and LAN.
             addresses.enabled.insert(sa);
             addresses.disabled.remove(&key);
         } else if lan_on {
-            // Local: LAN-only, on.
-            addresses.gua_wan.remove(&g);
+            // Local: LAN-only, on (local GUAs are opt-out, tracked in `disabled`).
             addresses.enabled.remove(&sa);
             addresses.disabled.remove(&key);
         } else {
             // Off.
-            addresses.gua_wan.remove(&g);
             addresses.enabled.remove(&sa);
             addresses.disabled.insert(key);
         }
@@ -672,6 +652,7 @@ pub(crate) fn set_nonssl_wan_group(
 ) {
     let mut domain_keys = Vec::new();
     let mut ipv4 = Vec::new();
+    let mut guas = Vec::new();
     for a in &addresses.available {
         if a.ssl || a.port != Some(port) {
             continue;
@@ -683,6 +664,11 @@ pub(crate) fn set_nonssl_wan_group(
             HostnameMetadata::Ipv4 { gateway: gw } if a.public && gw == gateway => {
                 if let Some(sa) = a.to_socket_addr() {
                     ipv4.push(sa);
+                }
+            }
+            HostnameMetadata::Ipv6 { gateway: gw, .. } if gw == gateway => {
+                if let Some(g) = a.gua() {
+                    guas.push(g);
                 }
             }
             _ => {}
@@ -700,6 +686,15 @@ pub(crate) fn set_nonssl_wan_group(
             addresses.enabled.insert(sa);
         } else {
             addresses.enabled.remove(&sa);
+        }
+    }
+    // The public domain flips the GUA's WAN opt-in (the stored `gua_wan` /
+    // `public` flag) with it; `resolve_nonssl_gua` then derives its reachability.
+    for g in guas {
+        if enabled {
+            addresses.gua_wan.insert(g);
+        } else {
+            addresses.gua_wan.remove(&g);
         }
     }
     resolve_nonssl_gua(addresses, gateway, port);
@@ -940,42 +935,40 @@ pub async fn set_gua_wan<Kind: HostApiKind>(
                     let bind = b.get_mut(&internal_port).or_not_found(internal_port)?;
                     let addrs = &mut bind.addresses;
                     let sa = SocketAddr::V6(gua);
-                    // A GUA mirrors two IPv4 addresses: public ~ the WAN IPv4,
-                    // local ~ the LAN IPv4. On a non-SSL port a dual-stack public
-                    // domain ties them together, so flipping the GUA moves the
-                    // whole {domain, WAN IPv4, GUA} group — but only when the GUA
-                    // ends up actually enabled (a public-but-off GUA mirrors a
-                    // disabled WAN IPv4, and cascades nothing).
-                    let linked_gw = match &address.metadata {
-                        HostnameMetadata::Ipv6 { gateway, .. }
-                            if !address.ssl
-                                && has_nonssl_public_domain(addrs, gateway, gua.port()) =>
-                        {
+                    // A GUA's WAN opt-in is the stored `gua_wan` / `public` flag.
+                    // With a co-located public domain, flipping the GUA drives the
+                    // whole WAN level (the public domain and bare WAN IPv4 follow —
+                    // correct precisely because a public domain is present).
+                    // Otherwise it is a standalone opt-in; `resolve_nonssl_gua`
+                    // derives the GUA's reachability from `gua_wan` + the LAN level.
+                    let gua_gw = match &address.metadata {
+                        HostnameMetadata::Ipv6 { gateway, .. } if !address.ssl => {
                             Some(gateway.clone())
                         }
                         _ => None,
                     };
-                    if let Some(gateway) = &linked_gw {
-                        // A public domain links this GUA to the WAN level: flipping
-                        // it public turns the level on (GUA -> public via resolve),
-                        // flipping it local turns the WAN level off (GUA -> local
-                        // while the LAN level stays on).
-                        set_nonssl_wan_group(addrs, gateway, gua.port(), wan);
-                    } else if wan {
-                        // Standalone GUA: publish it, carrying its on/off state.
-                        let on = !addrs
-                            .disabled
-                            .contains(&(address.hostname.clone(), gua.port()));
-                        addrs.gua_wan.insert(gua);
-                        if on {
-                            addrs.enabled.insert(sa);
-                        } else {
-                            addrs.enabled.remove(&sa);
+                    match gua_gw {
+                        Some(gateway) if has_nonssl_public_domain(addrs, &gateway, gua.port()) => {
+                            set_nonssl_wan_group(addrs, &gateway, gua.port(), wan);
                         }
-                    } else {
-                        // Standalone GUA: back to local (on unless disabled).
-                        addrs.gua_wan.remove(&gua);
-                        addrs.enabled.remove(&sa);
+                        Some(gateway) => {
+                            if wan {
+                                addrs.gua_wan.insert(gua);
+                            } else {
+                                addrs.gua_wan.remove(&gua);
+                            }
+                            resolve_nonssl_gua(addrs, &gateway, gua.port());
+                        }
+                        None => {
+                            // SSL / non-linkable GUA: a plain WAN opt-in toggle.
+                            if wan {
+                                addrs.gua_wan.insert(gua);
+                                addrs.enabled.insert(sa);
+                            } else {
+                                addrs.gua_wan.remove(&gua);
+                                addrs.enabled.remove(&sa);
+                            }
+                        }
                     }
                     Ok(())
                 })?;
@@ -1212,6 +1205,55 @@ mod test {
                 .gua_wan
                 .contains(&"[2001:db8::1]:42000".parse().unwrap()),
             "GUA is local, not public"
+        );
+    }
+
+    #[test]
+    fn lan_change_preserves_a_stored_wan_gua() {
+        let gw = GatewayId::from(InternedString::intern("wg1"));
+        let mk = |host: &str, meta| HostnameInfo {
+            ssl: false,
+            public: false,
+            hostname: InternedString::intern(host),
+            port: Some(42000),
+            metadata: meta,
+        };
+        let mut info = DerivedAddressInfo::default();
+        info.available.insert(mk(
+            "priv.local",
+            HostnameMetadata::PrivateDomain {
+                gateways: BTreeSet::from([gw.clone()]),
+            },
+        ));
+        info.available.insert(mk(
+            "10.0.0.5",
+            HostnameMetadata::Ipv4 {
+                gateway: gw.clone(),
+            },
+        ));
+        info.available.insert(mk(
+            "2001:db8::1",
+            HostnameMetadata::Ipv6 {
+                gateway: gw.clone(),
+                scope_id: 0,
+            },
+        ));
+        let gua_v6: SocketAddrV6 = "[2001:db8::1]:42000".parse().unwrap();
+        // Operator opted this GUA into WAN directly (stored preference) — there is
+        // no public domain to link it.
+        info.gua_wan.insert(gua_v6);
+        info.enabled.insert(SocketAddr::V6(gua_v6));
+
+        // A LAN-level change must NOT un-publish the GUA's stored WAN opt-in.
+        set_nonssl_lan_group(&mut info, &gw, 42000, false);
+        assert!(
+            info.gua_wan.contains(&gua_v6),
+            "a LAN change must not clobber the GUA's stored WAN opt-in"
+        );
+        set_nonssl_lan_group(&mut info, &gw, 42000, true);
+        assert!(
+            info.gua_wan.contains(&gua_v6),
+            "still WAN after LAN re-enabled"
         );
     }
 

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -803,6 +803,20 @@ pub async fn set_gua_wan<Kind: HostApiKind>(
                     let bind = b.get_mut(&internal_port).or_not_found(internal_port)?;
                     let addrs = &mut bind.addresses;
                     let sa = SocketAddr::V6(gua);
+                    // A GUA mirrors two IPv4 addresses: public ~ the WAN IPv4,
+                    // local ~ the LAN IPv4. On a non-SSL port a dual-stack public
+                    // domain ties them together, so flipping the GUA moves the
+                    // whole {domain, WAN IPv4, GUA} group — but only when the GUA
+                    // ends up actually enabled (a public-but-off GUA mirrors a
+                    // disabled WAN IPv4, and cascades nothing).
+                    let linked_gw = match &address.metadata {
+                        HostnameMetadata::Ipv6 { gateway, .. }
+                            if !address.ssl && has_nonssl_domain(addrs, gateway, gua.port()) =>
+                        {
+                            Some(gateway.clone())
+                        }
+                        _ => None,
+                    };
                     if wan {
                         let on = !addrs
                             .disabled
@@ -810,21 +824,17 @@ pub async fn set_gua_wan<Kind: HostApiKind>(
                         addrs.gua_wan.insert(gua);
                         if on {
                             addrs.enabled.insert(sa);
+                            if let Some(g) = &linked_gw {
+                                set_nonssl_wan_group(addrs, g, gua.port(), true);
+                            }
                         } else {
                             addrs.enabled.remove(&sa);
                         }
                     } else {
                         addrs.gua_wan.remove(&gua);
                         addrs.enabled.remove(&sa);
-                    }
-                    // A dual-stack public domain links this GUA to the co-located
-                    // WAN IPv4 (non-SSL, no SNI): if one is present, move the whole
-                    // group so the domain and v4 follow the GUA.
-                    if !address.ssl {
-                        if let HostnameMetadata::Ipv6 { gateway, .. } = &address.metadata {
-                            if has_nonssl_domain(addrs, gateway, gua.port()) {
-                                set_nonssl_wan_group(addrs, gateway, gua.port(), wan);
-                            }
+                        if let Some(g) = &linked_gw {
+                            set_nonssl_wan_group(addrs, g, gua.port(), false);
                         }
                     }
                     Ok(())

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -544,7 +544,7 @@ pub struct BindingSetAddressEnabledParams {
 /// Is there a non-SSL public domain at this `gateway` + `port`? A public domain
 /// is what links the WAN IPv4 and IPv6 GUA at a non-SSL port (see
 /// [`set_nonssl_wan_group`]); without one they toggle independently.
-pub(crate) fn has_nonssl_domain(
+pub(crate) fn has_nonssl_public_domain(
     addresses: &DerivedAddressInfo,
     gateway: &GatewayId,
     port: u16,
@@ -561,7 +561,7 @@ pub(crate) fn has_nonssl_domain(
 /// port there is no SNI, so all three share the same packets, and a public domain
 /// is assumed dual-stack, so it ties the v4 and v6 sides. They must move as one:
 /// enabling the IPv4 (or the domain) publishes the GUA, and vice versa. Callers
-/// gate this on a domain being present ([`has_nonssl_domain`]) — without one the
+/// gate this on a domain being present ([`has_nonssl_public_domain`]) — without one the
 /// v4 and GUA are independent.
 pub(crate) fn set_nonssl_wan_group(
     addresses: &mut DerivedAddressInfo,
@@ -649,7 +649,7 @@ fn set_address_enabled_on(
         if !address.ssl {
             if let HostnameMetadata::Ipv4 { gateway } = &address.metadata {
                 let port = sa.port();
-                if has_nonssl_domain(addresses, gateway, port) {
+                if has_nonssl_public_domain(addresses, gateway, port) {
                     set_nonssl_wan_group(addresses, gateway, port, enabled);
                 }
             }
@@ -811,7 +811,8 @@ pub async fn set_gua_wan<Kind: HostApiKind>(
                     // disabled WAN IPv4, and cascades nothing).
                     let linked_gw = match &address.metadata {
                         HostnameMetadata::Ipv6 { gateway, .. }
-                            if !address.ssl && has_nonssl_domain(addrs, gateway, gua.port()) =>
+                            if !address.ssl
+                                && has_nonssl_public_domain(addrs, gateway, gua.port()) =>
                         {
                             Some(gateway.clone())
                         }
@@ -927,8 +928,8 @@ mod test {
             },
         ));
 
-        assert!(has_nonssl_domain(&info, &gw, 42000));
-        assert!(!has_nonssl_domain(&info, &gw, 9999));
+        assert!(has_nonssl_public_domain(&info, &gw, 42000));
+        assert!(!has_nonssl_public_domain(&info, &gw, 9999));
 
         let v4_sa: SocketAddr = "64.23.194.12:42000".parse().unwrap();
         let gua_v6: SocketAddrV6 = "[2001:db8::1]:42000".parse().unwrap();

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -541,9 +541,17 @@ pub struct BindingSetAddressEnabledParams {
     enabled: Option<bool>,
 }
 
-/// Is there a non-SSL public domain at this `gateway` + `port`? A public domain
-/// is what links the WAN IPv4 and IPv6 GUA at a non-SSL port (see
-/// [`set_nonssl_wan_group`]); without one they toggle independently.
+// On a non-SSL port (no SNI) a domain shares the bare IP's packets, so a domain
+// links the IPs at its gateway+port. There are two parallel "levels":
+//   WAN level: public domain(s) + bare WAN IPv4 + the GUA-as-public
+//   LAN level: private domain(s) + bare LAN IPv4 + the GUA-as-local
+// The IPv6 GUA is a single address shared by both — a public GUA is reachable on
+// LAN too, so **public wins**: if the WAN level is on the GUA is public, else if
+// the LAN level is on it is local, else it is off. WAN addresses are opt-in
+// (public IPs), LAN addresses are opt-out (on by default).
+
+/// Is there a non-SSL public domain at this `gateway` + `port`? Without one the
+/// WAN IPv4 and GUA toggle independently.
 pub(crate) fn has_nonssl_public_domain(
     addresses: &DerivedAddressInfo,
     gateway: &GatewayId,
@@ -556,13 +564,106 @@ pub(crate) fn has_nonssl_public_domain(
     })
 }
 
-/// Set the whole non-SSL WAN group at `gateway` + `port` — the public domain(s),
-/// the bare WAN IPv4, and the WAN IPv6 GUA — to `enabled` together. On a non-SSL
-/// port there is no SNI, so all three share the same packets, and a public domain
-/// is assumed dual-stack, so it ties the v4 and v6 sides. They must move as one:
-/// enabling the IPv4 (or the domain) publishes the GUA, and vice versa. Callers
-/// gate this on a domain being present ([`has_nonssl_public_domain`]) — without one the
-/// v4 and GUA are independent.
+/// Is there a non-SSL private domain at this `gateway` + `port`? The LAN mirror
+/// of [`has_nonssl_public_domain`].
+pub(crate) fn has_nonssl_private_domain(
+    addresses: &DerivedAddressInfo,
+    gateway: &GatewayId,
+    port: u16,
+) -> bool {
+    addresses.available.iter().any(|a| {
+        !a.ssl
+            && a.port == Some(port)
+            && matches!(&a.metadata, HostnameMetadata::PrivateDomain { gateways } if gateways.contains(gateway))
+    })
+}
+
+/// Is the WAN level (public domain or bare WAN IPv4) currently on at
+/// `gateway`+`port`? Excludes the shared GUA (which is resolved from this).
+fn nonssl_wan_on(addresses: &DerivedAddressInfo, gateway: &GatewayId, port: u16) -> bool {
+    addresses.available.iter().any(|a| {
+        if a.ssl || a.port != Some(port) {
+            return false;
+        }
+        match &a.metadata {
+            HostnameMetadata::PublicDomain { gateway: gw } if gw == gateway => {
+                !addresses.disabled.contains(&(a.hostname.clone(), port))
+            }
+            HostnameMetadata::Ipv4 { gateway: gw } if a.public && gw == gateway => a
+                .to_socket_addr()
+                .is_some_and(|sa| addresses.enabled.contains(&sa)),
+            _ => false,
+        }
+    })
+}
+
+/// Is the LAN level (private domain or bare LAN IPv4) currently on at
+/// `gateway`+`port`? LAN addresses are opt-out (on by default). Excludes the GUA.
+fn nonssl_lan_on(addresses: &DerivedAddressInfo, gateway: &GatewayId, port: u16) -> bool {
+    addresses.available.iter().any(|a| {
+        if a.ssl || a.port != Some(port) {
+            return false;
+        }
+        match &a.metadata {
+            HostnameMetadata::PrivateDomain { gateways } if gateways.contains(gateway) => {
+                !addresses.disabled.contains(&(a.hostname.clone(), port))
+            }
+            HostnameMetadata::Ipv4 { gateway: gw } if !a.public && gw == gateway => {
+                !addresses.disabled.contains(&(a.hostname.clone(), port))
+            }
+            _ => false,
+        }
+    })
+}
+
+/// Recompute every GUA at `gateway`+`port` from the two levels: public if the WAN
+/// level is on (public is inclusive of LAN — it wins), else local if the LAN
+/// level is on, else off. Call after any level change so the shared GUA stays
+/// consistent.
+fn resolve_nonssl_gua(addresses: &mut DerivedAddressInfo, gateway: &GatewayId, port: u16) {
+    let wan_on = nonssl_wan_on(addresses, gateway, port);
+    let lan_on = nonssl_lan_on(addresses, gateway, port);
+    let guas: Vec<(SocketAddrV6, InternedString)> = addresses
+        .available
+        .iter()
+        .filter_map(|a| {
+            if a.ssl || a.port != Some(port) {
+                return None;
+            }
+            match &a.metadata {
+                HostnameMetadata::Ipv6 { gateway: gw, .. } if gw == gateway => {
+                    a.gua().map(|g| (g, a.hostname.clone()))
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    for (g, host) in guas {
+        let key = (host, port);
+        let sa = SocketAddr::V6(g);
+        if wan_on {
+            // Public: WAN-exposed (and reachable on LAN).
+            addresses.gua_wan.insert(g);
+            addresses.enabled.insert(sa);
+            addresses.disabled.remove(&key);
+        } else if lan_on {
+            // Local: LAN-only, on.
+            addresses.gua_wan.remove(&g);
+            addresses.enabled.remove(&sa);
+            addresses.disabled.remove(&key);
+        } else {
+            // Off.
+            addresses.gua_wan.remove(&g);
+            addresses.enabled.remove(&sa);
+            addresses.disabled.insert(key);
+        }
+    }
+}
+
+/// Set the non-SSL WAN level at `gateway`+`port` — the public domain(s) and the
+/// bare WAN IPv4 — to `enabled`, then resolve the shared GUA. On a non-SSL port
+/// there is no SNI, so these share the same packets and move as one. Callers gate
+/// on a public domain being present ([`has_nonssl_public_domain`]).
 pub(crate) fn set_nonssl_wan_group(
     addresses: &mut DerivedAddressInfo,
     gateway: &GatewayId,
@@ -571,7 +672,6 @@ pub(crate) fn set_nonssl_wan_group(
 ) {
     let mut domain_keys = Vec::new();
     let mut ipv4 = Vec::new();
-    let mut guas = Vec::new();
     for a in &addresses.available {
         if a.ssl || a.port != Some(port) {
             continue;
@@ -583,11 +683,6 @@ pub(crate) fn set_nonssl_wan_group(
             HostnameMetadata::Ipv4 { gateway: gw } if a.public && gw == gateway => {
                 if let Some(sa) = a.to_socket_addr() {
                     ipv4.push(sa);
-                }
-            }
-            HostnameMetadata::Ipv6 { gateway: gw, .. } if gw == gateway => {
-                if let Some(g) = a.gua() {
-                    guas.push(g);
                 }
             }
             _ => {}
@@ -607,15 +702,42 @@ pub(crate) fn set_nonssl_wan_group(
             addresses.enabled.remove(&sa);
         }
     }
-    for g in guas {
-        if enabled {
-            addresses.gua_wan.insert(g);
-            addresses.enabled.insert(SocketAddr::V6(g));
-        } else {
-            addresses.gua_wan.remove(&g);
-            addresses.enabled.remove(&SocketAddr::V6(g));
+    resolve_nonssl_gua(addresses, gateway, port);
+}
+
+/// Set the non-SSL LAN level at `gateway`+`port` — the private domain(s) and the
+/// bare LAN IPv4 (both opt-out, keyed in `disabled`) — to `enabled`, then resolve
+/// the shared GUA. The LAN mirror of [`set_nonssl_wan_group`]; callers gate on a
+/// private domain being present ([`has_nonssl_private_domain`]).
+pub(crate) fn set_nonssl_lan_group(
+    addresses: &mut DerivedAddressInfo,
+    gateway: &GatewayId,
+    port: u16,
+    enabled: bool,
+) {
+    let mut keys = Vec::new();
+    for a in &addresses.available {
+        if a.ssl || a.port != Some(port) {
+            continue;
+        }
+        match &a.metadata {
+            HostnameMetadata::PrivateDomain { gateways } if gateways.contains(gateway) => {
+                keys.push((a.hostname.clone(), port));
+            }
+            HostnameMetadata::Ipv4 { gateway: gw } if !a.public && gw == gateway => {
+                keys.push((a.hostname.clone(), port));
+            }
+            _ => {}
         }
     }
+    for k in keys {
+        if enabled {
+            addresses.disabled.remove(&k);
+        } else {
+            addresses.disabled.insert(k);
+        }
+    }
+    resolve_nonssl_gua(addresses, gateway, port);
 }
 
 /// Toggle one address on/off for a binding's `DerivedAddressInfo`. Public IPs
@@ -663,11 +785,26 @@ fn set_address_enabled_on(
         } else {
             addresses.disabled.insert(key);
         }
-        // Non-SSL PublicDomain: move the whole {IPv4, domain(s), GUA} group — a
-        // dual-stack domain ties the v4 and v6 sides together (no SNI here).
+        // Non-SSL: a domain ties the v4 and v6 sides together (no SNI). A public
+        // domain moves the WAN level; a private domain (or the bare LAN IPv4, when
+        // a private domain links them) moves the LAN level.
         if !address.ssl {
-            if let HostnameMetadata::PublicDomain { gateway } = &address.metadata {
-                set_nonssl_wan_group(addresses, gateway, port, enabled);
+            match &address.metadata {
+                HostnameMetadata::PublicDomain { gateway } => {
+                    set_nonssl_wan_group(addresses, gateway, port, enabled);
+                }
+                HostnameMetadata::PrivateDomain { gateways } => {
+                    for gateway in gateways {
+                        set_nonssl_lan_group(addresses, gateway, port, enabled);
+                    }
+                }
+                // Bare LAN IPv4 (this branch is never reached for a public IP).
+                HostnameMetadata::Ipv4 { gateway } => {
+                    if has_nonssl_private_domain(addresses, gateway, port) {
+                        set_nonssl_lan_group(addresses, gateway, port, enabled);
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -818,25 +955,27 @@ pub async fn set_gua_wan<Kind: HostApiKind>(
                         }
                         _ => None,
                     };
-                    if wan {
+                    if let Some(gateway) = &linked_gw {
+                        // A public domain links this GUA to the WAN level: flipping
+                        // it public turns the level on (GUA -> public via resolve),
+                        // flipping it local turns the WAN level off (GUA -> local
+                        // while the LAN level stays on).
+                        set_nonssl_wan_group(addrs, gateway, gua.port(), wan);
+                    } else if wan {
+                        // Standalone GUA: publish it, carrying its on/off state.
                         let on = !addrs
                             .disabled
                             .contains(&(address.hostname.clone(), gua.port()));
                         addrs.gua_wan.insert(gua);
                         if on {
                             addrs.enabled.insert(sa);
-                            if let Some(g) = &linked_gw {
-                                set_nonssl_wan_group(addrs, g, gua.port(), true);
-                            }
                         } else {
                             addrs.enabled.remove(&sa);
                         }
                     } else {
+                        // Standalone GUA: back to local (on unless disabled).
                         addrs.gua_wan.remove(&gua);
                         addrs.enabled.remove(&sa);
-                        if let Some(g) = &linked_gw {
-                            set_nonssl_wan_group(addrs, g, gua.port(), false);
-                        }
                     }
                     Ok(())
                 })?;
@@ -948,6 +1087,132 @@ mod test {
         assert!(!info.enabled.contains(&v4_sa));
         assert!(!info.gua_wan.contains(&gua_v6));
         assert!(!info.enabled.contains(&SocketAddr::V6(gua_v6)));
+    }
+
+    #[test]
+    fn shared_gua_public_wins_over_local() {
+        let gw = GatewayId::from(InternedString::intern("wg1"));
+        let mk = |ssl, public, host: &str, meta| HostnameInfo {
+            ssl,
+            public,
+            hostname: InternedString::intern(host),
+            port: Some(42000),
+            metadata: meta,
+        };
+        let mut info = DerivedAddressInfo::default();
+        info.available.insert(mk(
+            false,
+            true,
+            "pub.example.com",
+            HostnameMetadata::PublicDomain {
+                gateway: gw.clone(),
+            },
+        ));
+        info.available.insert(mk(
+            false,
+            true,
+            "64.23.194.12",
+            HostnameMetadata::Ipv4 {
+                gateway: gw.clone(),
+            },
+        ));
+        info.available.insert(mk(
+            false,
+            false,
+            "priv.local",
+            HostnameMetadata::PrivateDomain {
+                gateways: BTreeSet::from([gw.clone()]),
+            },
+        ));
+        info.available.insert(mk(
+            false,
+            false,
+            "10.0.0.5",
+            HostnameMetadata::Ipv4 {
+                gateway: gw.clone(),
+            },
+        ));
+        info.available.insert(mk(
+            false,
+            false,
+            "2001:db8::1",
+            HostnameMetadata::Ipv6 {
+                gateway: gw.clone(),
+                scope_id: 0,
+            },
+        ));
+
+        let gua_v6: SocketAddrV6 = "[2001:db8::1]:42000".parse().unwrap();
+        let gua_key = (InternedString::intern("2001:db8::1"), 42000u16);
+
+        // WAN level on -> GUA public (public is inclusive of LAN, so it wins).
+        set_nonssl_wan_group(&mut info, &gw, 42000, true);
+        assert!(
+            info.gua_wan.contains(&gua_v6),
+            "public domain on => GUA public"
+        );
+
+        // WAN level off, LAN level still on -> GUA drops to local, not off.
+        set_nonssl_wan_group(&mut info, &gw, 42000, false);
+        assert!(!info.gua_wan.contains(&gua_v6), "GUA no longer public");
+        assert!(
+            !info.disabled.contains(&gua_key),
+            "GUA is local (on), not off, because the LAN level is still up"
+        );
+    }
+
+    #[test]
+    fn nonssl_lan_group_moves_private_v4_gua_together() {
+        let gw = GatewayId::from(InternedString::intern("wg1"));
+        let mk = |host: &str, meta| HostnameInfo {
+            ssl: false,
+            public: false,
+            hostname: InternedString::intern(host),
+            port: Some(42000),
+            metadata: meta,
+        };
+        let mut info = DerivedAddressInfo::default();
+        info.available.insert(mk(
+            "priv.local",
+            HostnameMetadata::PrivateDomain {
+                gateways: BTreeSet::from([gw.clone()]),
+            },
+        ));
+        info.available.insert(mk(
+            "10.0.0.5",
+            HostnameMetadata::Ipv4 {
+                gateway: gw.clone(),
+            },
+        ));
+        info.available.insert(mk(
+            "2001:db8::1",
+            HostnameMetadata::Ipv6 {
+                gateway: gw.clone(),
+                scope_id: 0,
+            },
+        ));
+
+        let priv_key = (InternedString::intern("priv.local"), 42000u16);
+        let lan_key = (InternedString::intern("10.0.0.5"), 42000u16);
+        let gua_key = (InternedString::intern("2001:db8::1"), 42000u16);
+
+        // Disable the LAN level (nothing on the WAN side to keep the GUA) -> off.
+        set_nonssl_lan_group(&mut info, &gw, 42000, false);
+        assert!(info.disabled.contains(&priv_key));
+        assert!(info.disabled.contains(&lan_key));
+        assert!(info.disabled.contains(&gua_key), "GUA off");
+
+        // Re-enable -> private domain + LAN IPv4 on, GUA local (on, not public).
+        set_nonssl_lan_group(&mut info, &gw, 42000, true);
+        assert!(!info.disabled.contains(&priv_key));
+        assert!(!info.disabled.contains(&lan_key));
+        assert!(!info.disabled.contains(&gua_key));
+        assert!(
+            !info
+                .gua_wan
+                .contains(&"[2001:db8::1]:42000".parse().unwrap()),
+            "GUA is local, not public"
+        );
     }
 
     #[test]

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -1233,8 +1233,15 @@ impl NetService {
                 let hostname = ServerHostname::load(db.as_public().as_server_info())?;
                 let mut ports = db.as_private().as_available_ports().de()?;
                 let host = host_for(db, pkg_id.as_ref().unwrap_or(&PackageId::start_os()), &id)?;
+                let is_new = !host.as_bindings().contains_key(&internal_port)?;
                 host.add_binding(&mut ports, internal_port, options)?;
                 host.update_addresses(&hostname, &gateways, &ports)?;
+                // Isolate a newly-bound binding from any pre-existing public
+                // domain on this host, then re-derive so port forwards match.
+                if is_new {
+                    host.reconcile_domains_on_new_binding(internal_port)?;
+                    host.update_addresses(&hostname, &gateways, &ports)?;
+                }
                 db.as_private_mut().as_available_ports_mut().ser(&ports)?;
                 Ok(())
             })
@@ -1264,6 +1271,9 @@ impl NetService {
                 let hostname = ServerHostname::load(db.as_public().as_server_info())?;
                 let mut ports = db.as_private().as_available_ports().de()?;
                 let host = host_for(db, pkg_id.as_ref().unwrap_or(&PackageId::start_os()), &id)?;
+                let is_new = !host
+                    .as_binding_ranges()
+                    .contains_key(&internal_start_port)?;
                 host.add_binding_range(
                     &mut ports,
                     internal_start_port,
@@ -1271,6 +1281,12 @@ impl NetService {
                     number_of_ports,
                 )?;
                 host.update_addresses(&hostname, &gateways, &ports)?;
+                // Isolate a newly-bound range from any pre-existing public domain
+                // on this host, then re-derive so port forwards match.
+                if is_new {
+                    host.reconcile_domains_on_new_range(internal_start_port)?;
+                    host.update_addresses(&hostname, &gateways, &ports)?;
+                }
                 db.as_private_mut().as_available_ports_mut().ser(&ports)?;
                 Ok(())
             })

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -1239,7 +1239,7 @@ impl NetService {
                 // Isolate a newly-bound binding from any pre-existing public
                 // domain on this host, then re-derive so port forwards match.
                 if is_new {
-                    host.reconcile_domains_on_new_binding(internal_port)?;
+                    host.reconcile_public_domains_on_new_binding(internal_port)?;
                     host.update_addresses(&hostname, &gateways, &ports)?;
                 }
                 db.as_private_mut().as_available_ports_mut().ser(&ports)?;
@@ -1284,7 +1284,7 @@ impl NetService {
                 // Isolate a newly-bound range from any pre-existing public domain
                 // on this host, then re-derive so port forwards match.
                 if is_new {
-                    host.reconcile_domains_on_new_range(internal_start_port)?;
+                    host.reconcile_public_domains_on_new_range(internal_start_port)?;
                     host.update_addresses(&hostname, &gateways, &ports)?;
                 }
                 db.as_private_mut().as_available_ports_mut().ser(&ports)?;


### PR DESCRIPTION
## Problem

A public domain is scoped to its target binding: `add_public_domain` enables it on that binding and, on the same host, is supposed to keep it off *other* bindings. Two gaps:

1. Port **ranges** were never handled. Because a range's synthesized domain row is enabled-by-default (opt-out, like any domain), a domain added to a sibling binding silently WAN-forwarded the **entire range** (the `mod.rs` range-forward loop) while the range's own WAN toggle read "disabled". (This is the coturn relay-range report — attaching a domain to `turn` invisibly forwarded 42000–42499.)
2. The old sibling cleanup blindly wrote the domain into `disabled` regardless of an already-enabled WAN IP. Since a non-SSL domain shares the bare WAN IP's packets (no SNI), a sibling/range whose WAN IPv4 was already enabled would then show the domain "disabled" while it was in fact still reachable — reintroducing the same mismatch on a re-add or when a second domain is added.

## Fix

Replace the blind sibling-disable with a **reconcile** applied identically to sibling bindings and port ranges (`reconcile_domain_on_sibling`):

- **non-SSL** domain row: if the co-located WAN IPv4 (same gateway + port) is already enabled on that sibling, **enable** the domain to match; otherwise **disable** it.
- **SSL** domain row: always isolated (it carries its own SNI).

So a domain and its bare WAN IP stay in lockstep on every binding and every range — in both directions and across re-adds. The direct per-address enable/disable toggle path (`set_address_enabled_on`, shared by bindings and ranges) was already correct and is unchanged; this only fixes the `add_public_domain`-time reconciliation.

## Tests

New unit tests for `reconcile_domain_on_sibling`: non-SSL follows an enabled WAN IP; non-SSL isolated when the IP is off; SSL always isolated; an enabled IP on a *different* gateway is not honored. `cargo test -p start-core net::host` → 31 passed. `cargo check -p start-core` clean.

## Note

Supersedes #3463 (the abandoned "expose the whole host" direction).
