### PR TITLE
fix(start-sdk): don't publish a stale dist or leak the file: link into the tarball

### DIFF
--- a/projects/start-sdk/Makefile
+++ b/projects/start-sdk/Makefile
@@ -3,16 +3,17 @@ START_CORE := ../../shared-libs/ts-modules/start-core
 START_CORE_DIST := $(START_CORE)/dist
 START_CORE_SRC := $(shell git ls-files $(START_CORE)/lib) $(START_CORE)/package.json
 
-.PHONY: all test clean clean-dist bundle fmt check-fmt check publish link node_modules
+.DELETE_ON_ERROR:
+
+.PHONY: all test clean bundle fmt check-fmt check publish link
 
 all: bundle
 
-# start-core is an external dependency now: the SDK imports it and bundles its
-# built lib into the published dist so external authors still install one package.
-# Prerequisites matter here: with none, this only fired when start-core/dist was
-# *missing*, leaving the SDK's dist stale against a rebuilt start-core.
+# Prereqs so a rebuilt start-core restales the SDK dist; touch after because start-core's
+# build regenerates a tracked source (exver.ts) without bumping dist (else it rebuilds every time).
 $(START_CORE_DIST)/package.json: $(START_CORE_SRC)
 	$(MAKE) -C $(START_CORE) dist
+	touch $(START_CORE_DIST)/package.json
 
 test: node_modules
 	npm test
@@ -20,27 +21,24 @@ test: node_modules
 clean:
 	rm -rf dist node_modules lib/test/output.ts
 
-clean-dist:
-	rm -rf dist
-
 # Build artifacts only — verification (test/check-fmt) is intentionally NOT a
 # prerequisite so consumers (the OS build) don't re-run the jest suite every
 # build. CI and `publish` run test/check-fmt explicitly.
-bundle: dist
-	touch dist
+bundle: dist/package.json
 
-dist: $(TS_FILES) package.json .npmignore node_modules README.md LICENSE CHANGELOG.md s9pk.mk tsconfig.base.json eslint.config.base.mjs lint.mjs $(START_CORE_DIST)/package.json
+# The sentinel is dist/package.json, not the dist/ dir: make can't see content
+# changes under a directory target, so a stale dist/ once published 2.0.5 as 2.0.4.
+dist/package.json: $(TS_FILES) package.json .npmignore node_modules README.md LICENSE CHANGELOG.md s9pk.mk tsconfig.base.json eslint.config.base.mjs lint.mjs $(START_CORE_DIST)/package.json
 	rm -rf dist
 	npm run tsc
-	rsync -ac node_modules dist/
+	# Don't stage npm's hidden lockfile: it pins start-core to an out-of-tree path.
+	rsync -ac --exclude=.package-lock.json node_modules dist/
 	rm -rf dist/node_modules/@start9labs/start-core
 	mkdir -p dist/node_modules/@start9labs
 	rsync -aL $(START_CORE_DIST)/ dist/node_modules/@start9labs/start-core/
-	# The hidden lockfile rsync'd in above records start-core as a `file:` link out to
-	# shared-libs, so `npm publish` resolves the bundled dep through it and emits paths
-	# outside the package root (npm E415) despite the real files being right here.
-	rm -f dist/node_modules/.package-lock.json
-	cp package.json dist/package.json
+	# Point the bundled dep at its in-tarball copy so npm never resolves start-core
+	# out of tree (the source spec is a file: link out to shared-libs).
+	node -e "const fs=require('fs'),d=JSON.parse(fs.readFileSync('package.json','utf8'));d.dependencies['@start9labs/start-core']='file:./node_modules/@start9labs/start-core';fs.writeFileSync('dist/package.json',JSON.stringify(d,null,2)+'\n')"
 	cp .npmignore dist/.npmignore
 	cp README.md dist/README.md
 	cp LICENSE dist/LICENSE
@@ -49,7 +47,7 @@ dist: $(TS_FILES) package.json .npmignore node_modules README.md LICENSE CHANGEL
 	cp tsconfig.base.json dist/tsconfig.base.json
 	cp eslint.config.base.mjs dist/eslint.config.base.mjs
 	cp lint.mjs dist/lint.mjs
-	touch dist
+	touch dist/package.json
 
 full-bundle: bundle
 
@@ -62,18 +60,18 @@ fmt: node_modules
 check-fmt: node_modules
 	npx prettier "**/*.ts" --check
 
+# Touch after install: npm may leave these no newer than their prereqs, so without
+# it make reruns npm every build (node_modules was also .PHONY, forcing npm ci always).
 package-lock.json: package.json $(START_CORE_DIST)/package.json
 	npm i
