### PR TITLE
fix(cli): resolve .local hosts via the system resolver

### DIFF
--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -15,6 +15,16 @@ or the CLI's externally observable behavior.
 
 ### Fixed
 
+- **`.local` (mDNS) hostnames resolve again.** Every command against a `.local` address — the
+  way most people reach their server — failed after ~5s with an opaque
+  `error sending request for url (...)`, while `curl` against the same URL succeeded instantly.
+  `start-cli` ships as a statically linked musl binary, and musl's `getaddrinfo` implements no
+  NSS: it ignores `/etc/nsswitch.conf`, so `mdns4_minimal` is never consulted and the lookup
+  falls through to unicast DNS, which dies on musl's hard-coded 5s timeout. A `.local` host is
+  now resolved through the system resolver (`getent`, the same path `curl` takes) when the
+  client context is built, so the HTTP client and the log/progress websockets alike are handed
+  an address. Linux only — macOS resolves `.local` natively. (#3469)
+
 - **An ambient config file no longer shadows the workspace `.startos/config.yaml`.**
   `host`/`registry` set in `~/.startos/config.yaml` or `/etc/startos/config.yaml` was merged into
   the same field as an explicit `-H`/`-r`, so it silently outranked the workspace's `default`

--- a/shared-libs/crates/start-core/src/context/cli.rs
+++ b/shared-libs/crates/start-core/src/context/cli.rs
@@ -28,6 +28,7 @@ use crate::context::config::{
 use crate::context::{DiagnosticContext, InitContext, RpcContext, SetupContext};
 use crate::developer::{OS_DEVELOPER_KEY_PATH, default_developer_key_path, load_signing_key};
 use crate::middleware::auth::local::LocalAuthContext;
+use crate::net::mdns::pin_mdns_host;
 use crate::prelude::*;
 use crate::rpc_continuations::Guid;
 use crate::s9pk::init::{BUILD_KEY_FILE, STARTOS_DIR};
@@ -137,6 +138,9 @@ impl CliContext {
             Some(url) => url,
             None => "http://localhost".parse()?,
         };
+        // Before anything derives a URL from this one: a `.local` host is unresolvable from a
+        // musl-static binary, so pin it to an address the system resolver found.
+        pin_mdns_host(&mut url)?;
 
         let registry = resolve_target_layered(
             config.registry.as_deref(),
@@ -176,6 +180,7 @@ impl CliContext {
             },
             registry_url: registry
                 .map(|mut registry| {
+                    pin_mdns_host(&mut registry)?;
                     registry
                         .path_segments_mut()
                         .map_err(|_| eyre!("Url cannot be base"))

--- a/shared-libs/crates/start-core/src/net/mdns.rs
+++ b/shared-libs/crates/start-core/src/net/mdns.rs
@@ -1,10 +1,79 @@
 use std::net::Ipv4Addr;
 
 use color_eyre::eyre::eyre;
+use reqwest::Url;
 use tokio::process::Command;
 
 use crate::prelude::*;
 use crate::util::Invoke;
+
+/// BLOCKING. Point a `*.local` URL at its resolved address, leaving every other URL alone.
+///
+/// Our binaries are statically linked against musl, whose `getaddrinfo` implements no NSS:
+/// `/etc/nsswitch.conf` is ignored, so `mdns4_minimal` is never consulted and a `.local` name
+/// cannot be resolved in-process. The lookup falls through to unicast DNS and dies after musl's
+/// hard-coded 5s timeout, which is why `curl` resolves a name that `start-cli` cannot.
+///
+/// Rewriting the URL once here, at context build, means every consumer downstream — the HTTP
+/// client and the websocket path alike — is handed an address rather than a name. The server's
+/// cert carries IP SANs (see [`crate::net::ssl`]), so TLS still verifies.
+#[cfg(target_os = "linux")]
+pub fn pin_mdns_host(url: &mut Url) -> Result<(), Error> {
+    let Some(hostname) = url
+        .host_str()
+        .map(|host| host.trim_end_matches('.').to_owned())
+        .filter(|host| host.ends_with(".local"))
+    else {
+        return Ok(());
+    };
+    let ip = resolve_system(&hostname)?;
+    url.set_ip_host(ip).map_err(|_| {
+        Error::new(
+            eyre!("Cannot point url at resolved address {ip}"),
+            crate::ErrorKind::ParseUrl,
+        )
+    })
+}
+
+/// darwin's `getaddrinfo` resolves `.local` through mDNSResponder natively, so there is nothing
+/// to work around: the binary is linked against the system libc, not musl.
+#[cfg(not(target_os = "linux"))]
+pub fn pin_mdns_host(_url: &mut Url) -> Result<(), Error> {
+    Ok(())
+}
+
+/// BLOCKING. Resolve a hostname through the *system* resolver by shelling out to `getent`.
+///
+/// `getent` is a separate, dynamically linked binary, so it goes through the host's real NSS
+/// stack — exactly the path `curl` and `ping` take — and honors whatever that machine is
+/// configured for: mDNS, `/etc/hosts`, LDAP. Unlike [`resolve_mdns`] it needs nothing installed
+/// beyond libc; `avahi-resolve-host-name` lives in `avahi-utils`, which mDNS on Linux does not
+/// depend on and which most desktops don't have.
+#[cfg(target_os = "linux")]
+fn resolve_system(hostname: &str) -> Result<std::net::IpAddr, Error> {
+    let unresolved = || {
+        Error::new(
+            eyre!("Failed to resolve hostname: {hostname}"),
+            crate::ErrorKind::Network,
+        )
+    };
+    let output = std::process::Command::new("getent")
+        .arg("ahosts")
+        .arg(hostname)
+        .output()
+        .with_ctx(|_| (crate::ErrorKind::Network, "getent ahosts"))?;
+    if !output.status.success() {
+        return Err(unresolved());
+    }
+    // One line per socket type, address first — take whichever the resolver preferred:
+    //     192.168.8.170   STREAM demo.local
+    //     192.168.8.170   DGRAM
+    String::from_utf8(output.stdout)?
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .find_map(|addr| addr.parse().ok())
+        .ok_or_else(unresolved)
+}
 
 pub async fn resolve_mdns(hostname: &str) -> Result<Ipv4Addr, Error> {
     Ok(String::from_utf8(


### PR DESCRIPTION
Fixes #3469. Stacked on #3471 (both touch `context/cli.rs` and the 1.0.3 changelog) — **base will retarget to `master` once #3471 merges**; review just the top commit.

## What was wrong

`start-cli` ships as a **statically linked musl** binary, and musl's `getaddrinfo` implements no NSS: it ignores `/etc/nsswitch.conf`, so `mdns4_minimal` is never consulted. A `.local` name is therefore unresolvable in-process — the lookup falls through to unicast DNS, which SERVFAILs, and musl retries until its hard-coded **5s** budget expires. That's the whole bug: `curl` resolves a name `start-cli` cannot, and the only lookup path musl *does* have is `/etc/hosts`, which is why the `/etc/hosts` workaround in the report worked.

## The fix

As you asked: `getent`, at the context build stage.

`pin_mdns_host` rewrites a `*.local` URL to its resolved address in `CliContext::init`, before anything derives a URL from it. That's what makes tokio-tungstenite a non-issue — `base_url` is already an address by the time `ws_continuation` clones it, so `logs -f` and install progress are covered without touching the websocket path at all. Applied to the registry URL too, since a LAN registry has the identical bug.

Resolution shells out to **`getent ahosts`**: a separate, dynamically linked binary, so it goes through the host's real NSS stack — precisely the path `curl` takes — and honors whatever the machine is configured for (mDNS, `/etc/hosts`, LDAP). Linux only; darwin resolves `.local` via mDNSResponder natively, so the non-linux `pin_mdns_host` is a no-op.

TLS is unaffected: StartOS certs carry IP SANs (`san.ip(..)`, `net/ssl.rs:474`), verified empirically — `-H https://192.168.8.170` validates and reaches the server.

## Why not `resolve_mdns` / avahi

The existing helper shells out to `avahi-resolve-host-name`, which lives in **`avahi-utils`** — a package Linux mDNS does not depend on. `libnss-mdns` only *Recommends* `avahi-daemon`; nothing pulls in the CLI tools. On my Ubuntu box `.local` resolves fine via `getent`/`curl`/`ping` and `avahi-resolve-host-name` **is not installed**. It works on StartOS (which bundles avahi) — which is where `resolve_mdns` is called from today (SOCKS, CIFS) — but `start-cli` runs on laptops. Left that function untouched for its server-side callers.

## Verification

`getent` semantics confirmed against the real box: success prints the address as the first token (`192.168.8.170   STREAM demo.local`, exit 0); an unresolvable name exits 2, so we surface "Failed to resolve hostname" instead of hanging.

**Not yet exercised end-to-end** — a `start-cli` build is heavy on my machine and CI can't test this anyway (no mDNS responder on a runner). I'll build and confirm against `demo.local` before this merges; happy to paste the before/after.