### PR TITLE
fix(exver): compare downstream revision when ordering version range points

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.5 — StartOS 0.4.0-beta.10 (2026-07-13)
+
+### Fixed
+
+- **ExVer range operations no longer ignore the downstream revision.** `compareVersionRangePoints` and `adjacentVersionRangePoints` compared the upstream version twice instead of comparing the downstream on the second pass, so two points that shared an upstream but differed in downstream (`1.0.0:3` vs `1.0.0:15`) collapsed into a single point. Everything built on the truth tables inherited the error — `normalize()` silently dropped the lower of the two, and `intersects()` / `satisfiable()` could answer on a merged point. `=1.0.0:0 || =1.0.0:1` normalized to `=1.0.0:1`.
+
+  The visible consequence was in packed manifests: `canMigrateFrom` / `canMigrateTo` are derived from the version graph and normalized, so any package declaring an `other` version sharing `current`'s upstream advertised a range narrower than the truth (`mempool` at `3.3.1:15` with `other: [3.3.1:3]` shipped `canMigrateFrom: <=3.3.1:3` rather than `<=3.3.1:15`). No upgrade actually broke — StartOS resolves migrations through the version graph rather than gating on this field, and the registry index does not yet populate `sourceVersion` from it — but the manifests were wrong and would have become load-bearing the moment either changed. The Rust implementation derives its point ordering and was never affected.
+
 ## 2.0.4 — StartOS 0.4.0-beta.10
 
 ### Fixed