+	touch package-lock.json
 
 node_modules: package-lock.json $(START_CORE_DIST)/package.json
 	npm ci
+	touch node_modules
 
-# Rebuild dist from scratch: it is a directory target, so make's staleness check
-# does not track its contents, and a stale dist packed 2.0.5 as 2.0.4.
 # Prompt for the npm 2FA OTP here (after the build) so it can't expire; OTP=… skips.
-publish: test check-fmt package.json README.md LICENSE CHANGELOG.md
-	$(MAKE) clean-dist
-	$(MAKE) bundle
+publish: bundle test check-fmt package.json README.md LICENSE CHANGELOG.md
 	@otp='$(OTP)'; \
 	if [ -z "$$otp" ] && [ -t 0 ]; then \
 		printf 'npm one-time password (OTP): ' >&2; \

--- a/projects/start-sdk/Makefile
+++ b/projects/start-sdk/Makefile
@@ -38,7 +38,7 @@ dist/package.json: $(TS_FILES) package.json .npmignore node_modules README.md LI
 	rsync -aL $(START_CORE_DIST)/ dist/node_modules/@start9labs/start-core/
 	# Point the bundled dep at its in-tarball copy so npm never resolves start-core
 	# out of tree (the source spec is a file: link out to shared-libs).
-	node -e "const fs=require('fs'),d=JSON.parse(fs.readFileSync('package.json','utf8'));d.dependencies['@start9labs/start-core']='file:./node_modules/@start9labs/start-core';fs.writeFileSync('dist/package.json',JSON.stringify(d,null,2)+'\n')"
+	jq '.dependencies["@start9labs/start-core"]="file:./node_modules/@start9labs/start-core"' package.json > dist/package.json
 	cp .npmignore dist/.npmignore
 	cp README.md dist/README.md
 	cp LICENSE dist/LICENSE

--- a/projects/start-sdk/Makefile
+++ b/projects/start-sdk/Makefile
@@ -1,14 +1,17 @@
 TS_FILES := $(shell git ls-files lib)
 START_CORE := ../../shared-libs/ts-modules/start-core
 START_CORE_DIST := $(START_CORE)/dist
+START_CORE_SRC := $(shell git ls-files $(START_CORE)/lib) $(START_CORE)/package.json
 
-.PHONY: all test clean bundle fmt check-fmt check publish link node_modules
+.PHONY: all test clean clean-dist bundle fmt check-fmt check publish link node_modules
 
 all: bundle
 
 # start-core is an external dependency now: the SDK imports it and bundles its
 # built lib into the published dist so external authors still install one package.
-$(START_CORE_DIST)/package.json:
+# Prerequisites matter here: with none, this only fired when start-core/dist was
+# *missing*, leaving the SDK's dist stale against a rebuilt start-core.
+$(START_CORE_DIST)/package.json: $(START_CORE_SRC)
 	$(MAKE) -C $(START_CORE) dist
 
 test: node_modules
@@ -16,6 +19,9 @@ test: node_modules
 
 clean:
 	rm -rf dist node_modules lib/test/output.ts
+
+clean-dist:
+	rm -rf dist
 
 # Build artifacts only — verification (test/check-fmt) is intentionally NOT a
 # prerequisite so consumers (the OS build) don't re-run the jest suite every
@@ -30,6 +36,10 @@ dist: $(TS_FILES) package.json .npmignore node_modules README.md LICENSE CHANGEL
 	rm -rf dist/node_modules/@start9labs/start-core
 	mkdir -p dist/node_modules/@start9labs
 	rsync -aL $(START_CORE_DIST)/ dist/node_modules/@start9labs/start-core/
+	# The hidden lockfile rsync'd in above records start-core as a `file:` link out to
+	# shared-libs, so `npm publish` resolves the bundled dep through it and emits paths
+	# outside the package root (npm E415) despite the real files being right here.
+	rm -f dist/node_modules/.package-lock.json
 	cp package.json dist/package.json
 	cp .npmignore dist/.npmignore
 	cp README.md dist/README.md
@@ -58,8 +68,12 @@ package-lock.json: package.json $(START_CORE_DIST)/package.json
 node_modules: package-lock.json $(START_CORE_DIST)/package.json
 	npm ci
 
+# Rebuild dist from scratch: it is a directory target, so make's staleness check
+# does not track its contents, and a stale dist packed 2.0.5 as 2.0.4.
 # Prompt for the npm 2FA OTP here (after the build) so it can't expire; OTP=… skips.
