### PR TITLE
fix(cli): config precedence + .local (mDNS) resolution — start-cli 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7709,7 +7709,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "start-cli"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "start-core",
  "tracing",

--- a/projects/start-cli/ARCHITECTURE.md
+++ b/projects/start-cli/ARCHITECTURE.md
@@ -33,7 +33,7 @@ standalone binary it behaves like a dedicated CLI.
 argv ─▶ MultiExecutable ─▶ start_cli::main (in start-core)
                               │
                               ├─ build CliApp from start-core::main_api()
-                              ├─ load ClientConfig (flags + .startos/config.yaml + /etc/startos)
+                              ├─ load ClientConfig (flags + -c + workspace + ~/.startos + /etc/startos)
                               └─ run:
                                    • remote command  ─▶ CliContext ─HTTPS RPC─▶ StartOS server
                                    • local command   ─▶ executed in-process (s9pk, keys, util)
@@ -55,10 +55,18 @@ and `tunnel` groups can target a separate registry/tunnel host via `--registry`/
 
 ### Configuration
 
-`ClientConfig` (in `start-core::context::config`) is parsed from CLI flags and merged with
-config files in priority order: explicit flags → workspace `.startos/config.yaml` →
-`/etc/startos/config.yaml`. It carries the target host/registry/tunnel, proxy, cookie path,
-developer key path, root CAs, and the `--insecure` toggle. The loaded config becomes a
+`ClientConfig` (in `start-core::context::config`) is the single config type — the workspace
+`.startos/config.yaml`, `~/.startos/config.yaml`, `/etc/startos/config.yaml`, and `-c` files all
+deserialize into it (a `schema` key marks a real workspace for the walk-up). `host`/`registry` are
+each a `Profiles` namespace with one config key; `-H`/`-r` parse (via `Profiles`' `FromStr` /
+`ValueParserFactory`) straight into `{ default: <value> }`, so the flag is just the top layer of
+that namespace — no separate selector field. `ClientConfig::load` then layers the config files
+under the flags: a `-c` chain, the discovered workspace (only its `host`/`registry`), `~/.startos`,
+then `/etc/startos`. A bare URL is shorthand for `default`, and the layers combine into one
+namespace — a union of aliases where a name defined at more than one level takes the higher tier's
+value. `resolve_target` follows the `default` profile, chasing a value that names another profile
+until it reaches a URL, which it parses only then. `ClientConfig` also carries tunnel, proxy,
+cookie path, developer key path, root CAs, and the `--insecure` toggle. The loaded config becomes a
 `CliContext` that the RPC handlers use.
 
 ## Man pages

--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -11,6 +11,35 @@ or the CLI's externally observable behavior.
 
 ## [Unreleased]
 
+## [1.0.3]
+
+### Added
+
+- **`host`/`registry` profiles work in every config file, not just the workspace.** A config
+  file's `host`/`registry` is a namespace of named profiles — `default`, `prod`, whatever you
+  like — and a bare URL is shorthand for the `default` profile, so a legacy flat
+  `host: https://box.local` still targets that URL. Profiles from a `-c` file, the workspace
+  `.startos/config.yaml`, `~/.startos/config.yaml`, and `/etc/startos/config.yaml` all **combine**
+  into one namespace, so you can keep reusable profiles in your home config and reach them from
+  anywhere — inside a packaging workspace or not. A profile's value can be a URL or the name of
+  another profile, and `-H`/`-r` just set the `default` profile for that invocation (`-H prod`
+  points `default` at your `prod` profile); resolution follows the chain to a URL. A value that
+  isn't a URL is reported only when it's the one resolved, so a stale ambient config never fails an
+  unrelated command.
+
+### Fixed
+
+- **An ambient config file no longer shadows the workspace `.startos/config.yaml`.** A `host`
+  set in `~/.startos/config.yaml` or `/etc/startos/config.yaml` was merged into the same field as
+  an explicit `-H`/`-r`, so it silently outranked the workspace's `default` profile — the opposite
+  of the documented layering, and a trap for anyone with a leftover pre-1.0 flat config in their
+  home directory. Profiles now layer in a strict order, highest precedence first: a command-line
+  flag (`-H`/`-r`), a config file named with `-c`, the workspace config, `~/.startos/config.yaml`,
+  then `/etc/startos/config.yaml`. Where the same profile name is defined at more than one level
+  the higher tier wins; what you name on the command line overrides the workspace, what you don't
+  is an ambient default beneath it. A `-H`/`-r` naming an unknown profile still errors rather than
+  quietly falling through to a lower tier.
+
 ## [1.0.2]
 
 ### Changed
