### PR TITLE
fix(start-sdk): make Daemons.dynamic compose with setupMain

### DIFF
--- a/projects/start-sdk/ARCHITECTURE.md
+++ b/projects/start-sdk/ARCHITECTURE.md
@@ -260,21 +260,23 @@ Features:
 
 Internally the builder is record-then-materialize: `.addDaemon()` appends a recorded entry, `Daemons.build()` walks the entries to construct `HealthDaemon`s with correct dependency wiring and runs `updateStatus()`. Side-effects start at `build()`, so the timing is identical to the prior eager builder for `setupMain` users.
 
-**`Daemons.dynamic`** makes the daemon set a reactive function of on-disk state. The builder returns a regular `Daemons.of(...).addDaemon(...)` chain; the reconciler diffs its entries against the running set on every `effects.constRetry` trigger:
+**`Daemons.dynamic`** makes the daemon set a reactive function of on-disk state. `main` is always `setupMain`; `Daemons.dynamic(effects, fn)` returns a `DaemonsReconciler` — a `T.DaemonBuildable`, exactly like a static `Daemons.of(...)` chain — which you return from `setupMain`. The builder `fn` returns a regular `Daemons.of(...).addDaemon(...)` chain; the reconciler diffs its entries against the running set on every `effects.constRetry` trigger. Inside the builder, `constRetry` is bound to a rerun-and-reconcile rather than `effects.restart()`, so a change reconciles in place and the service stays `running`:
 
 ```typescript
-export const main = sdk.Daemons.dynamic(async ({ effects }) => {
-  const { instances } = (await instancesYaml.read().const(effects)) ?? { instances: [] }
-  let daemons = sdk.Daemons.of<Manifest>({ effects })
-  for (const inst of instances) {
-    daemons = daemons.addDaemon(`reg-${inst.id}`, {
-      subcontainer: sdk.SubContainer.of(effects, { imageId: 'reg', sharedRun: true }, mounts, `reg-${inst.id}-sub`),
-      exec: { command: ['start-registryd'] },
-      ready: { display: inst.label, fn: () => sdk.healthCheck.checkPortListening(effects, inst.port, {}) },
-      requires: [],
-    })
-  }
-  return daemons
+export const main = sdk.setupMain(async ({ effects }) => {
+  return sdk.Daemons.dynamic(effects, async ({ effects }) => {
+    const { instances } = (await instancesYaml.read().const(effects)) ?? { instances: [] }
+    let daemons = sdk.Daemons.of<Manifest>({ effects })
+    for (const inst of instances) {
+      daemons = daemons.addDaemon(`reg-${inst.id}`, {
+        subcontainer: sdk.SubContainer.of(effects, { imageId: 'reg', sharedRun: true }, mounts, `reg-${inst.id}-sub`),
+        exec: { command: ['start-registryd'] },
+        ready: { display: inst.label, fn: () => sdk.healthCheck.checkPortListening(effects, inst.port, {}) },
+        requires: [],
+      })
+    }
+    return daemons
+  })
 })
 ```
 

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2.0.4 — StartOS 0.4.0-beta.10
+
+### Fixed
+
+- **`Daemons.dynamic` now composes with `setupMain` instead of replacing it.** `main` is always `sdk.setupMain(...)`; what varies is the `DaemonBuildable` you return from it — a static `sdk.Daemons.of(...)` chain, or the reconciler for a runtime-varying daemon set. The OS ABI has always said as much (`ExpectedExports.main` returns a `DaemonBuildable`, and **both** `Daemons` and `DaemonsReconciler` implement it), but two signatures made that composition unwritable: `setupMain` demanded a `Daemons` rather than the ABI's `DaemonBuildable`, and `Daemons.dynamic(fn)` returned a `main` export — burying the `DaemonsReconciler` it constructs inside a closure. The only shape that compiled was the wrong one: replace `main` with `Daemons.dynamic(...)`, then nest `Daemons.of()` inside its builder. Packages adopting dynamic daemons were funnelled straight into it. Now:
+  - **Breaking — `Daemons.dynamic` takes `effects` and returns the reconciler:** `sdk.Daemons.dynamic(effects, fn): DaemonsReconciler` (was `sdk.Daemons.dynamic(fn): main`). Return it from `setupMain`.
+  - `setupMain`'s callback is widened to the ABI: it accepts any `T.DaemonBuildable`.
+
+  Migration — wrap the builder in `setupMain` and pass `effects`:
+
+  ```typescript
+  // before (2.0.0–2.0.3)
+  export const main = sdk.Daemons.dynamic(async ({ effects }) => {
+    return sdk.Daemons.of(effects).addDaemon(...)
+  })
+
+  // after
+  export const main = sdk.setupMain(async ({ effects }) => {
+    return sdk.Daemons.dynamic(effects, async ({ effects }) => {
+      return sdk.Daemons.of(effects).addDaemon(...)
+    })
+  })
+  ```
+
+  Reconcile semantics are unchanged: inside the builder, `constRetry` reruns-and-reconciles rather than firing `effects.restart()`, so a watched-state change touches only the daemons whose `configHash` moved and the service stays `running`. Reported in [#3470](https://github.com/Start9Labs/start-technologies/issues/3470)
+
 ## 2.0.3 — StartOS 0.4.0-beta.10 (2026-07-08)
 
 ### Fixed

--- a/projects/start-sdk/docs/src/main.md
+++ b/projects/start-sdk/docs/src/main.md
@@ -51,7 +51,7 @@ export const main = sdk.setupMain(async ({ effects }) => {
 ```
 
 > [!NOTE]
-> For a daemon set that changes at runtime — one per tunnel, site, or account — use `sdk.Daemons.dynamic(async ({ effects }) => …)` as your `main` export instead of `setupMain`. It reconciles the running daemons against a freshly-built list on each config change rather than restarting all of them. See [Create Dynamic Daemons](./recipe-dynamic-daemons.md).
+> `main` is **always** `setupMain`. What you return from it is the daemon topology: the static `sdk.Daemons.of(effects)` chain above, or — for a daemon set that changes at runtime (one per tunnel, site, or account) — `return sdk.Daemons.dynamic(effects, async ({ effects }) => …)`. The reconciler diffs the running daemons against a freshly-built list on each config change instead of restarting them all, and reconciles **in place** rather than restarting the service. Both are a `DaemonBuildable`. See [Create Dynamic Daemons](./recipe-dynamic-daemons.md).
 
 ## SubContainers
 

--- a/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
+++ b/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
@@ -6,29 +6,36 @@ Some services need a variable number of daemons based on user configuration — 
 
 Read a variable-length list from a file model in `setupMain()`, then loop over entries to build the daemon chain with `.addDaemon()`. All dynamic daemons can share a single subcontainer image. The daemon ID must be unique per entry — derive it from the entry's data. An alternative approach generates dynamic config files (e.g., nginx server blocks) from the list and runs a single daemon serving all entries.
 
-Building the chain inside `setupMain` rebuilds **every** daemon whenever the list changes (a reactive `.const(effects)` read re-runs `setupMain`). When sub-instances are added, renamed, or removed at runtime and you don't want to bounce the unaffected ones, use **`sdk.Daemons.dynamic()`** instead — it reconciles the running set against a freshly-built one, touching only what actually changed.
+Returning a plain `Daemons.of(...)` chain from `setupMain` rebuilds **every** daemon whenever the list changes (a reactive `.const(effects)` read re-runs `setupMain` via `effects.restart()`). When sub-instances are added, renamed, or removed at runtime and you don't want to bounce the unaffected ones — or restart the whole service — return **`sdk.Daemons.dynamic(effects, fn)`** instead. It reconciles the running set against a freshly-built one, touching only what actually changed.
+
+> [!IMPORTANT]
+> `main` is **always** `sdk.setupMain(...)`. What varies is what you return from it: a static `sdk.Daemons.of(...)` chain, or the reconciler from `sdk.Daemons.dynamic(effects, ...)`. Both are a `DaemonBuildable`. Never use `Daemons.dynamic` _as_ your `main` export.
 
 ```typescript
 import { sdk } from './sdk'
 import { tunnelsFile } from './fileModels/tunnels.json'
 
-// `main` IS the reconciler — no `setupMain` wrapper.
-export const main = sdk.Daemons.dynamic(async ({ effects }) => {
-  // Re-runs whenever the watched file changes (a constRetry trigger).
-  const tunnels = (await tunnelsFile.read().const(effects)) ?? []
+export const main = sdk.setupMain(async ({ effects }) => {
+  // Return the reconciler — it is a DaemonBuildable, just like Daemons.of(...).
+  return sdk.Daemons.dynamic(effects, async ({ effects }) => {
+    // Re-runs whenever the watched file changes (a constRetry trigger).
+    // Inside the builder, `constRetry` reconciles in place — it does NOT
+    // restart the service.
+    const tunnels = (await tunnelsFile.read().const(effects)) ?? []
 
-  let daemons = sdk.Daemons.of(effects)
-  for (const t of tunnels) {
-    daemons = daemons.addDaemon(`tunnel-${t.id}`, {
-      // Must be a LAZY SubContainer (`.of`, not `.eager`): the reconciler
-      // rejects eager handles, and lazy ones are never materialized for
-      // daemons that diff to "leave alone".
-      subcontainer: sdk.SubContainer.of(effects, { imageId: 'tunnel' }, sdk.Mounts.of(), `tunnel-${t.id}`),
-      exec: { command: ['tunnel', '--port', String(t.port)] },
-      requires: [],
-    })
-  }
-  return daemons // return the record-mode chain — do NOT call `.build()`.
+    let daemons = sdk.Daemons.of(effects)
+    for (const t of tunnels) {
+      daemons = daemons.addDaemon(`tunnel-${t.id}`, {
+        // Must be a LAZY SubContainer (`.of`, not `.eager`): the reconciler
+        // rejects eager handles, and lazy ones are never materialized for
+        // daemons that diff to "leave alone".
+        subcontainer: sdk.SubContainer.of(effects, { imageId: 'tunnel' }, sdk.Mounts.of(), `tunnel-${t.id}`),
+        exec: { command: ['tunnel', '--port', String(t.port)] },
+        requires: [],
+      })
+    }
+    return daemons // return the record-mode chain — do NOT call `.build()`.
+  })
 })
 ```
 

--- a/projects/start-sdk/lib/StartSdk.ts
+++ b/projects/start-sdk/lib/StartSdk.ts
@@ -798,12 +798,15 @@ export class StartSdk<Manifest extends T.SDKManifest> {
        */
       setupInterfaces: setupServiceInterfaces,
       /**
-       * Define the main entrypoint for the service. The provided function should
-       * configure and return a `Daemons` instance describing all long-running processes.
-       * @param fn - Async function that receives `effects` and returns a `Daemons` instance
+       * Define the main entrypoint for the service. `main` is always `setupMain`.
+       * The provided function returns the daemon topology: either a static
+       * `sdk.Daemons.of(effects).addDaemon(...)` chain, or — for a daemon set that
+       * changes at runtime — the reconciler from
+       * `sdk.Daemons.dynamic(effects, fn)`. Both are `T.DaemonBuildable`.
+       * @param fn - Async function that receives `effects` and returns a `Daemons` chain or a `DaemonsReconciler`
        */
       setupMain: (
-        fn: (o: { effects: Effects }) => Promise<Daemons<Manifest, any>>,
+        fn: (o: { effects: Effects }) => Promise<T.DaemonBuildable>,
       ) => setupMain<Manifest>(fn),
       /**
        * Built-in trigger strategies that control how often a health check polls.
@@ -914,19 +917,25 @@ export class StartSdk<Manifest extends T.SDKManifest> {
           return Daemons.of<Manifest>({ effects })
         },
         /**
-         * Build a reactive `main` entrypoint that reconciles its daemon set
-         * against a `Daemons` chain on every `effects.constRetry` trigger.
-         * See {@link Daemons.dynamic} for diff semantics and the rule that
-         * `fn`'s subcontainers must be lazy (`sdk.SubContainer.of(...)`).
+         * Build a reconciler whose daemon set is a function of on-disk state:
+         * it diffs `fn`'s freshly-built `Daemons` chain against the running set
+         * on every `effects.constRetry` trigger, touching only what changed.
          *
+         * Return it from `setupMain` — it is a `T.DaemonBuildable`, just like a
+         * static `sdk.Daemons.of(...)` chain. See {@link Daemons.dynamic} for
+         * diff semantics and the rule that `fn`'s subcontainers must be lazy
+         * (`sdk.SubContainer.of(...)`).
+         *
+         * @param effects The effects context, from `setupMain`
          * @param fn Async builder invoked on startup and on every constRetry
          */
         dynamic(
+          effects: Effects,
           fn: (o: {
             effects: Effects
           }) => Promise<Daemons<Manifest, any>> | Daemons<Manifest, any>,
         ) {
-          return Daemons.dynamic<Manifest>(fn)
+          return Daemons.dynamic<Manifest>(effects, fn)
         },
       },
       SubContainer: {

--- a/projects/start-sdk/lib/mainFn/Daemons.ts
+++ b/projects/start-sdk/lib/mainFn/Daemons.ts
@@ -316,13 +316,27 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    * re-runs that diff to "leave alone"; the reconciler throws at hash time
    * if it sees one.
    *
+   * Return the result from `setupMain` — it is a {@link T.DaemonBuildable},
+   * exactly like a static `Daemons.of(...)` chain:
+   *
+   * ```typescript
+   * export const main = sdk.setupMain(async ({ effects }) => {
+   *   return sdk.Daemons.dynamic(effects, async ({ effects }) => {
+   *     const sites = await storeJson.read((s) => s.sites).const(effects)
+   *     return sdk.Daemons.of(effects).addDaemon(...)
+   *   })
+   * })
+   * ```
+   *
+   * @param effects The effects context, from `setupMain`
    * @param fn Async builder invoked on startup and on every `constRetry`. Must return a `Daemons` in record-mode (not pre-`build()`-ed)
-   * @returns A `main` export compatible with `T.ExpectedExports.main`
+   * @returns A {@link DaemonsReconciler} — a `T.DaemonBuildable` to return from `setupMain`
    */
   static dynamic<Manifest extends T.SDKManifest>(
+    effects: T.Effects,
     fn: DaemonsBuilder<Manifest>,
-  ): T.ExpectedExports.main {
-    return async ({ effects }) => new DaemonsReconciler<Manifest>(effects, fn)
+  ): DaemonsReconciler<Manifest> {
+    return new DaemonsReconciler<Manifest>(effects, fn)
   }
 
   private appendEntry(entry: DaemonEntry<Manifest>): Daemons<Manifest, any> {

--- a/projects/start-sdk/lib/mainFn/index.ts
+++ b/projects/start-sdk/lib/mainFn/index.ts
@@ -1,5 +1,4 @@
 import * as T from '@start9labs/start-core/types'
-import { Daemons } from './Daemons'
 import '@start9labs/start-core/interfaces/ServiceInterfaceBuilder'
 import '@start9labs/start-core/interfaces/Origin'
 
@@ -12,11 +11,16 @@ export const DEFAULT_SIGTERM_TIMEOUT = 60_000
  * 2. We setup all the commands to setup the system
  * 3. We create the health checks
  * 4. We setup the daemons init system
+ *
+ * `fn` returns any {@link T.DaemonBuildable} — a static `Daemons.of(...)` chain,
+ * or the reconciler from `Daemons.dynamic(effects, ...)` for a daemon set that
+ * changes at runtime. `main` is always `setupMain`; the choice of static vs
+ * reactive is what you return from it.
  * @param fn
  * @returns
  */
 export const setupMain = <Manifest extends T.SDKManifest>(
-  fn: (o: { effects: T.Effects }) => Promise<Daemons<Manifest, any>>,
+  fn: (o: { effects: T.Effects }) => Promise<T.DaemonBuildable>,
 ): T.ExpectedExports.main => {
   return async options => {
     const result = await fn(options)

--- a/projects/start-sdk/lib/test/Daemons.test.ts
+++ b/projects/start-sdk/lib/test/Daemons.test.ts
@@ -1,6 +1,7 @@
-import { Daemons, configHash } from '../mainFn/Daemons'
+import { Daemons, DaemonsReconciler, configHash } from '../mainFn/Daemons'
 import { Daemon } from '../mainFn/Daemon'
 import { Mounts } from '../mainFn/Mounts'
+import { setupMain } from '../mainFn'
 import { SubContainer } from '../util/SubContainer'
 import * as T from '@start9labs/start-core/types'
 
@@ -398,5 +399,49 @@ describe('SubContainer.of (lazy) identity', () => {
     const a = SubContainer.of<Manifest>(e, { imageId: 'reg' }, null, 'name')
     const b = SubContainer.of<Manifest>(e, { imageId: 'reg' }, null, 'name')
     expect(a.identity).not.toBe(b.identity)
+  })
+})
+
+// `main` is always `setupMain`; what varies is the `DaemonBuildable` returned
+// from it. Nothing exercised that composition before, which is how
+// `Daemons.dynamic` shipped returning a `main` export instead of the
+// reconciler — making the correct shape unwritable and funnelling packages into
+// replacing `main` with it. These lock the contract. See #3470.
+describe('setupMain composition', () => {
+  const builder = ({ effects }: { effects: T.Effects }) =>
+    Daemons.of<Manifest>({ effects }).addDaemon('reg', {
+      subcontainer: lazy(effects),
+      exec: { command: ['start-registryd'] },
+      ready: baseReady,
+      requires: [],
+    })
+
+  it('Daemons.dynamic returns a DaemonsReconciler, not a main export', () => {
+    const e = fakeEffects()
+    const reconciler = Daemons.dynamic<Manifest>(e, builder)
+    expect(reconciler).toBeInstanceOf(DaemonsReconciler)
+    // A DaemonBuildable — the same shape `Daemons.of(...)` satisfies.
+    expect(typeof reconciler.build).toBe('function')
+    expect(typeof (Daemons.of<Manifest>({ effects: e }) as any).build).toBe(
+      'function',
+    )
+  })
+
+  it('setupMain accepts a static Daemons chain', async () => {
+    const e = fakeEffects()
+    const main = setupMain<Manifest>(async ({ effects }) =>
+      builder({ effects }),
+    )
+    const built = await main({ effects: e } as any)
+    expect(built).toBeInstanceOf(Daemons)
+  })
+
+  it('setupMain accepts a Daemons.dynamic reconciler', async () => {
+    const e = fakeEffects()
+    const main = setupMain<Manifest>(async ({ effects }) =>
+      Daemons.dynamic<Manifest>(effects, builder),
+    )
+    const built = await main({ effects: e } as any)
+    expect(built).toBeInstanceOf(DaemonsReconciler)
   })
 })

--- a/projects/start-sdk/package-lock.json
+++ b/projects/start-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",

--- a/projects/start-sdk/package.json
+++ b/projects/start-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Fixes #3470 — the API correction dr-bonez approved ("Proposed fix is correct, ship as a patch").

## The problem

`main` is always `sdk.setupMain(...)`; what varies is the `DaemonBuildable` you return from it — a static `Daemons.of(...)` chain, or the reconciler for a runtime-varying daemon set. The ABI has always said exactly that:

- `ExpectedExports.main` returns a `DaemonBuildable` (`shared-libs/ts-modules/start-core/lib/types.ts:60`)
- **both** `Daemons` and `DaemonsReconciler` `implements T.DaemonBuildable`

But two signatures made that composition unwritable:

1. **`setupMain` was typed narrower than the ABI** — it demanded a `Daemons`, so it could not accept a reconciler.
2. **`Daemons.dynamic(fn)` returned a `main` export** — burying the `DaemonsReconciler` it constructs inside a closure.

So the only shape that compiled was the wrong one: replace `main` with `Daemons.dynamic(...)`, then nest `Daemons.of()` inside its builder. Every package reaching for dynamic daemons got funnelled straight into it — and the recipe docs taught it outright (`// \`main\` IS the reconciler — no \`setupMain\` wrapper.`).

## The change

- **Breaking:** `sdk.Daemons.dynamic(effects, fn)` now returns a `DaemonsReconciler` (was `sdk.Daemons.dynamic(fn)` returning a `main`). Return it from `setupMain`.
- `setupMain`'s callback is widened to the ABI: it accepts any `T.DaemonBuildable`.
- Fixed the pattern in `docs/src/main.md`, `docs/src/recipe-dynamic-daemons.md`, and `ARCHITECTURE.md`.
- SDK `2.0.3` → `2.0.4` + CHANGELOG entry.

Migration:

```typescript
// before (2.0.0–2.0.3)
export const main = sdk.Daemons.dynamic(async ({ effects }) => {
  return sdk.Daemons.of(effects).addDaemon(...)
})

// after
export const main = sdk.setupMain(async ({ effects }) => {
  return sdk.Daemons.dynamic(effects, async ({ effects }) => {
    return sdk.Daemons.of(effects).addDaemon(...)
  })
})
```

Reconcile semantics are unchanged: inside the builder, `constRetry` reruns-and-reconciles rather than firing `effects.restart()`, so a watched-state change touches only the daemons whose `configHash` moved and the service stays `running`.

## Verification

`tsc --noEmit` clean; jest 77/77 passing; `make start-sdk-format` clean.

## Follow-up (not in this PR)

Packages on `next` that adopted the old shape need the migration once this publishes — known: `coturn-startos` (unmerged PR, carries a `TODO.md` for it), and `start9-pages-startos` / `holesail-startos` should be checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