--- a/projects/start-sdk/docs/src/agent-context.md
+++ b/projects/start-sdk/docs/src/agent-context.md
@@ -110,7 +110,7 @@ The full rules are in `start-technologies/projects/start-sdk/docs/src/workflow.m
 - **Keep `README.md` and `instructions.md` in sync.** `README.md` tracks architecture/behavior (for developers and AI); `instructions.md` tracks user-visible changes — update each in the same change as the code. Content rules: `writing-readmes.md`, `writing-instructions.md`.
 - **Iterate with a dirty tree; commit once.** The `-modified` pack-hash suffix is informational — don't commit between test attempts. One clean commit when the package works; `git reset --soft HEAD~N` collapses accumulated fixups.
 - **Pre-existing errors are still errors.** A red `tsc`, test, or pack step means the package doesn't pass, even if unrelated to your change. Fix it or flag it; never report green when a check was red.
-- **Don't create unnecessary version files.** The latest version always lives in `startos/versions/current.ts`; most bumps just edit that file in place. A new file is spun off only when the bump carries a migration. See `versions.md` (When to Create a New Version File, Release Notes).
+- **Don't create unnecessary version files.** The latest version always lives in `startos/versions/current.ts`; most bumps just edit that file in place. A new file is spun off only when the bump carries a migration — **a version having been released is not a reason to declare it.** `VersionGraph` synthesizes a range vertex beneath `current`, so any lower installed version migrates up in one hop without its own node; `canMigrateFrom` is derived from that graph, not authored. See `versions.md` (When to Create a New Version File, Why Released Versions Don't Need to Be Declared, Release Notes).
 
 ## Starting a new package
 

--- a/projects/start-sdk/docs/src/versions.md
+++ b/projects/start-sdk/docs/src/versions.md
@@ -146,6 +146,27 @@ The deciding question is **does this bump need a migration?**
 
 This keeps `versions/` lean: only versions that a migration upgrades _from_ survive as their own files; everything else is just the latest state of `current.ts`.
 
+### Why Released Versions Don't Need to Be Declared
+
+A released version is **not** a reason to add it to `other`. Only a migration is. This trips people up, so here is the mechanism.
+
+`VersionGraph` does not only add a vertex per version you declare. For every version whose `up` is not `IMPOSSIBLE`, it also synthesizes a **range vertex** — an edge _into_ that version, covering the whole gap beneath it (`<X` if it is the lowest declared version, otherwise `>=prev && <X`). A package with `other: []` and `current` at `1.0.0:3` therefore has a graph of exactly two vertices:
+
+```
+<1.0.0:3  --[up]-->  1.0.0:3
+```
+
+Any installed version below `current` falls inside that range and migrates to `current` **in a single hop**, running `current`'s `up` migration once. This holds whether or not that version was ever declared, and whether or not it was ever released — including versions you shipped as sideloadable `.s9pk`s outside a registry. Most packages in the Start9 registry carry `other: []` and have upgraded across dozens of downstream revisions on exactly this path.
+
+A version earns a declared node **only** when it has its own migration that must run in sequence on the way up. Declaring migration-less versions adds files that must be read, kept compiling, and reasoned about forever, and buys no behavior. Don't do it to record release history — git history of `current.ts` already is that record.
+
+> [!NOTE]
+> A corollary: to make an update reachable for users on a version you shipped elsewhere, you only need `current`'s version string to sort _above_ theirs. You do not need to declare the intervening revisions.
+
+### canMigrateFrom Is Derived, Not Curated
+
+The manifest's `canMigrateFrom` / `canMigrateTo` fields are **computed from the graph** — a reverse/forward search from `current`, which `setupManifest` serializes into the manifest at pack time. They are not something you author, and not something the `other` array exists to feed. Adding versions to `other` to "widen" them is a misconception: `other: []` already yields the widest possible range (`<=current`), via the range vertex above.
+
 ### Upstream Update
 
 When the upstream project releases a new version:

--- a/projects/start-sdk/package-lock.json
+++ b/projects/start-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",

--- a/projects/start-sdk/package.json
+++ b/projects/start-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/shared-libs/ts-modules/start-core/lib/exver/index.ts
+++ b/shared-libs/ts-modules/start-core/lib/exver/index.ts
@@ -191,7 +191,7 @@ function compareVersionRangePoints(
   if (up != 0) {
     return up
   }
-  let down = a.upstream.compareForSort(b.upstream)
+  let down = a.downstream.compareForSort(b.downstream)
   if (down != 0) {
     return down
   }
@@ -212,7 +212,7 @@ function adjacentVersionRangePoints(
   if (up != 0) {
     return false
   }
-  let down = a.upstream.compareForSort(b.upstream)
+  let down = a.downstream.compareForSort(b.downstream)
   if (down != 0) {
     return false
   }

--- a/shared-libs/ts-modules/start-core/lib/test/exver.test.ts
+++ b/shared-libs/ts-modules/start-core/lib/test/exver.test.ts
@@ -420,4 +420,41 @@ describe('ExVer', () => {
       })
     }
   }
+
+  // `tables()` distinguishes points by (upstream, downstream, side). Ranges that
+  // differ only in the downstream revision are the case that regressed: they
+  // collapsed into one another, so `normalize()` silently dropped the lower.
+  describe('downstream revisions are distinct points', () => {
+    const eq = (v: string) => VersionRange.anchor('=', ExtendedVersion.parse(v))
+
+    test('normalize preserves a union of same-upstream downstream revisions', () => {
+      const union = eq('1.0.0:0').or(eq('1.0.0:1')).normalize()
+
+      expect(union.satisfiedBy(ExtendedVersion.parse('1.0.0:0'))).toEqual(true)
+      expect(union.satisfiedBy(ExtendedVersion.parse('1.0.0:1'))).toEqual(true)
+      expect(union.satisfiedBy(ExtendedVersion.parse('1.0.0:2'))).toEqual(false)
+    })
+
+    test('normalize preserves the whole span below a downstream revision', () => {
+      // The shape a VersionGraph produces for `other: [1.0.0:3]`, current 1.0.0:15.
+      const reachable = VersionRange.none()
+        .or(eq('1.0.0:15'))
+        .or(
+          VersionRange.anchor('>=', ExtendedVersion.parse('1.0.0:3')).and(
+            VersionRange.anchor('<', ExtendedVersion.parse('1.0.0:15')),
+          ),
+        )
+        .or(eq('1.0.0:3'))
+        .or(VersionRange.anchor('<', ExtendedVersion.parse('1.0.0:3')))
+        .normalize()
+
+      for (const v of ['1.0.0:0', '1.0.0:3', '1.0.0:4', '1.0.0:14', '1.0.0:15'])
+        expect(reachable.satisfiedBy(ExtendedVersion.parse(v))).toEqual(true)
+    })
+
+    test('intersects distinguishes downstream revisions', () => {
+      expect(eq('1.0.0:0').intersects(eq('1.0.0:1'))).toEqual(false)
+      expect(eq('1.0.0:1').intersects(eq('1.0.0:1'))).toEqual(true)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

`compareVersionRangePoints` and `adjacentVersionRangePoints` each compared the **upstream** version twice instead of comparing the **downstream** on the second pass:

```ts
let up = a.upstream.compareForSort(b.upstream)
if (up != 0) return up
let down = a.upstream.compareForSort(b.upstream)   // ← downstream never compared
```

So two points sharing an upstream but differing in downstream (`1.0.0:3` vs `1.0.0:15`) compared equal, and `zip` merged them. Everything built on the truth tables inherited it: `normalize()` silently dropped the lower point, and `intersects()` / `satisfiable()` could answer on a merged one. Minimal case — `=1.0.0:0 || =1.0.0:1` normalizes to `=1.0.0:1`, which `1.0.0:0` no longer satisfies.

The visible consequence is in packed manifests. `canMigrateFrom` / `canMigrateTo` are derived from the version graph and normalized before `setupManifest` serializes them, so **any package declaring an `other` version that shares `current`'s upstream advertises a range narrower than the truth.** `mempool-startos` (`current 3.3.1:15`, `other: [3.3.1:3]`) ships `canMigrateFrom: <=3.3.1:3` today; it should be `<=3.3.1:15`.

**No upgrade actually broke**, for three independent reasons — stating them so the severity is clear:

1. StartOS resolves migrations through the version graph's shortest path, not by gating on this field (`service_map.rs` uses it only to pick the outgoing package's uninit target).
2. The registry index sets `source_version: None, // TODO` (`registry/package/index.rs:155`), so the UI's reachability filter sees `*`.
3. The convention — `other: []` unless a version carries a migration — keeps almost every package off the affected code path entirely.

But the manifests were wrong, and this becomes load-bearing the moment (1) or (2) changes. The Rust implementation derives `Ord` on `Point { upstream, downstream, side }` and was never affected; this is TypeScript-only.

## Also

The packaging guide stated the "only spin off a version file when the bump carries a migration" rule without ever justifying it, so packagers reasonably conclude that a *released* version must be declared in `other`. (This came up on a live community PR.) The second commit documents the actual mechanism — `VersionGraph` synthesizes a range vertex beneath `current`, so any lower installed version migrates up in one hop without its own node — and that `canMigrateFrom` is derived rather than authored.

## Verification

- Three regression tests added to `exver.test.ts`. Confirmed all three **fail** without the fix and pass with it, and that no existing test depended on the broken behavior (the 51 existing tests pass either way).
- Full `start-core` TS suite green: 86 passed, 9 skipped.
- Rebuilt `start-core` and re-derived the real graphs against the built output: `mempool` now yields `<=3.3.1:15`.

SDK bumped to 2.0.5 with a changelog entry (2.0.4 is published as npm `latest`), since the fix only reaches packagers via the bundled `dist/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)