@@ -103,7 +132,8 @@ init-workspace`), so an existing package repo is one command away from building.
 - `ws_continuation` honors `--root-ca` / `--insecure` (#3274).
 - `choose` falls back to a generic non-tty prompt instead of failing when stdin isn't a terminal (#3265).
 
-[Unreleased]: https://github.com/Start9Labs/start-technologies/compare/start-cli/v1.0.2...HEAD
+[Unreleased]: https://github.com/Start9Labs/start-technologies/compare/start-cli/v1.0.3...HEAD
+[1.0.3]: https://github.com/Start9Labs/start-technologies/releases/tag/start-cli/v1.0.3
 [1.0.2]: https://github.com/Start9Labs/start-technologies/releases/tag/start-cli/v1.0.2
 [1.0.1]: https://github.com/Start9Labs/start-technologies/releases/tag/start-cli/v1.0.1
 [1.0.0]: https://github.com/Start9Labs/start-technologies/releases/tag/start-cli/v1.0.0

--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -29,6 +29,16 @@ or the CLI's externally observable behavior.
 
 ### Fixed
 
+- **`.local` (mDNS) hostnames resolve again.** Every command against a `.local` address — the
+  way most people reach their server — failed after ~5s with an opaque
+  `error sending request for url (...)`, while `curl` against the same URL succeeded instantly.
+  `start-cli` ships as a statically linked musl binary, and musl's `getaddrinfo` implements no
+  NSS: it ignores `/etc/nsswitch.conf`, so `mdns4_minimal` is never consulted and the lookup
+  falls through to unicast DNS, which dies on musl's hard-coded 5s timeout. A `.local` host is
+  now resolved through the system resolver (`getent`, the same path `curl` takes) when the
+  client context is built, so the HTTP client and the log/progress websockets alike are handed
+  an address. Linux only — macOS resolves `.local` natively. (#3469)
+
 - **An ambient config file no longer shadows the workspace `.startos/config.yaml`.** A `host`
   set in `~/.startos/config.yaml` or `/etc/startos/config.yaml` was merged into the same field as
   an explicit `-H`/`-r`, so it silently outranked the workspace's `default` profile — the opposite

--- a/projects/start-cli/Cargo.toml
+++ b/projects/start-cli/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-cli"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "1.0.2"                                               # VERSION_BUMP
+version = "1.0.3"                                               # VERSION_BUMP
 
 [[bin]]
 name = "start-cli"

--- a/projects/start-cli/README.md
+++ b/projects/start-cli/README.md
@@ -40,7 +40,7 @@ target/debug/start-cli s9pk pack ...                # build a package
 ## Connecting to a server
 
 `-H/--host` accepts either a URL (`https://server.local`) or a `host` profile name
