### PR TITLE
fix(container-runtime): drop prettier from the build script

### DIFF
--- a/projects/start-os/AGENTS.md
+++ b/projects/start-os/AGENTS.md
@@ -37,7 +37,9 @@ monorepo-wide rules, and [ARCHITECTURE.md](ARCHITECTURE.md) and
 - Type-check the runtime: `cd projects/start-os/container-runtime && npm run check`.
 - Build the UI: `make start-os-ui` (or `make start-os-uis` for ui + setup-wizard).
 - Tests: `make test` (Rust + SDK + container-runtime), or `make start-core-test`.
-- Format: `make start-os-format` / `make start-os-format-check`.
+- Format: `make start-os-format` / `make start-os-format-check` (Rust only);
+  TS/web/container-runtime formatting runs through `make web-format` (root
+  prettier config).
 - Regenerate `start-container` man pages (committed under `man/`):
   `cargo test -p start-core export_manpage_start_container`.
 
@@ -49,8 +51,10 @@ monorepo-wide rules, and [ARCHITECTURE.md](ARCHITECTURE.md) and
 - **`unshare-userns` must stay a multi-call applet**, not a CLI subcommand: it
   calls `unshare(CLONE_NEWUSER)`, which the kernel rejects on a multi-threaded
   process. See the comment in `src/bin/start-container.rs`.
-- **Don't normalize style across components.** The container-runtime uses double
-  quotes + no semicolons (its own prettier config); the SDK uses single quotes.
+- **One prettier config.** All TS (web, container-runtime) is governed by the
+  root `.prettierrc.json` + `.prettierignore`; run prettier from the repo root
+  so the ignore applies (`__fixtures__/` etc. must stay unformatted). Don't add
+  per-component prettier configs or scripts.
 - **Don't edit generated binding files** like
   `shared-libs/ts-modules/start-core/lib/osBindings/index.ts` or `projects/start-sdk/s9pk.mk`.
 - **Ask before destructive `make` recipes** — `update*`, `reflash`, `wormhole*`,

--- a/projects/start-os/CONTRIBUTING.md
+++ b/projects/start-os/CONTRIBUTING.md
@@ -123,13 +123,14 @@ make test                      # Rust + SDK + container-runtime
 make start-core-test                 # backend only
 ```
 
-The container-runtime has its own test suite and prettier config (double quotes, no semicolons) — see [container-runtime/CONTRIBUTING.md](container-runtime/CONTRIBUTING.md). Note CI builds a multi-platform matrix (apple-darwin + aarch64/x86_64/riscv64 musl); local `cargo check` is linux-only, so consider platform-specific impact.
+The container-runtime has its own test suite — see [container-runtime/CONTRIBUTING.md](container-runtime/CONTRIBUTING.md). Note CI builds a multi-platform matrix (apple-darwin + aarch64/x86_64/riscv64 musl); local `cargo check` is linux-only, so consider platform-specific impact.
 
 ## Formatting
 
 ```sh
-make start-os-format            # format this product (core bins + web + container-runtime)
+make start-os-format            # format this product's Rust (core bins + backup-fs)
 make start-os-format-check      # CI-style check