-publish: bundle test check-fmt package.json README.md LICENSE CHANGELOG.md
+publish: test check-fmt package.json README.md LICENSE CHANGELOG.md
+	$(MAKE) clean-dist
+	$(MAKE) bundle
 	@otp='$(OTP)'; \
 	if [ -z "$$otp" ] && [ -t 0 ]; then \
 		printf 'npm one-time password (OTP): ' >&2; \


### PR DESCRIPTION
## Symptom

`make publish` from `projects/start-sdk` fails:

```
npm error code E415
npm error 415 Unsupported Media Type - PUT https://registry.npmjs.org/@start9labs%2fstart-sdk
npm error   invalid path: package/../../shared-libs/ts-modules/start-core/dist/node_modules/isomorphic-fetch/.editorconfig
```

## Cause

The `dist` recipe does `rsync -ac node_modules dist/`, which drags along npm's hidden lockfile. That file describes the **source** tree, where the bundled dep is a `file:` symlink:

```json
"node_modules/@start9labs/start-core": {
  "resolved": "../../shared-libs/ts-modules/start-core/dist",
  "link": true
}
```

When `npm publish` runs from `dist/`, Arborist reads that lockfile, decides `@start9labs/start-core` is a link, and packs **through it** — emitting paths that escape the package root — even though the very next line of the recipe (`rsync -aL`) has already put the real dereferenced files in `dist/node_modules/@start9labs/start-core/`. npm strips `.package-lock.json` from the tarball regardless, so it was never doing anything for consumers; deleting it from `dist/` is a no-op for them and removes the link record entirely.

## Why this regressed now, when every previous publish worked

Worth being precise, because the `link: true` record is **not** new — it has always been copied into `dist/`, which is why publishes have always worked. From the npm debug log of the failing run:

```
verbose shrinkwrap failed to load node_modules/.package-lock.json out of date,
        updated: ../../shared-libs/ts-modules/start-core/dist
```

The link record alone is inert. npm only re-resolves through it when it judges the hidden lockfile **stale** — at which point it discards it and re-derives the tree from the `file:` spec in `dist/package.json`. So the bug needs both halves, and the second half is what changed today.

**Confirmed:** the mechanism above (stale hidden lockfile → re-resolve through the `file:` link → escaping paths).

**Hypothesis, not proven:** the trigger was rebuilding `start-core/dist` while working on #3475. `$(START_CORE_DIST)/package.json` is a prerequisite of the SDK's `package-lock.json` and `node_modules` rules, so that rebuild made `make publish` re-run `npm i` + `npm ci` for the first time in a while, regenerating `node_modules` and its hidden lockfile mid-build (`npm i` also rewrote `package.json` — its mtime was the publish time, not the earlier version bump). That plausibly perturbs the mtime relationship npm uses to decide the hidden lockfile is current, so the copy landing in `dist/` was judged stale. Previously `dist/` was reused untouched and the lockfile stayed "fresh."

I could not verify this: npm keeps only the last 10 logs (`logs-max=10`), and both the failing log and the successful 2.0.4 log have since been pruned, so the diff that would settle it is gone. Flagging it as a hypothesis rather than dressing it up as a finding. The fix makes the trigger moot either way — `dist/` no longer carries the lockfile the staleness check operates on.

## Two staleness bugs found alongside it

These are what let a wrong `dist` reach `npm publish` in the first place:

- **`$(START_CORE_DIST)/package.json` had no prerequisites**, so make only ran it when `start-core/dist` was *missing* — never when start-core's sources changed. A rebuilt start-core left the SDK's `dist` stale against it. Now depends on start-core's sources.
- **`dist` is a directory target**, so make's staleness check doesn't track its contents (a directory's mtime only moves when top-level entries change, and the recipe ends in `touch dist`). This is how the failing run packed a **2.0.5** source tree as a **2.0.4** tarball. `publish` now does a clean rebuild rather than trusting incremental `dist`; `bundle` stays incremental so the OS build isn't slowed.

## Verification

Clean rebuild, then packed the real tarball (`npm pack --dry-run` is not usable here — it reports `bundled files: 0`):

- `dist/package.json` → `2.0.5`, matching source
- `2983` files under `package/node_modules/@start9labs/start-core/` — bundled as real files
- **0** paths containing `../`

With this applied, `make publish` succeeded and **`@start9labs/start-sdk@2.0.5` is live on npm**.

Found while publishing 2.0.5 (#3475).

🤖 Generated with [Claude Code](https://claude.com/claude-code)