-defined in a workspace `.startos/config.yaml`. Common flags:
+defined in a config file (see [Profiles](#profiles) below). Common flags:
 
 | Flag                          | Purpose                                 |
 | ----------------------------- | --------------------------------------- |
@@ -51,8 +51,39 @@ defined in a workspace `.startos/config.yaml`. Common flags:
 | `--developer-key-path <path>` | Developer signing key location          |
 | `--insecure`                  | Skip TLS verification (testing only)    |
 
-Configuration is layered: explicit flags override `.startos/config.yaml` (local workspace),
-which overrides `/etc/startos/config.yaml`. See
+### Profiles
+
+Every config file carries named `host` and `registry` **profiles**:
+
+```yaml
+host:
+  default: https://dev-vm.local
+  prod: https://prodbox.local
+registry:
+  default: https://registry.start9.com
+```
+
+`-H prod` targets the `prod` profile; a command with no `-H` uses `default`. A bare URL is
+shorthand for the `default` profile, so `host: https://dev-vm.local` and
+`host: { default: https://dev-vm.local }` mean the same thing. `-H`/`-r` simply set the `default`
+profile for that one invocation, on top of whatever the config files provide.
+
+A profile's value is either a URL or the name of another profile, so `default: prod` (or `-H prod`)
+points `default` at `prod`, and resolution follows the chain until it reaches a URL.
+
+Profiles are read from these sources, highest precedence first:
+
+1. `-H`/`-r` on the command line (set the `default` profile)
+2. a config file named on the command line (`-c`)
+3. the nearest workspace `.startos/config.yaml` (found by walking up from the current directory)
+4. `~/.startos/config.yaml`
+5. `/etc/startos/config.yaml`
+
+The profiles from every source **combine** into one namespace, and a name defined at more than one
+level takes its value from the higher tier — so `-H`'s `default` outranks the workspace's, which
+outranks `~/.startos`'s. You can keep reusable profiles in `~/.startos/config.yaml` and reach them
+with `-H` from anywhere, while a workspace still overrides `default` for the box you're standing in,
+and a `host` left in `~/.startos/config.yaml` can't hijack the workspace's `default`. See
 [`shared-libs/crates/start-core/src/context/config.rs`](../../shared-libs/crates/start-core/src/context/config.rs).
 
 ## Command surface

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -2491,6 +2491,12 @@ context.cli.unknown-profile-or-url:
   es_ES: "«%{value}» no es un perfil conocido ni una URL válida"
   fr_FR: "« %{value} » n'est pas un profil connu ni une URL valide"
   pl_PL: "„%{value}” nie jest znanym profilem ani prawidłowym adresem URL"
+context.cli.profile-cycle:
+  en_US: "'%{value}' is part of a profile reference cycle"
+  de_DE: "„%{value}“ ist Teil eines Profilverweis-Zyklus"
+  es_ES: "«%{value}» forma parte de un ciclo de referencias de perfil"
+  fr_FR: "« %{value} » fait partie d'un cycle de références de profil"
+  pl_PL: "„%{value}” jest częścią cyklu odwołań profili"
 
 # context/rpc.rs
 context.rpc.rpc-context-dropped:

--- a/shared-libs/crates/start-core/src/context/cli.rs
+++ b/shared-libs/crates/start-core/src/context/cli.rs
@@ -26,6 +26,7 @@ use crate::context::config::{ClientConfig, local_config_path, resolve_target};
 use crate::context::{DiagnosticContext, InitContext, RpcContext, SetupContext};
 use crate::developer::{OS_DEVELOPER_KEY_PATH, default_developer_key_path, load_signing_key};
 use crate::middleware::auth::local::LocalAuthContext;
+use crate::net::mdns::pin_mdns_host;
 use crate::prelude::*;
 use crate::rpc_continuations::Guid;
 use crate::s9pk::init::{BUILD_KEY_FILE, STARTOS_DIR};
@@ -130,6 +131,9 @@ impl CliContext {
             Some(url) => url,
             None => "http://localhost".parse()?,
         };
+        // Before anything derives a URL from this one: a `.local` host is unresolvable from a
+        // musl-static binary, so pin it to an address the system resolver found.
+        pin_mdns_host(&mut url)?;
 
         let registry = resolve_target(config.registry.as_ref())?;
 
@@ -164,6 +168,7 @@ impl CliContext {
             },
             registry_url: registry
                 .map(|mut registry| {
+                    pin_mdns_host(&mut registry)?;
                     registry
                         .path_segments_mut()
                         .map_err(|_| eyre!("Url cannot be base"))

--- a/shared-libs/crates/start-core/src/context/cli.rs
+++ b/shared-libs/crates/start-core/src/context/cli.rs
@@ -22,7 +22,7 @@ use tokio_tungstenite::{Connector, MaybeTlsStream, WebSocketStream};
 use tracing::instrument;
 
 use super::setup::CURRENT_SECRET;
-use crate::context::config::{ClientConfig, WorkspaceConfig, local_config_path, resolve_target};
+use crate::context::config::{ClientConfig, local_config_path, resolve_target};
 use crate::context::{DiagnosticContext, InitContext, RpcContext, SetupContext};
 use crate::developer::{OS_DEVELOPER_KEY_PATH, default_developer_key_path, load_signing_key};
 use crate::middleware::auth::local::LocalAuthContext;
@@ -123,19 +123,15 @@ impl CliContext {
     /// BLOCKING
     #[instrument(skip_all)]
     pub fn init(config: ClientConfig) -> Result<Self, Error> {
-        // Resolve -H/-r (profile name or URL) against the workspace config, falling
-        // back to a literal URL, then to localhost / no registry when unset.
-        let workspace = WorkspaceConfig::find()?;
-        let mut url =
-            match resolve_target(config.host.as_deref(), workspace.as_ref().map(|w| &w.host))? {
-                Some(url) => url,
-                None => "http://localhost".parse()?,
-            };
+        // Follow each namespace's `default` profile to a URL (`load` already seeded
+        // -H/-r as `default` and layered every config file in), then localhost / no
+        // registry when unset.
+        let mut url = match resolve_target(config.host.as_ref())? {
+            Some(url) => url,
+            None => "http://localhost".parse()?,
+        };
 
-        let registry = resolve_target(
-            config.registry.as_deref(),
-            workspace.as_ref().map(|w| &w.registry),
-        )?;
+        let registry = resolve_target(config.registry.as_ref())?;
 
         let cookie_path = config.cookie_path.unwrap_or_else(|| {
             local_config_path()

--- a/shared-libs/crates/start-core/src/context/config.rs
+++ b/shared-libs/crates/start-core/src/context/config.rs
@@ -1,13 +1,14 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
+use clap::builder::{StringValueParser, TypedValueParser, ValueParser, ValueParserFactory};
 use imbl_value::InternedString;
 use reqwest::Url;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::de::{DeserializeOwned, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::MAIN_DATA;
 use crate::prelude::*;
@@ -17,6 +18,95 @@ use crate::version::VersionT;
 pub const DEVICE_CONFIG_PATH: &str = "/media/startos/config/config.yaml"; // "/media/startos/config/config.yaml";
 pub const CONFIG_PATH: &str = "/etc/startos/config.yaml";
 pub const CONFIG_PATH_LOCAL: &str = ".startos/config.yaml";
+
+/// The profile a `-H`/`-r` with no explicit name resolves to.
+pub const DEFAULT_PROFILE: &str = "default";
+
+/// Named `host`/`registry` targets — the namespace every config file shares
+/// (the workspace `.startos/config.yaml`, `~/.startos/config.yaml`,
+/// `/etc/startos/config.yaml`, and any `-c` file). A bare value is shorthand for
+/// the `default` profile, so a legacy flat `host: https://x` and an explicit
+/// `host: { default: https://x }` mean the same thing.
+///
+/// Values are kept as written and only parsed into a URL at resolve time (like a
+/// literal `-H`), so a stale or malformed ambient config never fails a command that
+/// doesn't actually target it — it errors only if it's the one selected. A
+/// null/empty value is an empty namespace, not an error.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct Profiles(pub BTreeMap<String, String>);
+impl<'de> Deserialize<'de> for Profiles {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ProfilesVisitor;
+        impl<'de> Visitor<'de> for ProfilesVisitor {
+            type Value = Profiles;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a URL, or a map of profile name to URL")
+            }
+            fn visit_unit<E>(self) -> Result<Profiles, E> {
+                Ok(Profiles::default())
+            }
+            fn visit_none<E>(self) -> Result<Profiles, E> {
+                Ok(Profiles::default())
+            }
+            fn visit_str<E>(self, value: &str) -> Result<Profiles, E> {
+                Ok(if value.trim().is_empty() {
+                    Profiles::default()
+                } else {
+                    Profiles(BTreeMap::from([(
+                        DEFAULT_PROFILE.to_owned(),
+                        value.to_owned(),
+                    )]))
+                })
+            }
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Profiles, A::Error> {
+                let mut profiles = BTreeMap::new();
+                while let Some((name, url)) = map.next_entry::<String, String>()? {
+                    profiles.insert(name, url);
+                }
+                Ok(Profiles(profiles))
+            }
+        }
+        deserializer.deserialize_any(ProfilesVisitor)
+    }
+}
+impl Profiles {
+    /// Add every profile from `lower` that `self` doesn't already define, so a
+    /// higher-precedence config keeps its own entries and only inherits the rest.
+    fn merge_under(&mut self, lower: Profiles) {
+        for (name, url) in lower.0 {
+            self.0.entry(name).or_insert(url);
+        }
+    }
+}
+/// A `-H`/`-r` value is shorthand for the `default` profile — so the flag needs no
+/// special handling, it just contributes `{ default: <value> }` at the top of the stack.
+impl std::str::FromStr for Profiles {
+    type Err = std::convert::Infallible;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(if value.trim().is_empty() {
+            Profiles::default()
+        } else {
+            Profiles(BTreeMap::from([(
+                DEFAULT_PROFILE.to_owned(),
+                value.to_owned(),
+            )]))
+        })
+    }
+}
+impl ValueParserFactory for Profiles {
+    type Parser = ValueParser;
+    fn value_parser() -> Self::Parser {
+        ValueParser::new(StringValueParser::new().try_map(|value| value.parse::<Profiles>()))
+    }
+}
+
+/// Union `from`'s profiles into `into`, keeping `into`'s entry for any shared alias.
+fn merge_profiles(into: &mut Option<Profiles>, from: Option<Profiles>) {
+    if let Some(from) = from {
+        into.get_or_insert_with(Profiles::default).merge_under(from);
+    }
+}
 
 pub fn local_config_path() -> Option<PathBuf> {
     if let Ok(home) = std::env::var("HOME") {
@@ -61,12 +151,22 @@ pub trait ContextConfig: DeserializeOwned + Default {
 pub struct ClientConfig {
     #[arg(short = 'c', long, help = "help.arg.config-file-path")]
     pub config: Option<PathBuf>,
-    /// A `host` profile name from the workspace `.startos/config.yaml`, or a URL.
+    /// The `host` namespace — named profiles from every config source, merged in
+    /// precedence order (`-H`, a `-c` chain, the workspace, `~/.startos`, `/etc/startos`).
+    /// `-H <value>` is shorthand for `{ default: <value> }`, so the flag just seeds the
+    /// top of the stack; resolution follows the `default` profile, chasing a value that
+    /// names another profile until it reaches a URL.
     #[arg(short = 'H', long, help = "help.arg.host-url")]
-    pub host: Option<String>,
-    /// A `registry` profile name from the workspace `.startos/config.yaml`, or a URL.
+    pub host: Option<Profiles>,
+    /// The `registry` namespace, merged the same way. See [`Self::host`].
     #[arg(short = 'r', long, help = "help.arg.registry-url")]
-    pub registry: Option<String>,
+    pub registry: Option<Profiles>,
+    /// A workspace marker: `.startos/config.yaml` sets `schema: 1`. Read only during
+    /// walk-up discovery, to tell a real workspace from a legacy flat config; every
+    /// other config source ignores it.
+    #[arg(skip)]
+    #[serde(default)]
+    pub schema: Option<u64>,
     #[arg(long, help = "help.arg.registry-hostname")]
     pub registry_hostname: Option<Vec<InternedString>>,
     #[arg(skip)]
@@ -107,8 +207,10 @@ impl ContextConfig for ClientConfig {
         self.config.take()
     }
     fn merge_with(&mut self, other: Self) {
-        self.host = self.host.take().or(other.host);
-        self.registry = self.registry.take().or(other.registry);
+        // Profiles merge *beneath* what's already loaded, so a nearer source's profiles
+        // win a shared alias while distinct aliases accumulate into the union.
+        merge_profiles(&mut self.host, other.host);
+        merge_profiles(&mut self.registry, other.registry);
         self.registry_hostname = self.registry_hostname.take().or(other.registry_hostname);
         self.registry_listen = self.registry_listen.take().or(other.registry_listen);
         self.s9pk_s3base = self.s9pk_s3base.take().or(other.s9pk_s3base);
@@ -125,81 +227,84 @@ impl ContextConfig for ClientConfig {
 }
 impl ClientConfig {
     pub fn load(mut self) -> Result<Self, Error> {
+        // `-H`/`-r` already sit in `host`/`registry` as `{ default: <value> }` (clap parsed
+        // them via `Profiles`), at the top of the stack. Merge config files under them,
+        // nearest-first — a `-c` chain, the discovered workspace, `~/.startos`, then
+        // `/etc/startos` — each only *adding* profiles a nearer layer didn't already define.
         let path = self.next();
         self.load_path_rec(path)?;
+        if let Some(workspace) = find_workspace_config()? {
+            // Only its `host`/`registry` profiles — a workspace found by walking up from
+            // cwd must not reach into TLS, proxy, signing-key or cookie settings just
+            // because you `cd`'d into its tree (unlike the fixed-path files below, which
+            // you own and which `merge_with` folds in whole).
+            merge_profiles(&mut self.host, workspace.host);
+            merge_profiles(&mut self.registry, workspace.registry);
+        }
         self.load_path_rec(local_config_path())?;
         self.load_path_rec(Some(CONFIG_PATH))?;
         Ok(self)
     }
 }
 
-/// Per-workspace config (`.startos/config.yaml`), discovered by walking up from
-/// cwd. Unlike the flat global config it carries named `host`/`registry` profiles.
-/// The required `schema` field is what distinguishes it from the legacy flat
-/// `~/.startos/config.yaml` (which has no `schema`, so it's skipped here and still
-/// loaded the old way).
-#[derive(Debug, Default, Deserialize)]
-pub struct WorkspaceConfig {
-    #[allow(dead_code)]
-    pub schema: u64,
-    #[serde(default)]
-    pub host: BTreeMap<String, Url>,
-    #[serde(default)]
-    pub registry: BTreeMap<String, Url>,
-}
-impl WorkspaceConfig {
-    /// Walk up from cwd for the nearest `.startos/config.yaml` that parses as a
-    /// workspace config. A flat config (no `schema`) fails to parse and is skipped,
-    /// so the walk continues — preserving the global fallback when there's none.
-    /// EACCES (or any other IO error) on a candidate stops the walk and reports
-    /// no workspace; an inaccessible ancestor isn't surfaced as an error.
-    pub fn find() -> Result<Option<Self>, Error> {
-        let mut dir = std::env::current_dir()?;
-        loop {
-            let candidate = dir.join(".startos").join("config.yaml");
-            match File::open(&candidate) {
-                Ok(file) => {
-                    if let Ok(config) = IoFormat::Yaml.from_reader::<_, Self>(file) {
+/// Walk up from cwd for the nearest workspace `.startos/config.yaml` — the one that
+/// sets `schema`. A legacy flat config (no `schema`) is skipped so the walk continues,
+/// and it's still picked up as an ambient config by [`ClientConfig::load`]. EACCES (or
+/// any other IO error) on a candidate stops the walk and reports no workspace; an
+/// inaccessible ancestor isn't surfaced as an error.
+fn find_workspace_config() -> Result<Option<ClientConfig>, Error> {
+    let mut dir = std::env::current_dir()?;
+    loop {
+        let candidate = dir.join(".startos").join("config.yaml");
+        match File::open(&candidate) {
+            Ok(file) => {
+                if let Ok(config) = IoFormat::Yaml.from_reader::<_, ClientConfig>(file) {
+                    if config.schema.is_some() {
                         return Ok(Some(config));
                     }
-                    // Present but not a workspace config (e.g. the legacy flat
-                    // config) — keep walking up.
+                    // Present but not a workspace (no `schema`) — keep walking up.
                 }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(_) => return Ok(None),
             }
-            if !dir.pop() {
-                return Ok(None);
-            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => return Ok(None),
+        }
+        if !dir.pop() {
+            return Ok(None);
         }
     }
 }
 
-/// Resolve a `-H`/`-r` value against a profile map: a profile-name match first,
-/// then a literal URL, else an error. A missing value falls back to the `default`
-/// profile, or `None` when there's no workspace config (keeping the global fallback).
-pub fn resolve_target(
-    value: Option<&str>,
-    profiles: Option<&BTreeMap<String, Url>>,
-) -> Result<Option<Url>, Error> {
-    match value {
-        Some(value) => {
-            if let Some(url) = profiles.and_then(|p| p.get(value)) {
-                Ok(Some(url.clone()))
-            } else if let Ok(url) = Url::parse(value) {
-                Ok(Some(url))
-            } else {
-                Err(Error::new(
-                    eyre!(
-                        "{}",
-                        t!("context.cli.unknown-profile-or-url", value = value)
-                    ),
-                    ErrorKind::InvalidRequest,
-                ))
-            }
+/// Resolve a profile namespace to a URL by following the `default` profile: its value
+/// is either a URL or the name of another profile, which is chased (guarding against
+/// cycles) until a URL is reached. `None` when there's no namespace or no `default` — so
+/// an unqualified command with no config falls back to localhost / no registry. The final
+/// value is parsed here, so a bad or unknown target errors only when it's the one selected.
+pub fn resolve_target(profiles: Option<&Profiles>) -> Result<Option<Url>, Error> {
+    let Some(profiles) = profiles else {
+        return Ok(None);
+    };
+    let Some(mut target) = profiles.0.get(DEFAULT_PROFILE) else {
+        return Ok(None);
+    };
+    let mut visited = BTreeSet::from([DEFAULT_PROFILE]);
+    while let Some((name, value)) = profiles.0.get_key_value(target.as_str()) {
+        if !visited.insert(name.as_str()) {
+            return Err(Error::new(
+                eyre!("{}", t!("context.cli.profile-cycle", value = name)),
+                ErrorKind::InvalidRequest,
+            ));
         }
-        None => Ok(profiles.and_then(|p| p.get("default")).cloned()),
+        target = value;
     }
+    Url::parse(target).map(Some).map_err(|_| {
+        Error::new(
+            eyre!(
+                "{}",
+                t!("context.cli.unknown-profile-or-url", value = target)
+            ),
+            ErrorKind::InvalidRequest,
+        )
+    })
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, Parser)]
@@ -257,5 +362,213 @@ impl ServerConfig {
             .with_ctx(|_| (crate::ErrorKind::Filesystem, db_path.display().to_string()))?;
 
         Ok(db)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profiles(pairs: &[(&str, &str)]) -> Profiles {
+        Profiles(
+            pairs
+                .iter()
+                .map(|(name, url)| (name.to_string(), url.to_string()))
+                .collect(),
+        )
+    }
+
+    /// Parse a config file the way `load_path_rec` does.
+    fn parse(yaml: &str) -> ClientConfig {
+        IoFormat::Yaml.from_reader(yaml.as_bytes()).unwrap()
+    }
+
+    fn resolved(profiles: &Profiles) -> Option<String> {
+        resolve_target(Some(profiles))
+            .unwrap()
+            .map(|url| url.to_string())
+    }
+
+    /// A `-H`/`-r` flag value is parsed straight into the `default` profile, so the flag
+    /// is a profile map like every other source and needs no special handling.
+    #[test]
+    fn a_flag_value_is_the_default_profile() {
+        assert_eq!(
+            "prod".parse::<Profiles>().unwrap(),
+            profiles(&[("default", "prod")]),
+        );
+        assert_eq!(
+            "https://x/".parse::<Profiles>().unwrap(),
+            profiles(&[("default", "https://x/")]),
+        );
+        assert_eq!("".parse::<Profiles>().unwrap(), Profiles::default());
+    }
+
+    // A config file's `host`/`registry` is one key: a bare URL is the `default` profile,
+    // a map is taken verbatim, and null/empty is no namespace.
+
+    #[test]
+    fn a_bare_url_is_the_default_profile() {
+        assert_eq!(
+            parse("host: https://flat/").host,
+            Some(profiles(&[("default", "https://flat/")])),
+        );
+    }
+
+    #[test]
+    fn a_map_is_taken_as_named_profiles() {
+        assert_eq!(
+            parse("host:\n  default: https://ws/\n  remote: https://remote/").host,
+            Some(profiles(&[
+                ("default", "https://ws/"),
+                ("remote", "https://remote/"),
+            ])),
+        );
+    }
+
+    /// A leftover `host:` (null) or `host: ''` is no namespace, not a parse error — it
+    /// can't brick unrelated commands, and a sibling key still loads.
+    #[test]
+    fn a_null_or_empty_host_is_no_namespace() {
+        assert!(parse("host:").host.unwrap_or_default().0.is_empty());
+        assert!(parse("host: ''").host.unwrap_or_default().0.is_empty());
+        assert!(parse("host:\nregistry: https://r/").registry.is_some());
+    }
+
+    /// Merging unions namespaces; a shared alias keeps the nearer source's value.
+    #[test]
+    fn merging_unions_profiles() {
+        let mut config = ClientConfig {
+            host: Some(profiles(&[("default", "https://near/")])),
+            ..Default::default()
+        };
+        config.merge_with(parse(
+            "host:\n  default: https://far/\n  remote: https://far-remote/",
+        ));
+        assert_eq!(
+            config.host,
+            Some(profiles(&[
+                ("default", "https://near/"),      // shared alias: nearer source wins
+                ("remote", "https://far-remote/"), // new alias: added to the union
+            ])),
+        );
+    }
+
+    /// Sources merge nearest-first: `~/.startos` before `/etc/startos`.
+    #[test]
+    fn a_nearer_source_wins_a_shared_alias() {
+        let mut config = ClientConfig::default();
+        config.merge_with(parse("host:\n  default: https://home/"));
+        config.merge_with(parse("host:\n  default: https://etc/\n  ci: https://ci/"));
+        assert_eq!(
+            config.host,
+            Some(profiles(&[
+                ("default", "https://home/"),
+                ("ci", "https://ci/")
+            ])),
+        );
+    }
+
+    // Resolution follows the `default` profile, chasing profile references to a URL.
+
+    #[test]
+    fn no_namespace_or_default_resolves_to_nothing() {
+        assert_eq!(resolve_target(None).unwrap(), None);
+        assert_eq!(resolved(&Profiles::default()), None);
+        assert_eq!(resolved(&profiles(&[("prod", "https://p/")])), None);
+    }
+
+    #[test]
+    fn a_default_url_resolves() {
+        assert_eq!(
+            resolved(&profiles(&[("default", "https://d/")])),
+            Some("https://d/".into()),
+        );
+    }
+
+    /// `default` may name another profile (this is how `-H prod`, and a flat
+    /// `host: prod`, target a profile) — resolution follows the reference.
+    #[test]
+    fn a_default_may_reference_another_profile() {
+        let ns = profiles(&[("default", "prod"), ("prod", "https://prod/")]);
+        assert_eq!(resolved(&ns), Some("https://prod/".into()));
+    }
+
+    #[test]
+    fn a_reference_chain_is_followed_to_a_url() {
+        let ns = profiles(&[("default", "a"), ("a", "b"), ("b", "https://leaf/")]);
+        assert_eq!(resolved(&ns), Some("https://leaf/".into()));
+    }
+
+    /// A `default` that is neither a known profile nor a valid URL is an error.
+    #[test]
+    fn an_unresolvable_default_errors() {
+        assert!(resolve_target(Some(&profiles(&[("default", "nope")]))).is_err());
+    }
+
+    /// A profile reference cycle errors instead of looping forever.
+    #[test]
+    fn a_profile_cycle_errors() {
+        let ns = profiles(&[("default", "a"), ("a", "b"), ("b", "a")]);
+        assert!(resolve_target(Some(&ns)).is_err());
+    }
+
+    /// A bare non-URL value loads fine (so a stale ambient config never fails a
+    /// command that doesn't target it) and errors only when it's the one resolved.
+    #[test]
+    fn a_non_url_value_loads_but_errors_only_when_selected() {
+        let config = parse("host: box.local");
+        assert_eq!(config.host, Some(profiles(&[("default", "box.local")])));
+        assert!(resolve_target(config.host.as_ref()).is_err());
+    }
+
+    /// `-H`/`-r` (parsed as `{ default: <value> }`) override whatever `default` the files
+    /// set, because they sit at the top of the merge stack.
+    #[test]
+    fn a_flag_overrides_the_files_default() {
+        // as `load` sees it: the flag is already in `host`; files merge under it.
+        let mut config = ClientConfig {
+            host: Some("prod".parse::<Profiles>().unwrap()),
+            ..Default::default()
+        };
+        config.merge_with(parse(
+            "host:\n  default: https://file-default/\n  prod: https://prod/",
+        ));
+        assert_eq!(
+            resolved(config.host.as_ref().unwrap()),
+            Some("https://prod/".into()),
+        );
+    }
+
+    /// The stack `load` builds: the `-H` `default` outranks every file's, and aliases from
+    /// every tier combine into one namespace resolved by following references. The
+    /// walk-up workspace contributes only its `host`/`registry` (via `merge_profiles`).
+    #[test]
+    fn the_layered_namespace_combines_every_tier() {
+        let mut config = ClientConfig {
+            host: Some("https://flag/".parse::<Profiles>().unwrap()),
+            ..Default::default()
+        };
+        config.merge_with(parse(
+            "host:\n  default: https://cli/\n  shared: https://cli-shared/",
+        ));
+        merge_profiles(
+            &mut config.host,
+            parse("host:\n  shared: https://ws-shared/\n  ws-only: https://ws-only/").host,
+        );
+        config.merge_with(parse("host:\n  home-only: https://home-only/"));
+
+        let ns = config.host.unwrap();
+        // -H set `default`; it outranks every file's `default`.
+        assert_eq!(resolved(&ns), Some("https://flag/".into()));
+        // a shared alias resolves at its highest tier, and every tier's unique aliases survive.
+        let follow = |name: &str| {
+            let mut ns = ns.clone();
+            ns.0.insert("default".into(), name.into());
+            resolved(&ns)
+        };
+        assert_eq!(follow("shared"), Some("https://cli-shared/".into()));
+        assert_eq!(follow("ws-only"), Some("https://ws-only/".into()));
+        assert_eq!(follow("home-only"), Some("https://home-only/".into()));
     }
 }

--- a/shared-libs/crates/start-core/src/net/mdns.rs
+++ b/shared-libs/crates/start-core/src/net/mdns.rs
@@ -1,10 +1,79 @@
 use std::net::Ipv4Addr;
 
 use color_eyre::eyre::eyre;
+use reqwest::Url;
 use tokio::process::Command;
 
 use crate::prelude::*;
 use crate::util::Invoke;
+
+/// BLOCKING. Point a `*.local` URL at its resolved address, leaving every other URL alone.
+///
+/// Our binaries are statically linked against musl, whose `getaddrinfo` implements no NSS:
+/// `/etc/nsswitch.conf` is ignored, so `mdns4_minimal` is never consulted and a `.local` name
+/// cannot be resolved in-process. The lookup falls through to unicast DNS and dies after musl's
+/// hard-coded 5s timeout, which is why `curl` resolves a name that `start-cli` cannot.
+///
+/// Rewriting the URL once here, at context build, means every consumer downstream — the HTTP
+/// client and the websocket path alike — is handed an address rather than a name. The server's
+/// cert carries IP SANs (see [`crate::net::ssl`]), so TLS still verifies.
+#[cfg(target_os = "linux")]
+pub fn pin_mdns_host(url: &mut Url) -> Result<(), Error> {
+    let Some(hostname) = url
+        .host_str()
+        .map(|host| host.trim_end_matches('.').to_owned())
+        .filter(|host| host.ends_with(".local"))
+    else {
+        return Ok(());
+    };
+    let ip = resolve_system(&hostname)?;
+    url.set_ip_host(ip).map_err(|_| {
+        Error::new(
+            eyre!("Cannot point url at resolved address {ip}"),
+            crate::ErrorKind::ParseUrl,
+        )
+    })
+}
+
+/// darwin's `getaddrinfo` resolves `.local` through mDNSResponder natively, so there is nothing
+/// to work around: the binary is linked against the system libc, not musl.
+#[cfg(not(target_os = "linux"))]
+pub fn pin_mdns_host(_url: &mut Url) -> Result<(), Error> {
+    Ok(())
+}
+
+/// BLOCKING. Resolve a hostname through the *system* resolver by shelling out to `getent`.
+///
+/// `getent` is a separate, dynamically linked binary, so it goes through the host's real NSS
+/// stack — exactly the path `curl` and `ping` take — and honors whatever that machine is
+/// configured for: mDNS, `/etc/hosts`, LDAP. Unlike [`resolve_mdns`] it needs nothing installed
+/// beyond libc; `avahi-resolve-host-name` lives in `avahi-utils`, which mDNS on Linux does not
+/// depend on and which most desktops don't have.
+#[cfg(target_os = "linux")]
+fn resolve_system(hostname: &str) -> Result<std::net::IpAddr, Error> {
+    let unresolved = || {
+        Error::new(
+            eyre!("Failed to resolve hostname: {hostname}"),
+            crate::ErrorKind::Network,
+        )
+    };
+    let output = std::process::Command::new("getent")
+        .arg("ahosts")
+        .arg(hostname)
+        .output()
+        .with_ctx(|_| (crate::ErrorKind::Network, "getent ahosts"))?;
+    if !output.status.success() {
+        return Err(unresolved());
+    }
+    // One line per socket type, address first — take whichever the resolver preferred:
+    //     192.168.8.170   STREAM demo.local
+    //     192.168.8.170   DGRAM
+    String::from_utf8(output.stdout)?
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .find_map(|addr| addr.parse().ok())
+        .ok_or_else(unresolved)
+}
 
 pub async fn resolve_mdns(hostname: &str) -> Result<Ipv4Addr, Error> {
     Ok(String::from_utf8(

--- a/shared-libs/crates/start-core/src/s9pk/init.rs
+++ b/shared-libs/crates/start-core/src/s9pk/init.rs
@@ -497,16 +497,16 @@ mod test {
 
     #[test]
     fn scaffolded_config_parses_as_workspace() {
-        // the config init-workspace writes must load as a full WorkspaceConfig (typed
-        // host/registry URL maps), which is what the runtime actually reads — not
-        // merely as schema-tagged YAML.
-        assert!(
-            IoFormat::Yaml
-                .from_reader::<_, crate::context::config::WorkspaceConfig>(
-                    WORKSPACE_CONFIG_CONTENTS.as_bytes()
-                )
-                .is_ok()
-        );
+        // the config init-workspace writes must load as the unified ClientConfig (its
+        // schema marker + host/registry profile maps), which is what the runtime reads
+        // — not merely as schema-tagged YAML.
+        let config = IoFormat::Yaml
+            .from_reader::<_, crate::context::config::ClientConfig>(
+                WORKSPACE_CONFIG_CONTENTS.as_bytes(),
+            )
+            .unwrap();
+        assert!(config.schema.is_some());
+        assert!(config.host.is_some_and(|host| !host.0.is_empty()));
     }
 
     #[test]


### PR DESCRIPTION
> **Now carries two fixes.** #3474 (`.local`/mDNS resolution, closes #3469) was merged into this branch rather than into `master` — that's the stacked-PR mechanic. So **merging this PR is what ships both fixes**, plus the start-cli **1.0.3** release. #3474's own review discussion is [here](https://github.com/Start9Labs/start-technologies/pull/3474); the mDNS change is verified end-to-end against a real box (old: 5.04s failure → new: 0.54s real server response).
>
> The rest of this description covers the config-precedence fix only.

---

## The bug

`start-cli`'s README documents the layering as:

> Configuration is layered: explicit flags override `.startos/config.yaml` (local workspace), which overrides `/etc/startos/config.yaml`.

The code does the opposite for config files. `ClientConfig::load()` merges `~/.startos/config.yaml` and `/etc/startos/config.yaml` into the **same field** as the `-H`/`-r` flag, and `CliContext::init` then feeds that one field to `resolve_target`. A config file therefore resolves with *flag-level* precedence and silently shadows the workspace's `default` profile.

Concretely: a `host:` key in `~/.startos/config.yaml` hijacks every invocation, even deep inside a packaging workspace with its own `default` profile. That's a live trap — a leftover **pre-1.0 flat config** in `$HOME` (exactly what the 1.0 workspace migration leaves behind) quietly overrides the workspace you're standing in, and nothing tells you.

## The fix

A config file is a *fallback*, not a per-invocation override. Only a flag should outrank the workspace.

- `ClientConfig` gains `host_file` / `registry_file`. `merge_with` routes a config file's `host`/`registry` there, leaving `host`/`registry` to mean exactly "as passed on the command line". (`self` starts as the parsed command line; `other` is always a file — see `load_path_rec`.) Both new fields are `#[arg(skip)]` + `#[serde(skip)]`, so they're unreachable from a flag or a file key.
- New `resolve_target_layered(flag, file, profiles)` resolves in precedence order: **flag → workspace `default` → config file → nothing**. It leans on the existing `resolve_target(None, ..)` returning the `default` profile, so the flag and workspace-default cases collapse into one arm.
- `CliContext::init` uses it for both host and registry.

Unqualified behavior is unchanged: with no workspace in scope, a config file still supplies the host exactly as before (how `start-cli` runs outside a workspace, and on the server itself against `/etc/startos/config.yaml`). A flag naming an unknown profile still errors rather than quietly falling through to a file.

## Behavior change worth calling out

`-c <file>` is also demoted below the workspace. It's a flag that selects *a file of defaults*, and I read it as not itself asserting a host — but it is a judgment call, and the one place someone could notice a difference. Happy to special-case it if you'd rather an explicit `-c` keep flag-level precedence.

The shared `ClientConfig` also backs the `tunnelbox` / `registrybox` CLI contexts, so they pick up the same ordering. I left their changelogs alone since those track the server products; say the word if you want entries there.

## Tests

`context/config.rs` had no test module; this adds one covering the merge and all four precedence layers — including `the_workspace_default_outranks_a_config_file`, which fails on `master`.

## Verification

Formatting verified locally (`cargo +nightly fmt --check` on `start-core`, `prettier --check` on the touched markdown). **I did not compile locally** — a `start-core` build is heavyweight on my machine, so I'm leaning on CI for the typecheck and test run.

Found while diagnosing #3469 (unrelated root cause: `.local` mDNS resolution). Independent of it.

## Release

Ships as **start-cli 1.0.3** — crate version bumped, `Cargo.lock` synced, and the changelog entry promoted out of `Unreleased`.