+make web-format                 # prettier (root config) — covers web + container-runtime
 ```
 
 ## Cross-layer changes

--- a/projects/start-os/build.mk
+++ b/projects/start-os/build.mk
@@ -212,13 +212,12 @@ start-os-clean:
 	rm -rf projects/start-os/build/lib/firmware projects/start-os/build/lib/migration-images
 	rm -rf projects/start-os/build/image-recipe/deb
 
-# OS bins + backup-fs (Rust) and the container-runtime (its own prettier config).
-# The ui/setup-wizard web apps are formatted by `web-format` (whole Angular workspace).
+# The ui/setup-wizard web apps and the container-runtime are formatted by
+# `web-format`/`web-format-check` (root prettier config, run from the repo root so
+# the root .prettierignore applies). This target is just the Rust crates.
 .PHONY: start-os-format start-os-format-check
 start-os-format:
 	$(FMT) cargo fmt -p start-os -p startos-backup-fs
-	npm --prefix projects/start-os/container-runtime run format
 
 start-os-format-check:
 	$(FMT) cargo fmt --check -p start-os -p startos-backup-fs
-	npm --prefix projects/start-os/container-runtime run format:check

--- a/projects/start-os/container-runtime/AGENTS.md
+++ b/projects/start-os/container-runtime/AGENTS.md
@@ -20,7 +20,7 @@ Run from the monorepo root (`/path/to/start-os`):
 cd projects/start-sdk && make bundle && cd -                  # build SDK dependency first
 npm --prefix projects/start-os/container-runtime ci           # install deps
 npm --prefix projects/start-os/container-runtime run check     # tsc --noEmit (type-check)
-npm --prefix projects/start-os/container-runtime run build      # prettier + clean + tsc -> dist/
+npm --prefix projects/start-os/container-runtime run build      # clean + tsc -> dist/
 npm --prefix projects/start-os/container-runtime test           # jest (ts-jest)
 make container-runtime-test                            # SDK + jest via top-level Makefile
 ```
@@ -30,7 +30,7 @@ Tests are Jest + `ts-jest` (`jest.config.js`, `rootDir: ./src`). `mime` is mocke
 ## Gotchas
 
 - **Depends on the _built_ SDK at `../../start-sdk/dist`** (declared in `package.json` as `"@start9labs/start-sdk": "file:../../start-sdk/dist"`) **and on `@start9labs/start-core` at `../../../shared-libs/ts-modules/start-core/dist`** (for what were the deep `base/lib/...` imports). Editing `projects/start-sdk/` or `shared-libs/ts-modules/start-core/` source alone has no effect here — rebuild first: `cd projects/start-sdk && make bundle` (which builds start-core and bundles it). The Makefile target `projects/start-os/container-runtime/package-lock.json` also depends on `projects/start-sdk/dist/package.json`, so a stale SDK can break `npm ci`/`check`/`test`.
-- **Style: double quotes, no semicolons.** Prettier config lives in `package.json` (`semi: false`, `singleQuote: false`, `trailingComma: "all"`, `tabWidth: 2`). This differs from `start-sdk` / `shared-libs/ts-modules` (single quotes there) — do NOT "normalize" to single quotes. `npm run build` runs Prettier `--write` before compiling.
+- **Formatting is the root prettier config** (`.prettierrc.json` at the repo root), applied via `make format` / `make web-format` from the repo root. Never run prettier from inside this directory: the root `.prettierignore` (which protects `__fixtures__/`) only applies when prettier runs from the root cwd.
 - **`CLAUDE.md` is just `@AGENTS.md`** — edit this file, not `CLAUDE.md`.
 
 ## Image build (gotchas)

--- a/projects/start-os/container-runtime/CONTRIBUTING.md
+++ b/projects/start-os/container-runtime/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Run from the monorepo root:
 ```bash
 npm --prefix projects/start-os/container-runtime ci          # install deps
 npm --prefix projects/start-os/container-runtime run check     # type-check (tsc --noEmit)
-npm --prefix projects/start-os/container-runtime run build      # prettier + clean + tsc -> dist/
+npm --prefix projects/start-os/container-runtime run build      # clean + tsc -> dist/
 ```
 
 Or `cd projects/start-os/container-runtime` first and drop the `--prefix`.
@@ -46,15 +46,11 @@ Jest with `ts-jest` (`jest.config.js`, `rootDir: ./src`). The `mime` module is m
 
 ## Formatting
 
-Prettier config lives in `package.json`:
-
-- `trailingComma: "all"`, `tabWidth: 2`, `semi: false`, `singleQuote: false`.
-
-The runtime uses **double quotes**, unlike `start-sdk` and `shared-libs/ts-modules` (single quotes there) — do not normalize. `npm run build` runs Prettier `--write` before compiling, so formatting is applied automatically during a build.
-
-From the monorepo root, the canonical formatter is the top-level make target (container-runtime folds into the start-os product):
+The root prettier config (`.prettierrc.json` at the repo root) governs this directory — there is no local config or format script. Format from the monorepo root:
 
 ```bash
-make start-os-format          # write formatting
-make start-os-format-check    # CI read-only check
+make web-format               # prettier --write over the whole repo
+make web-format-check         # CI read-only check
 ```
+
+Never run prettier from inside this directory: the root `.prettierignore` only applies when prettier runs from the root cwd, and it must apply — it protects `__fixtures__/` (byte-exact test fixtures) from being reformatted.

--- a/projects/start-os/container-runtime/package-lock.json
+++ b/projects/start-os/container-runtime/package-lock.json
@@ -31,7 +31,6 @@
         "@types/jsonpath": "^0.2.4",
         "@types/node": "^20.11.13",
         "jest": "^29.7.0",
-        "prettier": "^3.2.5",
         "ts-jest": "^29.2.3",
         "typescript": ">5.2"
       }
@@ -66,7 +65,7 @@
     },
     "../../start-sdk/dist": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.1",
+      "version": "2.0.3",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",
@@ -5484,22 +5483,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/projects/start-os/container-runtime/package.json
+++ b/projects/start-os/container-runtime/package.json
@@ -5,9 +5,7 @@
   "module": "./index.js",
   "scripts": {
     "check": "tsc --noEmit",
-    "format": "prettier . '!tmp/**' --write",
-    "format:check": "prettier . '!tmp/**' --check",
-    "build": "prettier . '!tmp/**' --write && rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc",
     "tsc": "rm -rf dist; tsc",
     "test": "jest -c ./jest.config.js"
   },
@@ -39,7 +37,6 @@
     "@types/jsonpath": "^0.2.4",
     "@types/node": "^20.11.13",
     "jest": "^29.7.0",
-    "prettier": "^3.2.5",
     "ts-jest": "^29.2.3",
     "typescript": ">5.2"
   }


### PR DESCRIPTION
## Problem

Every StartOS build was rewriting `container-runtime/src/**/__fixtures__/*.ts` from double quotes to single quotes.

Root cause: the container-runtime `build` script ran `prettier . --write` from inside the project directory. Since #3437 removed the local prettier config, that invocation resolves the root `.prettierrc.json` (config files walk up the tree) **but not** the root `.prettierignore` (ignore files only resolve from the cwd) — so the `**/__fixtures__/` protection never applied. Verified with `prettier --file-info`: the same fixture file reports `ignored: false` from the project cwd and `ignored: true` from the repo root.

`make start-os-format`/`-check` had the same bug via the local `format`/`format:check` npm scripts.

## Fix

- `build` script is now just `rm -rf dist && tsc`; the local `format`/`format:check` scripts and the `prettier` devDependency are removed — one root prettier config, no per-component prettier surface.
- `start-os-format`/`start-os-format-check` are Rust-only, matching start-wrt/start-tunnel; TS formatting for web + container-runtime runs through `web-format` (root cwd, so the ignore applies).
- Updated the docs that still described the pre-#3437 setup (local config, double quotes, build-time formatting) in `projects/start-os/{AGENTS,CONTRIBUTING}.md` and `container-runtime/{AGENTS,CONTRIBUTING}.md`.
- Lockfile regenerated with pinned npm 11.13.0: drops prettier and syncs the `file:` SDK dist entry to 2.0.3 (matches the SDK version at HEAD).

No changelog entry — build tooling only, nothing user-visible.

## Verification

- `npm run build` exits 0 and leaves the tree untouched (fixtures stay double-quoted)
- `npx prettier --check` from the root passes over container-runtime and the edited docs
- container-runtime jest suite: 12 tests, 6 snapshots, all pass
- `make -n start-os-format start-os-format-check` parses and shows the expected Rust-only recipes