### PR TITLE
backup-fs: kernel idmapped mount (fuser 0.17 + drop internal idmap)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2677,19 +2677,22 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fuser"
-version = "0.14.0"
-source = "git+https://github.com/Start9Labs/fuser.git?rev=b6f91ac#b6f91ac6985310b1f4e3ff8075e9468b120e2fe0"
+version = "0.17.0"
+source = "git+https://github.com/Start9Labs/fuser.git?rev=4ef196b#4ef196b4381010046075d1b70e467f129ccd4493"
 dependencies = [
- "clap 4.6.1",
+ "bitflags 2.11.1",
  "libc",
  "log",
  "memchr",
- "nix 0.28.0",
+ "nix 0.30.1",
+ "num_enum",
  "page_size",
+ "parking_lot 0.12.5",
  "pkg-config",
+ "ref-cast",
  "serde",
  "smallvec",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3042,7 +3045,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5769,7 +5772,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6473,6 +6476,26 @@ dependencies = [
  "parking_lot 0.11.2",
  "smallvec",
  "spin",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10331,32 +10354,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive 0.8.48",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/projects/start-os/backup-fs/Cargo.toml
+++ b/projects/start-os/backup-fs/Cargo.toml
@@ -25,10 +25,8 @@ crossbeam-channel = "0.5"
 ctrlc = "3.4.4"
 env_logger = { version = "0.11", optional = true }
 fd-lock-rs = "0.1.4"
-fuser = { git = "https://github.com/Start9Labs/fuser.git", rev = "b6f91ac", features = [
-  "abi-7-31",
+fuser = { git = "https://github.com/Start9Labs/fuser.git", rev = "4ef196b", features = [
   "serializable",
-  "clap",
 ] }
 generic-array = { version = "1", features = ["serde"] }
 imbl = { version = "3", features = ["serde"] }

--- a/projects/start-os/backup-fs/benches/throughput.rs
+++ b/projects/start-os/backup-fs/benches/throughput.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, SystemTime};
 
 use backupfs::{BackupFS, BackupFSOptions};
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use fuser::{MountOption, Session};
+use fuser::{Config, MountOption, Session, SessionACL};
 
 const MIB: usize = 1024 * 1024;
 const SEQ_SIZE: usize = 64 * MIB;
@@ -58,9 +58,12 @@ impl Harness {
                 idmapped_root: vec![],
             })
             .unwrap();
-            let mut session = Session::new(fs, &mnt_dir, &opt).unwrap();
+            let mut config = Config::default();
+            config.mount_options = opt;
+            config.acl = SessionACL::All;
+            let mut session = Session::new(fs, &mnt_dir, &config).unwrap();
             tx.send(session.unmount_callable()).unwrap();
-            session.run().unwrap();
+            session.spawn().unwrap().join().unwrap();
         });
         let umount = rx.recv().unwrap();
         Harness {

--- a/projects/start-os/backup-fs/benches/throughput.rs
+++ b/projects/start-os/backup-fs/benches/throughput.rs
@@ -55,7 +55,7 @@ impl Harness {
                 password: "benchmark".to_string(),
                 file_size_padding: None,
                 readonly: false,
-                idmapped_root: vec![],
+                idmapped: false,
             })
             .unwrap();
             let mut config = Config::default();

--- a/projects/start-os/backup-fs/benches/throughput.rs
+++ b/projects/start-os/backup-fs/benches/throughput.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, SystemTime};
 
 use backupfs::{BackupFS, BackupFSOptions};
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use fuser::{Config, MountOption, Session, SessionACL};
+use fuser::{Config, MountOption};
 
 const MIB: usize = 1024 * 1024;
 const SEQ_SIZE: usize = 64 * MIB;
@@ -33,44 +33,34 @@ const RANDOM_OPS: usize = 1000;
 struct Harness {
     mnt: tempdir::TempDir,
     data: tempdir::TempDir,
-    umount: Option<fuser::SessionUnmounter>,
-    thread: Option<std::thread::JoinHandle<()>>,
+    bg: Option<fuser::BackgroundSession>,
 }
 
 impl Harness {
     fn mount() -> Self {
         let data = tempdir::TempDir::new("bench_data").unwrap();
         let mnt = tempdir::TempDir::new("bench_mnt").unwrap();
-        let opt = vec![
-            MountOption::FSName("backup-fs".to_string()),
-            MountOption::AutoUnmount,
-        ];
-        let data_dir = data.path().to_owned();
-        let mnt_dir = mnt.path().to_owned();
-        let (tx, rx) = std::sync::mpsc::channel();
-        let thread = std::thread::spawn(move || {
-            let fs = BackupFS::new(BackupFSOptions {
-                data_dir,
-                setuid_support: false,
-                password: "benchmark".to_string(),
-                file_size_padding: None,
-                readonly: false,
-                idmapped: false,
-            })
+        let fs = BackupFS::new(BackupFSOptions {
+            data_dir: data.path().to_owned(),
+            setuid_support: false,
+            password: "benchmark".to_string(),
+            file_size_padding: None,
+            readonly: false,
+            idmapped: false,
+        })
+        .unwrap();
+        let mut config = Config::default();
+        config.mount_options = vec![MountOption::FSName("backup-fs".to_string())];
+        // 0.17: drive the BackgroundSession lifecycle; no AutoUnmount (its
+        // helper deadlocks an explicit umount under spawn()).
+        let bg = fuser::Session::new(fs, mnt.path(), &config)
+            .unwrap()
+            .spawn()
             .unwrap();
-            let mut config = Config::default();
-            config.mount_options = opt;
-            config.acl = SessionACL::All;
-            let mut session = Session::new(fs, &mnt_dir, &config).unwrap();
-            tx.send(session.unmount_callable()).unwrap();
-            session.spawn().unwrap().join().unwrap();
-        });
-        let umount = rx.recv().unwrap();
         Harness {
             mnt,
             data,
-            umount: Some(umount),
-            thread: Some(thread),
+            bg: Some(bg),
         }
     }
 
@@ -85,11 +75,8 @@ impl Harness {
 
 impl Drop for Harness {
     fn drop(&mut self) {
-        if let Some(mut u) = self.umount.take() {
-            let _ = u.unmount();
-        }
-        if let Some(t) = self.thread.take() {
-            let _ = t.join();
+        if let Some(bg) = self.bg.take() {
+            let _ = bg.umount_and_join();
         }
     }
 }

--- a/projects/start-os/backup-fs/examples/benchmark.rs
+++ b/projects/start-os/backup-fs/examples/benchmark.rs
@@ -39,7 +39,7 @@ fn with_mount(data: &Path, body: impl FnOnce(&Path)) {
             password: "benchmark".to_string(),
             file_size_padding: None,
             readonly: false,
-            idmapped_root: vec![],
+            idmapped: false,
         })
         .unwrap();
         let mut config = Config::default();

--- a/projects/start-os/backup-fs/examples/benchmark.rs
+++ b/projects/start-os/backup-fs/examples/benchmark.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use std::time::{Instant, SystemTime};
 
 use backupfs::{BackupFS, BackupFSOptions};
-use fuser::{MountOption, Session};
+use fuser::{Config, MountOption, Session, SessionACL};
 
 const MIB: usize = 1024 * 1024;
 
@@ -42,9 +42,12 @@ fn with_mount(data: &Path, body: impl FnOnce(&Path)) {
             idmapped_root: vec![],
         })
         .unwrap();
-        let mut session = Session::new(fs, &mnt_dir, &opt).unwrap();
+        let mut config = Config::default();
+        config.mount_options = opt;
+        config.acl = SessionACL::All;
+        let mut session = Session::new(fs, &mnt_dir, &config).unwrap();
         tx.send(session.unmount_callable()).unwrap();
-        session.run().unwrap();
+        session.spawn().unwrap().join().unwrap();
     });
     let mut umount = rx.recv().unwrap();
     body(mnt.path());

--- a/projects/start-os/backup-fs/src/ctrl.rs
+++ b/projects/start-os/backup-fs/src/ctrl.rs
@@ -9,8 +9,6 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use chacha20::Key;
 use fuser::FileType;
-
-use crate::FUSE_ROOT_ID;
 use log::error;
 use rand::rand_core::UnwrapErr;
 use rand::RngExt;
@@ -23,7 +21,7 @@ use crate::inode::{Attributes, ContentId, FileData, Inode, InodeAttributes};
 use crate::seglog::{self, SegmentLog};
 use crate::superblock::{Constants, Superblock};
 use crate::vault::EccParams;
-use crate::{serde, BackupFSOptions};
+use crate::{serde, BackupFSOptions, FUSE_ROOT_ID};
 
 #[derive(Clone)]
 pub struct Controller(Arc<ControllerSeed>);

--- a/projects/start-os/backup-fs/src/ctrl.rs
+++ b/projects/start-os/backup-fs/src/ctrl.rs
@@ -8,7 +8,9 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use chacha20::Key;
-use fuser::{FileType, FUSE_ROOT_ID};
+use fuser::FileType;
+
+use crate::FUSE_ROOT_ID;
 use log::error;
 use rand::rand_core::UnwrapErr;
 use rand::RngExt;

--- a/projects/start-os/backup-fs/src/directory.rs
+++ b/projects/start-os/backup-fs/src/directory.rs
@@ -418,7 +418,7 @@ mod tests {
             password: "x".to_owned(),
             file_size_padding: None,
             readonly: false,
-            idmapped_root: vec![],
+            idmapped: false,
         })
         .unwrap()
     }

--- a/projects/start-os/backup-fs/src/error.rs
+++ b/projects/start-os/backup-fs/src/error.rs
@@ -2,7 +2,7 @@ use std::backtrace::Backtrace;
 use std::fmt::{Debug, Display};
 use std::io;
 
-use fuser::ReplyEntry;
+use fuser::{Errno, ReplyEntry};
 use libc::c_int;
 use log::{debug, warn};
 
@@ -92,7 +92,7 @@ impl BkfsError {
     }
 
     pub fn reply(&self, entry: ReplyEntry) {
-        entry.error(self.to_errno_log());
+        entry.error(Errno::from_i32(self.to_errno_log()));
     }
 }
 

--- a/projects/start-os/backup-fs/src/handle.rs
+++ b/projects/start-os/backup-fs/src/handle.rs
@@ -9,8 +9,11 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::SystemTime;
 
-use fuser::consts::FUSE_WRITE_KILL_PRIV;
-use fuser::{FileType, Request, TimeOrNow, FUSE_ROOT_ID};
+use fuser::{FileType, Request, TimeOrNow};
+
+use crate::FUSE_ROOT_ID;
+
+const FUSE_WRITE_KILL_PRIV: i32 = 1 << 2;
 use log::{debug, warn};
 
 use crate::contents::Contents;

--- a/projects/start-os/backup-fs/src/handle.rs
+++ b/projects/start-os/backup-fs/src/handle.rs
@@ -1149,7 +1149,12 @@ impl Handler {
         Ok(())
     }
 
-    pub fn opendir(&mut self, _req: &Request, inode: Inode, _flags: i32) -> BkfsResult<FileHandleId> {
+    pub fn opendir(
+        &mut self,
+        _req: &Request,
+        inode: Inode,
+        _flags: i32,
+    ) -> BkfsResult<FileHandleId> {
         let inode = self.load_inode(inode)?;
         let entries = match &inode.attrs.contents {
             FileData::Directory(dir) => dir.snapshot(self.ctrl(), inode.inode)?,

--- a/projects/start-os/backup-fs/src/handle.rs
+++ b/projects/start-os/backup-fs/src/handle.rs
@@ -21,7 +21,7 @@ use crate::ctrl::Controller;
 use crate::directory::{DirectoryContents, DirectoryEntry};
 use crate::error::{BkfsError, BkfsErrorKind, BkfsResult, BkfsResultExt};
 use crate::inode::{FileData, Inode, InodeAttributes};
-use crate::{FMODE_EXEC, MAX_NAME_LENGTH};
+use crate::MAX_NAME_LENGTH;
 
 /// True if `e` is "the inode's backing file isn't on disk" — either
 /// from a same-session create+delete that never touched disk, or a
@@ -531,7 +531,7 @@ impl Handler {
 
     pub fn lookup(
         &mut self,
-        req: &Request,
+        _req: &Request,
         parent: Inode,
         name: &OsStr,
     ) -> BkfsResult<InodeAttributes> {
@@ -539,12 +539,6 @@ impl Handler {
             return BkfsResult::errno(libc::ENAMETOOLONG);
         }
         let mut parent = self.load_inode(parent)?;
-        parent.attrs.check_access(
-            &self.ctrl().config().idmapped_root,
-            req.uid(),
-            req.gid(),
-            libc::X_OK,
-        )?;
 
         let inode = parent.lookup(self.ctrl(), name)?;
         let result = self.mutate_inode(inode, |_, attrs| {
@@ -630,15 +624,9 @@ impl Handler {
         Ok(inode)
     }
 
-    pub fn readlink(&mut self, req: &Request, inode: Inode) -> BkfsResult<PathBuf> {
+    pub fn readlink(&mut self, _req: &Request, inode: Inode) -> BkfsResult<PathBuf> {
         debug!("readlink() called on {:?}", inode);
         let inode = self.load_inode(inode)?;
-        inode.attrs.check_access(
-            &self.ctrl().config().idmapped_root,
-            req.uid(),
-            req.gid(),
-            libc::R_OK,
-        )?;
         let FileData::Symlink(p) = inode.attrs.contents else {
             return BkfsResult::errno(libc::EINVAL);
         };
@@ -673,13 +661,6 @@ impl Handler {
         }
 
         let mut parent = self.load_inode(parent)?;
-
-        parent.attrs.check_access(
-            &self.ctrl().config().idmapped_root,
-            req.uid(),
-            req.gid(),
-            libc::W_OK,
-        )?;
 
         let gid = parent.attrs.creation_gid(req.gid());
         let parent_inode = parent.inode;
@@ -810,14 +791,8 @@ impl Handler {
         Ok(true)
     }
 
-    pub fn unlink(&mut self, req: &Request, parent: Inode, name: &OsStr) -> BkfsResult<()> {
+    pub fn unlink(&mut self, _req: &Request, parent: Inode, name: &OsStr) -> BkfsResult<()> {
         let mut parent = self.load_inode(parent)?;
-        parent.attrs.check_access(
-            &self.ctrl().config().idmapped_root,
-            req.uid(),
-            req.gid(),
-            libc::W_OK,
-        )?;
 
         let ctrl = self.ctrl().clone();
         let parent_inode = parent.inode;
@@ -841,8 +816,6 @@ impl Handler {
                     return BkfsResult::errno(libc::ENOTEMPTY);
                 }
             }
-
-            parent.attrs.check_sticky(&inode.attrs, req.uid())?;
 
             inode.attrs.parents.remove(&(parent.inode, name.to_owned()));
 
@@ -888,7 +861,7 @@ impl Handler {
 
     pub fn link(
         &mut self,
-        req: &Request,
+        _req: &Request,
         inode: Inode,
         new_parent: Inode,
         new_name: &OsStr,
@@ -911,15 +884,6 @@ impl Handler {
 
             let mut new_parent = handler.load_inode(new_parent)?;
             let new_parent_inode = new_parent.inode;
-
-            new_parent.attrs.check_access(
-                &handler.ctrl().config().idmapped_root,
-                req.uid(),
-                req.gid(),
-                libc::W_OK,
-            )?;
-
-            let sticky_res = new_parent.attrs.check_sticky(&inode.attrs, req.uid());
 
             let new_entry = DirectoryEntry {
                 inode: inode.inode,
@@ -952,8 +916,6 @@ impl Handler {
                                 return BkfsResult::errno(libc::ENOTEMPTY);
                             }
                         }
-
-                        sticky_res?;
 
                         prev_inode
                             .attrs
@@ -1056,24 +1018,10 @@ impl Handler {
     ) -> BkfsResult<()> {
         let parent = self.load_inode(parent)?;
 
-        parent.attrs.check_access(
-            &self.ctrl().config().idmapped_root,
-            req.uid(),
-            req.gid(),
-            libc::W_OK,
-        )?;
-
         let inode = parent.lookup(self.ctrl(), name)?;
 
         if exchange {
             let new_parent = self.load_inode(new_parent)?;
-
-            new_parent.attrs.check_access(
-                &self.ctrl().config().idmapped_root,
-                req.uid(),
-                req.gid(),
-                libc::W_OK,
-            )?;
 
             if new_parent.inode == parent.inode && name == new_name {
                 // libc handles this case internally, but we should check
@@ -1111,36 +1059,24 @@ impl Handler {
         Ok(())
     }
 
-    pub fn open(&mut self, req: &Request, inode: Inode, flags: i32) -> BkfsResult<FileHandleId> {
-        let (access_mask, read, write) = match flags & libc::O_ACCMODE {
+    pub fn open(&mut self, _req: &Request, inode: Inode, flags: i32) -> BkfsResult<FileHandleId> {
+        let (read, write) = match flags & libc::O_ACCMODE {
             libc::O_RDONLY => {
                 // Behavior is undefined, but most filesystems return EACCES
                 if flags & libc::O_TRUNC != 0 {
                     return BkfsResult::errno(libc::EACCES);
                 }
-                if flags & FMODE_EXEC != 0 {
-                    // Open is from internal exec syscall
-                    (libc::X_OK, true, false)
-                } else {
-                    (libc::R_OK, true, false)
-                }
+                (true, false)
             }
-            libc::O_WRONLY => (libc::W_OK, false, true),
-            libc::O_RDWR => (libc::R_OK | libc::W_OK, true, true),
+            libc::O_WRONLY => (false, true),
+            libc::O_RDWR => (true, true),
             // Exactly one access mode flag must be specified
             _ => {
                 return BkfsResult::errno(libc::EINVAL);
             }
         };
 
-        self.fopen(inode, read, write, |handler, inode| {
-            inode.attrs.check_access(
-                &handler.ctrl().config().idmapped_root,
-                req.uid(),
-                req.gid(),
-                access_mask,
-            )
-        })
+        self.fopen(inode, read, write, |_, _| Ok(()))
     }
 
     pub fn read(
@@ -1213,29 +1149,8 @@ impl Handler {
         Ok(())
     }
 
-    pub fn opendir(&mut self, req: &Request, inode: Inode, flags: i32) -> BkfsResult<FileHandleId> {
+    pub fn opendir(&mut self, _req: &Request, inode: Inode, _flags: i32) -> BkfsResult<FileHandleId> {
         let inode = self.load_inode(inode)?;
-        let (access_mask, _read, _) = match flags & libc::O_ACCMODE {
-            libc::O_RDONLY => {
-                // Behavior is undefined, but most filesystems return EACCES
-                if flags & libc::O_TRUNC != 0 {
-                    return BkfsResult::errno(libc::EACCES);
-                }
-                (libc::R_OK, true, false)
-            }
-            libc::O_WRONLY => (libc::W_OK, false, true),
-            libc::O_RDWR => (libc::R_OK | libc::W_OK, true, true),
-            // Exactly one access mode flag must be specified
-            _ => {
-                return BkfsResult::errno(libc::EINVAL);
-            }
-        };
-        inode.attrs.check_access(
-            &self.ctrl().config().idmapped_root,
-            req.uid(),
-            req.gid(),
-            access_mask,
-        )?;
         let entries = match &inode.attrs.contents {
             FileData::Directory(dir) => dir.snapshot(self.ctrl(), inode.inode)?,
             _ => Default::default(),
@@ -1351,19 +1266,13 @@ impl Handler {
 
     pub fn setxattr(
         &mut self,
-        req: &Request,
+        _req: &Request,
         inode: Inode,
         key: &[u8],
         value: &[u8],
     ) -> BkfsResult<()> {
         self.mutate_inode(inode, |handler, inode| {
             let attrs = &mut inode.attrs;
-            attrs.xattr_access_check(
-                &handler.ctrl().config().idmapped_root,
-                key,
-                Some(Some(value)),
-                req,
-            )?;
             attrs.xattrs.insert(key.to_vec(), value.to_vec());
             attrs.changed();
             handler.save_inode(&*inode)?;
@@ -1371,45 +1280,31 @@ impl Handler {
         })
     }
 
-    pub fn getxattr(&self, req: &Request, inode: Inode, key: &[u8]) -> BkfsResult<Vec<u8>> {
-        self.peek_inode(inode, |inode| {
-            inode
-                .attrs
-                .xattr_access_check(&self.ctrl().config().idmapped_root, key, None, req)?;
-            match inode.attrs.xattrs.get(key) {
-                Some(v) => Ok(v.clone()),
-                #[cfg(target_os = "linux")]
-                None => BkfsResult::errno_notrace(libc::ENODATA),
-                #[cfg(not(target_os = "linux"))]
-                None => BkfsResult::errno_notrace(libc::ENOATTR),
-            }
+    pub fn getxattr(&self, _req: &Request, inode: Inode, key: &[u8]) -> BkfsResult<Vec<u8>> {
+        self.peek_inode(inode, |inode| match inode.attrs.xattrs.get(key) {
+            Some(v) => Ok(v.clone()),
+            #[cfg(target_os = "linux")]
+            None => BkfsResult::errno_notrace(libc::ENODATA),
+            #[cfg(not(target_os = "linux"))]
+            None => BkfsResult::errno_notrace(libc::ENOATTR),
         })
     }
 
     pub fn listxattr<'r>(
         &self,
-        req: &'r Request,
+        _req: &'r Request,
         inode: Inode,
     ) -> BkfsResult<impl Iterator<Item = (Vec<u8>, Vec<u8>)> + 'r> {
         // TODO: peek_inode and serialize to bytes here
         let inode = self.load_inode(inode)?;
         let mut attrs = inode.attrs;
         let xattrs = std::mem::replace(&mut attrs.xattrs, Default::default());
-        let idmap = self.ctrl().config().idmapped_root.clone();
-        Ok(xattrs
-            .into_iter()
-            .filter(move |(key, _)| attrs.xattr_access_check(&idmap, key, None, req).is_ok()))
+        Ok(xattrs.into_iter())
     }
 
-    pub fn removexattr(&mut self, req: &Request, inode: Inode, key: &[u8]) -> BkfsResult<Vec<u8>> {
+    pub fn removexattr(&mut self, _req: &Request, inode: Inode, key: &[u8]) -> BkfsResult<Vec<u8>> {
         let value = self.mutate_inode(inode, |handler, inode| {
             let attrs = &mut inode.attrs;
-            attrs.xattr_access_check(
-                &handler.ctrl().config().idmapped_root,
-                key,
-                Some(None),
-                req,
-            )?;
             let value = attrs.xattrs.remove(key);
             attrs.changed();
             handler.save_inode(&*inode)?;

--- a/projects/start-os/backup-fs/src/inode.rs
+++ b/projects/start-os/backup-fs/src/inode.rs
@@ -14,7 +14,6 @@ use crate::ctrl::{Controller, Exists, Load, Save};
 use crate::directory::DirectoryContents;
 use crate::error::{BkfsResult, BkfsResultExt};
 use crate::handle::{FileHandleId, Handler};
-use crate::{get_groups, IdMappedRoot};
 
 pub const BLOCK_SIZE: u64 = 4096;
 
@@ -94,14 +93,6 @@ impl From<&FileData> for fuser::FileType {
             FileData::Socket => fuser::FileType::Socket,
         }
     }
-}
-
-#[derive(Debug)]
-enum XattrNamespace {
-    Security,
-    System,
-    Trusted,
-    User,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -220,41 +211,6 @@ impl From<&InodeAttributes> for fuser::FileAttr {
     }
 }
 
-fn parse_xattr_namespace(key: &[u8]) -> BkfsResult<XattrNamespace> {
-    let user = b"user.";
-    if key.len() < user.len() {
-        return BkfsResult::errno(libc::ENOTSUP);
-    }
-    if key[..user.len()].eq(user) {
-        return Ok(XattrNamespace::User);
-    }
-
-    let system = b"system.";
-    if key.len() < system.len() {
-        return BkfsResult::errno(libc::ENOTSUP);
-    }
-    if key[..system.len()].eq(system) {
-        return Ok(XattrNamespace::System);
-    }
-
-    let trusted = b"trusted.";
-    if key.len() < trusted.len() {
-        return BkfsResult::errno(libc::ENOTSUP);
-    }
-    if key[..trusted.len()].eq(trusted) {
-        return Ok(XattrNamespace::Trusted);
-    }
-
-    let security = b"security";
-    if key.len() < security.len() {
-        return BkfsResult::errno(libc::ENOTSUP);
-    }
-    if key[..security.len()].eq(security) {
-        return Ok(XattrNamespace::Security);
-    }
-
-    return BkfsResult::errno(libc::ENOTSUP);
-}
 
 impl<'a> Save for &'a InodeAttributes {
     fn save(self, ctrl: &Controller) -> BkfsResult<()> {
@@ -308,15 +264,7 @@ impl Attributes {
 
         if let Some(mode) = mode {
             debug!("chmod() called with {:?}, {:o}", inode, mode);
-            if !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), [])
-                && req.uid() != self.uid
-            {
-                return BkfsResult::errno(libc::EPERM);
-            }
-            if !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), [])
-                && req.gid() != self.gid
-                && !get_groups(req.pid()).contains(&self.gid)
-            {
+            if req.uid() != 0 && req.gid() != self.gid {
                 // If SGID is set and the file belongs to a group that the caller is not part of
                 // then the SGID bit is suppose to be cleared during chmod
                 self.mode = (mode & !libc::S_ISGID as u32) as u16;
@@ -328,23 +276,6 @@ impl Attributes {
 
         if uid.is_some() || gid.is_some() {
             debug!("chown() called with {:?} {:?} {:?}", inode, uid, gid);
-            if let Some(gid) = gid {
-                // Non-root users can only change gid to a group they're in
-                // Only owner may change the group
-                if !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), [gid])
-                    && (!get_groups(req.pid()).contains(&gid) || req.uid() != self.uid)
-                {
-                    return BkfsResult::errno(libc::EPERM);
-                }
-            }
-            if let Some(uid) = uid {
-                if !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), [uid])
-                        // but no-op changes by the owner are not an error
-                        && !(uid == self.uid && req.uid() == self.uid)
-                {
-                    return BkfsResult::errno(libc::EPERM);
-                }
-            }
 
             if self.mode & (libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH) as u16 != 0 {
                 // SUID & SGID are suppose to be cleared when chown'ing an executable file
@@ -359,7 +290,7 @@ impl Attributes {
             if let Some(gid) = gid {
                 self.gid = gid;
                 // Clear SETGID unless user is root
-                if !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), []) {
+                if req.uid() != 0 {
                     self.mode &= !libc::S_ISGID as u16;
                 }
             }
@@ -381,13 +312,6 @@ impl Attributes {
                 {
                     return BkfsResult::errno(libc::EACCES);
                 }
-            } else {
-                self.check_access(
-                    &handler.ctrl().config().idmapped_root,
-                    req.uid(),
-                    req.gid(),
-                    libc::W_OK,
-                )?;
             }
             self.size = size;
             changed = true;
@@ -395,23 +319,6 @@ impl Attributes {
 
         if let Some(atime) = atime {
             debug!("utimens() called with {:?}, atime={:?}", inode, atime);
-
-            if self.uid != req.uid()
-                && !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), [])
-                && atime != TimeOrNow::Now
-            {
-                return BkfsResult::errno(libc::EPERM);
-            }
-
-            if self.uid != req.uid() {
-                self.check_access(
-                    &handler.ctrl().config().idmapped_root,
-                    req.uid(),
-                    req.gid(),
-                    libc::W_OK,
-                )?;
-            }
-
             self.atime = match atime {
                 TimeOrNow::SpecificTime(time) => time_from_system_time(&time),
                 TimeOrNow::Now => lazy_now(),
@@ -421,23 +328,6 @@ impl Attributes {
 
         if let Some(mtime) = mtime {
             debug!("utimens() called with {:?}, mtime={:?}", inode, mtime);
-
-            if self.uid != req.uid()
-                && !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), [])
-                && mtime != TimeOrNow::Now
-            {
-                return BkfsResult::errno(libc::EPERM);
-            }
-
-            if self.uid != req.uid() {
-                self.check_access(
-                    &handler.ctrl().config().idmapped_root,
-                    req.uid(),
-                    req.gid(),
-                    libc::W_OK,
-                )?;
-            }
-
             self.mtime = match mtime {
                 TimeOrNow::SpecificTime(time) => time_from_system_time(&time),
                 TimeOrNow::Now => lazy_now(),
@@ -447,26 +337,12 @@ impl Attributes {
 
         if let Some(ctime) = ctime {
             debug!("utimens() called with {:?}, ctime={:?}", inode, ctime);
-
-            if self.uid != req.uid()
-                && !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), [])
-            {
-                return BkfsResult::errno(libc::EPERM);
-            }
-
             self.ctime = time_from_system_time(&ctime);
             changed = true;
         }
 
         if let Some(crtime) = crtime {
             debug!("utimens() called with {:?}, crtime={:?}", inode, crtime);
-
-            if self.uid != req.uid()
-                && !self.is_root_for(&handler.ctrl().config().idmapped_root, req.uid(), [])
-            {
-                return BkfsResult::errno(libc::EPERM);
-            }
-
             self.crtime = time_from_system_time(&crtime);
             changed = true;
         }
@@ -476,69 +352,6 @@ impl Attributes {
         }
 
         Ok(changed)
-    }
-
-    pub fn is_root_for(
-        &self,
-        idmap: &[IdMappedRoot],
-        uid: u32,
-        uids: impl IntoIterator<Item = u32> + Clone,
-    ) -> bool {
-        uid == 0
-            || idmap
-                .into_iter()
-                .any(|idmap| idmap.is_root_for(uid, [self.uid].into_iter().chain(uids.clone())))
-    }
-
-    pub fn check_access(
-        &self,
-        idmap: &[IdMappedRoot],
-        uid: u32,
-        gid: u32,
-        mut access_mask: i32,
-    ) -> BkfsResult<()> {
-        // F_OK tests for existence of file
-        if access_mask == libc::F_OK {
-            return Ok(());
-        }
-        let file_mode = i32::from(self.mode);
-
-        // root is allowed to read & write anything
-        if self.is_root_for(idmap, uid, []) {
-            // root only allowed to exec if one of the X bits is set
-            access_mask &= libc::X_OK;
-            access_mask -= access_mask & (file_mode >> 6);
-            access_mask -= access_mask & (file_mode >> 3);
-            access_mask -= access_mask & file_mode;
-            return if access_mask == 0 {
-                Ok(())
-            } else {
-                BkfsResult::errno(libc::EACCES)
-            };
-        }
-
-        if uid == self.uid {
-            access_mask -= access_mask & (file_mode >> 6);
-        } else if gid == self.gid {
-            access_mask -= access_mask & (file_mode >> 3);
-        } else {
-            access_mask -= access_mask & file_mode;
-        }
-
-        if access_mask == 0 {
-            Ok(())
-        } else {
-            BkfsResult::errno(libc::EACCES)
-        }
-    }
-
-    pub fn check_sticky(&self, child: &Self, uid: u32) -> BkfsResult<()> {
-        if self.mode & libc::S_ISVTX as u16 != 0 && uid != 0 && uid != self.uid && uid != child.uid
-        {
-            BkfsResult::errno(libc::EACCES)
-        } else {
-            Ok(())
-        }
     }
 
     pub fn clear_suid_sgid(&mut self) {
@@ -555,59 +368,6 @@ impl Attributes {
         }
 
         gid
-    }
-
-    pub fn xattr_access_check(
-        &self,
-        idmap: &[IdMappedRoot],
-        key: &[u8],
-        value: Option<Option<&[u8]>>,
-        request: &Request,
-    ) -> BkfsResult<()> {
-        match parse_xattr_namespace(key)? {
-            XattrNamespace::Security => {
-                if value.is_some() && request.uid() != 0 {
-                    return BkfsResult::errno(libc::EPERM);
-                }
-            }
-            XattrNamespace::Trusted => {
-                if request.uid() != 0 {
-                    return BkfsResult::errno(libc::EPERM);
-                }
-            }
-            XattrNamespace::System => {
-                if value.is_some() {
-                    if key.eq(b"system.posix_acl_access")
-                        && self.uid != request.uid()
-                        && !self.is_root_for(idmap, request.uid(), [])
-                    {
-                        return BkfsResult::errno(libc::EPERM);
-                    } else if key.eq(b"system.posix_acl_access")
-                        && request.uid() != 0
-                        && !self.is_root_for(idmap, request.uid(), [])
-                    {
-                        return BkfsResult::errno(libc::EPERM);
-                    } else if request.uid() != 0 {
-                        return BkfsResult::errno(libc::EPERM);
-                    }
-                }
-            }
-            XattrNamespace::User => {
-                self.check_access(
-                    idmap,
-                    request.uid(),
-                    request.gid(),
-                    if value.is_some() {
-                        libc::W_OK
-                    } else {
-                        libc::R_OK
-                    },
-                )
-                .map_err(|_| io::Error::from_raw_os_error(libc::EPERM))?;
-            }
-        }
-
-        Ok(())
     }
 
     pub fn modified(&mut self) {

--- a/projects/start-os/backup-fs/src/inode.rs
+++ b/projects/start-os/backup-fs/src/inode.rs
@@ -3,7 +3,9 @@ use std::io;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use fuser::{Request, TimeOrNow, FUSE_ROOT_ID};
+use fuser::{Request, TimeOrNow};
+
+use crate::FUSE_ROOT_ID;
 use imbl::{OrdMap, OrdSet};
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -194,7 +196,7 @@ pub fn time_from_system_time(system_time: &SystemTime) -> (i64, u32) {
 impl From<&InodeAttributes> for fuser::FileAttr {
     fn from(InodeAttributes { inode, attrs, .. }: &InodeAttributes) -> Self {
         fuser::FileAttr {
-            ino: inode.0,
+            ino: fuser::INodeNo(inode.0),
             size: attrs.size,
             // st_blocks is reported in 512-byte units per POSIX, independent of blksize
             blocks: attrs.size.div_ceil(512),
@@ -560,7 +562,7 @@ impl Attributes {
         idmap: &[IdMappedRoot],
         key: &[u8],
         value: Option<Option<&[u8]>>,
-        request: &Request<'_>,
+        request: &Request,
     ) -> BkfsResult<()> {
         match parse_xattr_namespace(key)? {
             XattrNamespace::Security => {

--- a/projects/start-os/backup-fs/src/inode.rs
+++ b/projects/start-os/backup-fs/src/inode.rs
@@ -4,8 +4,6 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use fuser::{Request, TimeOrNow};
-
-use crate::FUSE_ROOT_ID;
 use imbl::{OrdMap, OrdSet};
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -14,6 +12,7 @@ use crate::ctrl::{Controller, Exists, Load, Save};
 use crate::directory::DirectoryContents;
 use crate::error::{BkfsResult, BkfsResultExt};
 use crate::handle::{FileHandleId, Handler};
+use crate::FUSE_ROOT_ID;
 
 pub const BLOCK_SIZE: u64 = 4096;
 
@@ -210,7 +209,6 @@ impl From<&InodeAttributes> for fuser::FileAttr {
         }
     }
 }
-
 
 impl<'a> Save for &'a InodeAttributes {
     fn save(self, ctrl: &Controller) -> BkfsResult<()> {

--- a/projects/start-os/backup-fs/src/lib.rs
+++ b/projects/start-os/backup-fs/src/lib.rs
@@ -9,16 +9,21 @@ use std::os::raw::c_int;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
 use fd_lock_rs::{FdLock, LockType};
-use fuser::consts::{FOPEN_DIRECT_IO, FUSE_HANDLE_KILLPRIV};
 use fuser::{
-    Filesystem, KernelConfig, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory,
-    ReplyDirectoryPlus, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, ReplyWrite, ReplyXattr,
-    Request, TimeOrNow, FUSE_ROOT_ID,
+    AccessFlags, BsdFileFlags, CopyFileRangeFlags, Errno, FileHandle, Filesystem, FopenFlags,
+    Generation, INodeNo, InitFlags, KernelConfig, LockOwner, OpenFlags, RenameFlags, ReplyAttr,
+    ReplyCreate, ReplyData, ReplyDirectory, ReplyDirectoryPlus, ReplyEmpty, ReplyEntry, ReplyOpen,
+    ReplyStatfs, ReplyWrite, ReplyXattr, Request, TimeOrNow, WriteFlags,
 };
 use log::{debug, error};
+
+fn errno(e: c_int) -> Errno {
+    Errno::from_i32(e)
+}
 
 use crate::ctrl::{Controller, StatFs};
 use crate::directory::DirectoryContents;
@@ -46,6 +51,8 @@ mod tests;
 #[allow(dead_code)]
 mod util;
 mod vault;
+
+pub const FUSE_ROOT_ID: u64 = INodeNo::ROOT.0;
 
 pub const MAX_NAME_LENGTH: u32 = 255;
 // const MAX_FILE_SIZE: u64 = 1024 * 1024 * 1024 * 1024;
@@ -119,7 +126,7 @@ impl FromStr for IdMappedRoot {
 // Directory data is stored in the file's contents, as a serialized DirectoryDescriptor
 pub struct BackupFS {
     lock: FdLock<File>,
-    handler: Handler,
+    handler: Mutex<Handler>,
 }
 
 // The master key and all format-affecting constants live in the versioned
@@ -153,22 +160,28 @@ impl BackupFS {
 
         Ok(BackupFS {
             lock,
-            handler: Handler::new(ctrl),
+            handler: Mutex::new(Handler::new(ctrl)),
         })
     }
 
     pub fn fsck(&mut self) -> BkfsResult<()> {
-        self.handler.ctrl().fsck(false)
+        self.handler.get_mut().unwrap().ctrl().fsck(false)
     }
 
     pub fn change_password(&mut self, password: &str) -> BkfsResult<()> {
-        self.handler.ctrl().change_password(password)
+        self.handler
+            .get_mut()
+            .unwrap()
+            .ctrl()
+            .change_password(password)
     }
 }
 
 impl Filesystem for BackupFS {
-    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> Result<(), c_int> {
-        config.add_capabilities(FUSE_HANDLE_KILLPRIV).unwrap();
+    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> io::Result<()> {
+        config
+            .add_capabilities(InitFlags::FUSE_HANDLE_KILLPRIV)
+            .unwrap();
 
         log::info!("filesystem initialized");
 
@@ -176,7 +189,7 @@ impl Filesystem for BackupFS {
     }
 
     fn destroy(&mut self) {
-        if let Err(e) = self.handler.close_all() {
+        if let Err(e) = self.handler.get_mut().unwrap().close_all() {
             error!("error closing FS: {e}");
         }
         // Every individual AtomicFile::save already calls sync_all
@@ -192,29 +205,28 @@ impl Filesystem for BackupFS {
         }
     }
 
-    fn lookup(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
-        match self.handler.lookup(req, Inode(parent), name) {
-            Ok(inode) => reply.entry(&ENTRY_TTL, &(&inode).into(), 0),
-            Err(e) => reply.error(e.to_errno_log()),
+    fn lookup(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+        let mut h = self.handler.lock().unwrap();
+        match h.lookup(req, Inode(parent.into()), name) {
+            Ok(inode) => reply.entry(&ENTRY_TTL, &(&inode).into(), Generation(0)),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    fn forget(&mut self, _req: &Request, _inode: u64, _nlookup: u64) {}
+    fn forget(&self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
 
-    fn getattr(&mut self, _req: &Request<'_>, inode: u64, _fh: Option<u64>, reply: ReplyAttr) {
-        match self
-            .handler
-            .mutate_inode(Inode(inode), |_, inode| Ok((&*inode).into()))
-        {
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+        let mut h = self.handler.lock().unwrap();
+        match h.mutate_inode(Inode(ino.into()), |_, inode| Ok((&*inode).into())) {
             Ok(attr) => reply.attr(&ENTRY_TTL, &attr),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn setattr(
-        &mut self,
+        &self,
         req: &Request,
-        inode: u64,
+        ino: INodeNo,
         mode: Option<u32>,
         uid: Option<u32>,
         gid: Option<u32>,
@@ -222,16 +234,17 @@ impl Filesystem for BackupFS {
         atime: Option<TimeOrNow>,
         mtime: Option<TimeOrNow>,
         ctime: Option<SystemTime>,
-        fh: Option<u64>,
+        fh: Option<FileHandle>,
         crtime: Option<SystemTime>,
         chgtime: Option<SystemTime>,
         bkuptime: Option<SystemTime>,
-        flags: Option<u32>,
+        flags: Option<BsdFileFlags>,
         reply: ReplyAttr,
     ) {
-        match self.handler.setattr(
+        let mut h = self.handler.lock().unwrap();
+        match h.setattr(
             req,
-            Inode(inode),
+            Inode(ino.into()),
             mode,
             uid,
             gid,
@@ -239,52 +252,54 @@ impl Filesystem for BackupFS {
             atime,
             mtime,
             ctime,
-            fh.map(FileHandleId),
+            fh.map(|fh| FileHandleId(fh.into())),
             crtime,
             chgtime,
             bkuptime,
-            flags,
+            flags.map(|f| f.bits()),
         ) {
             Ok(inode) => reply.attr(&ENTRY_TTL, &(&inode).into()),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    fn readlink(&mut self, req: &Request, inode: u64, reply: ReplyData) {
-        match self.handler.readlink(req, Inode(inode)) {
+    fn readlink(&self, req: &Request, ino: INodeNo, reply: ReplyData) {
+        let mut h = self.handler.lock().unwrap();
+        match h.readlink(req, Inode(ino.into())) {
             Ok(path) => reply.data(path.as_os_str().as_bytes()),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn mknod(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         name: &OsStr,
         mode: u32,
         umask: u32,
         rdev: u32,
         reply: ReplyEntry,
     ) {
-        match self.handler.mknod(
+        let mut h = self.handler.lock().unwrap();
+        match h.mknod(
             req,
-            Inode(parent),
+            Inode(parent.into()),
             name,
             mode,
             umask,
             rdev,
             None::<fn(Inode) -> FileData>,
         ) {
-            Ok(inode) => reply.entry(&ENTRY_TTL, &(&inode).into(), 0),
-            Err(e) => reply.error(e.to_errno_log()),
+            Ok(inode) => reply.entry(&ENTRY_TTL, &(&inode).into(), Generation(0)),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn mkdir(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         name: &OsStr,
         mode: u32,
         umask: u32,
@@ -293,119 +308,127 @@ impl Filesystem for BackupFS {
         self.mknod(req, parent, name, mode | libc::S_IFDIR, umask, 0, reply)
     }
 
-    fn unlink(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEmpty) {
-        match self.handler.unlink(req, Inode(parent), name) {
+    fn unlink(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+        let mut h = self.handler.lock().unwrap();
+        match h.unlink(req, Inode(parent.into()), name) {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    fn rmdir(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEmpty) {
-        match self.handler.unlink(req, Inode(parent), name) {
+    fn rmdir(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+        let mut h = self.handler.lock().unwrap();
+        match h.unlink(req, Inode(parent.into()), name) {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn symlink(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         link_name: &OsStr,
         target: &Path,
         reply: ReplyEntry,
     ) {
-        match self.handler.mknod(
+        let mut h = self.handler.lock().unwrap();
+        match h.mknod(
             req,
-            Inode(parent),
+            Inode(parent.into()),
             link_name,
             libc::S_IFLNK | 0o777,
             0,
             0,
             Some(|_| FileData::Symlink(target.to_owned())),
         ) {
-            Ok(inode) => reply.entry(&ENTRY_TTL, &(&inode).into(), 0),
-            Err(e) => reply.error(e.to_errno_log()),
+            Ok(inode) => reply.entry(&ENTRY_TTL, &(&inode).into(), Generation(0)),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn rename(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         name: &OsStr,
-        new_parent: u64,
-        new_name: &OsStr,
-        flags: u32,
+        newparent: INodeNo,
+        newname: &OsStr,
+        flags: RenameFlags,
         reply: ReplyEmpty,
     ) {
-        match self.handler.rename(
+        let mut h = self.handler.lock().unwrap();
+        match h.rename(
             req,
-            Inode(parent),
+            Inode(parent.into()),
             name,
-            Inode(new_parent),
-            new_name,
-            flags & libc::RENAME_EXCHANGE != 0,
+            Inode(newparent.into()),
+            newname,
+            flags.contains(RenameFlags::RENAME_EXCHANGE),
         ) {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn link(
-        &mut self,
+        &self,
         req: &Request,
-        inode: u64,
-        new_parent: u64,
-        new_name: &OsStr,
+        ino: INodeNo,
+        newparent: INodeNo,
+        newname: &OsStr,
         reply: ReplyEntry,
     ) {
-        debug!(
-            "link() called for {}, {}, {:?}",
-            inode, new_parent, new_name
-        );
-        match self
-            .handler
-            .link(req, Inode(inode), Inode(new_parent), new_name, None)
-        {
-            Ok(inode) => reply.entry(&ENTRY_TTL, &(&inode).into(), 0),
-            Err(e) => reply.error(e.to_errno_log()),
+        debug!("link() called for {}, {}, {:?}", ino, newparent, newname);
+        let mut h = self.handler.lock().unwrap();
+        match h.link(
+            req,
+            Inode(ino.into()),
+            Inode(newparent.into()),
+            newname,
+            None,
+        ) {
+            Ok(inode) => reply.entry(&ENTRY_TTL, &(&inode).into(), Generation(0)),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    fn open(&mut self, req: &Request, inode: u64, flags: i32, reply: ReplyOpen) {
-        debug!("open() called for {:?}", inode);
-        match self.handler.open(req, Inode(inode), flags) {
-            Ok(FileHandleId(fh)) => reply.opened(fh, FOPEN_DIRECT_IO),
-            Err(e) => reply.error(e.to_errno_log()),
+    fn open(&self, req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+        debug!("open() called for {:?}", ino);
+        let mut h = self.handler.lock().unwrap();
+        match h.open(req, Inode(ino.into()), flags.0) {
+            Ok(FileHandleId(fh)) => reply.opened(FileHandle(fh), FopenFlags::FOPEN_DIRECT_IO),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn read(
-        &mut self,
+        &self,
         _req: &Request,
-        inode: u64,
-        fh: u64,
-        offset: i64,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
         size: u32,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        _flags: OpenFlags,
+        _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {
         debug!(
             "read() called on {:?} offset={:?} size={:?}",
-            inode, offset, size
+            ino, offset, size
         );
-        if offset < 0 {
-            reply.error(libc::EINVAL);
-            return;
-        }
-        let Some(handle) = self.handler.handle(FileHandleId(fh)).cloned() else {
-            reply.error(libc::EBADF);
+        let handle = self
+            .handler
+            .lock()
+            .unwrap()
+            .handle(FileHandleId(fh.into()))
+            .cloned();
+        let Some(handle) = handle else {
+            reply.error(errno(libc::EBADF));
             return;
         };
         if !handle.read {
-            reply.error(libc::EACCES);
+            reply.error(errno(libc::EACCES));
             return;
         }
         // Offload the actual disk I/O — a stuck CIFS read must not
@@ -414,38 +437,40 @@ impl Filesystem for BackupFS {
         let key = handle.inode.0;
         pool::global().submit_for(key, move || {
             let mut contents = handle.contents.lock().unwrap();
-            let available = contents.inode.attrs.size.saturating_sub(offset as u64) as usize;
+            let available = contents.inode.attrs.size.saturating_sub(offset) as usize;
             let size = (size as usize).min(available);
             let mut buf = vec![0_u8; size];
-            match contents.read_exact_at(&mut buf, offset as u64) {
+            match contents.read_exact_at(&mut buf, offset) {
                 Ok(()) => reply.data(&buf),
-                Err(e) => reply.error(e.to_errno_log()),
+                Err(e) => reply.error(errno(e.to_errno_log())),
             }
         });
     }
 
     fn write(
-        &mut self,
+        &self,
         _req: &Request,
-        _inode: u64,
-        fh: u64,
-        offset: i64,
+        _ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
         data: &[u8],
-        _write_flags: u32,
-        flags: i32,
-        _lock_owner: Option<u64>,
+        write_flags: WriteFlags,
+        _flags: OpenFlags,
+        _lock_owner: Option<LockOwner>,
         reply: ReplyWrite,
     ) {
-        if offset < 0 {
-            reply.error(libc::EINVAL);
-            return;
-        }
-        let Some(handle) = self.handler.handle(FileHandleId(fh)).cloned() else {
-            reply.error(libc::EBADF);
+        let handle = self
+            .handler
+            .lock()
+            .unwrap()
+            .handle(FileHandleId(fh.into()))
+            .cloned();
+        let Some(handle) = handle else {
+            reply.error(errno(libc::EBADF));
             return;
         };
         if !handle.write {
-            reply.error(libc::EACCES);
+            reply.error(errno(libc::EACCES));
             return;
         }
         // Copy the bytes now (the kernel's buffer is reused after
@@ -454,48 +479,62 @@ impl Filesystem for BackupFS {
         let key = handle.inode.0;
         pool::global().submit_for(key, move || {
             let mut contents = handle.contents.lock().unwrap();
-            match contents.write_all_at(&mut buf, offset as u64) {
+            match contents.write_all_at(&mut buf, offset) {
                 Ok(()) => {
-                    if flags & fuser::consts::FUSE_WRITE_KILL_PRIV as i32 != 0 {
+                    if write_flags.contains(WriteFlags::FUSE_WRITE_KILL_SUIDGID) {
                         contents.inode.attrs.clear_suid_sgid();
                     }
                     reply.written(buf.len() as u32);
                 }
-                Err(e) => reply.error(e.to_errno_log()),
+                Err(e) => reply.error(errno(e.to_errno_log())),
             }
         });
     }
 
     fn flush(
-        &mut self,
+        &self,
         _req: &Request,
-        _inode: u64,
-        _fh: u64,
-        _lock_owner: u64,
+        _ino: INodeNo,
+        _fh: FileHandle,
+        _lock_owner: LockOwner,
         reply: ReplyEmpty,
     ) {
         reply.ok()
     }
 
     fn release(
-        &mut self,
+        &self,
         _req: &Request,
-        _inode: u64,
-        fh: u64,
-        _flags: i32,
-        _lock_owner: Option<u64>,
+        _ino: INodeNo,
+        fh: FileHandle,
+        _flags: OpenFlags,
+        _lock_owner: Option<LockOwner>,
         _flush: bool,
         reply: ReplyEmpty,
     ) {
-        match self.handler.fclose(FileHandleId(fh)) {
+        let mut h = self.handler.lock().unwrap();
+        match h.fclose(FileHandleId(fh.into())) {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    fn fsync(&mut self, _req: &Request, _inode: u64, fh: u64, _datasync: bool, reply: ReplyEmpty) {
-        let Some(handle) = self.handler.handle(FileHandleId(fh)).cloned() else {
-            reply.error(libc::EBADF);
+    fn fsync(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        fh: FileHandle,
+        _datasync: bool,
+        reply: ReplyEmpty,
+    ) {
+        let handle = self
+            .handler
+            .lock()
+            .unwrap()
+            .handle(FileHandleId(fh.into()))
+            .cloned();
+        let Some(handle) = handle else {
+            reply.error(errno(libc::EBADF));
             return;
         };
         // fsync drives the content-file atomic save + inode save —
@@ -505,36 +544,36 @@ impl Filesystem for BackupFS {
         let key = handle.inode.0;
         pool::global().submit_for(key, move || match handle.contents.lock().unwrap().fsync() {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         });
     }
 
-    fn opendir(&mut self, req: &Request, inode: u64, flags: i32, reply: ReplyOpen) {
-        debug!("opendir() called on {:?}", inode);
-        match self.handler.opendir(req, Inode(inode), flags) {
-            Ok(FileHandleId(fh)) => reply.opened(fh, FOPEN_DIRECT_IO),
-            Err(e) => reply.error(e.to_errno_log()),
+    fn opendir(&self, req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+        debug!("opendir() called on {:?}", ino);
+        let mut h = self.handler.lock().unwrap();
+        match h.opendir(req, Inode(ino.into()), flags.0) {
+            Ok(FileHandleId(fh)) => reply.opened(FileHandle(fh), FopenFlags::FOPEN_DIRECT_IO),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn readdir(
-        &mut self,
+        &self,
         req: &Request,
-        inode: u64,
-        fh: u64,
-        offset: i64,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
         mut reply: ReplyDirectory,
     ) {
-        if offset < 0 {
-            reply.error(libc::EINVAL);
-            return;
-        }
-        match self.handler.readdir(
+        let mut h = self.handler.lock().unwrap();
+        match h.readdir(
             req,
-            Inode(inode),
-            FileHandleId(fh),
-            offset,
-            |_, name, entry, offset| Ok(reply.add(entry.inode.0, offset, entry.ty, name)),
+            Inode(ino.into()),
+            FileHandleId(fh.into()),
+            offset as i64,
+            |_, name, entry, offset| {
+                Ok(reply.add(INodeNo(entry.inode.0), offset as u64, entry.ty, name))
+            },
         ) {
             Ok(done) => {
                 if done {
@@ -542,36 +581,33 @@ impl Filesystem for BackupFS {
                 }
                 reply.ok()
             }
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn readdirplus(
-        &mut self,
-        req: &Request<'_>,
-        inode: u64,
-        fh: u64,
-        offset: i64,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
         mut reply: ReplyDirectoryPlus,
     ) {
-        if offset < 0 {
-            reply.error(libc::EINVAL);
-            return;
-        }
-        match self.handler.readdir(
+        let mut h = self.handler.lock().unwrap();
+        match h.readdir(
             req,
-            Inode(inode),
-            FileHandleId(fh),
-            offset,
+            Inode(ino.into()),
+            FileHandleId(fh.into()),
+            offset as i64,
             |handler, name, entry, offset| {
                 match handler.mutate_inode(entry.inode, |_, inode| {
                     Ok(reply.add(
-                        inode.inode.0,
-                        offset,
+                        INodeNo(inode.inode.0),
+                        offset as u64,
                         name,
                         &ENTRY_TTL,
                         &(&*inode).into(),
-                        0,
+                        Generation(0),
                     ))
                 }) {
                     Ok(full) => Ok(full),
@@ -589,32 +625,30 @@ impl Filesystem for BackupFS {
                 }
                 reply.ok()
             }
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn releasedir(
-        &mut self,
-        req: &Request<'_>,
-        inode: u64,
-        fh: u64,
-        flags: i32,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        flags: OpenFlags,
         reply: ReplyEmpty,
     ) {
-        match self
-            .handler
-            .releasedir(req, Inode(inode), FileHandleId(fh), flags)
-        {
+        let mut h = self.handler.lock().unwrap();
+        match h.releasedir(req, Inode(ino.into()), FileHandleId(fh.into()), flags.0) {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn fsyncdir(
-        &mut self,
+        &self,
         _req: &Request,
-        _inode: u64,
-        _fh: u64,
+        _ino: INodeNo,
+        _fh: FileHandle,
         _datasync: bool,
         reply: ReplyEmpty,
     ) {
@@ -629,13 +663,14 @@ impl Filesystem for BackupFS {
         // have a working checkpoint.
         #[cfg(test)]
         FSYNCDIR_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        match self.handler.flush_all_dirty() {
+        let mut h = self.handler.lock().unwrap();
+        match h.flush_all_dirty() {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    fn syncfs(&mut self, _req: &Request<'_>, reply: ReplyEmpty) {
+    fn syncfs(&self, _req: &Request, reply: ReplyEmpty) {
         // `sync -f <mountpoint>` / syncfs(2). flush_all_dirty drains
         // both the dirty inode cache and every open Contents with
         // per-file sync_all, so the checkpoint is on stable storage
@@ -643,14 +678,15 @@ impl Filesystem for BackupFS {
         // without losing anything that was written before sync -f.
         #[cfg(test)]
         SYNCFS_CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        match self.handler.flush_all_dirty() {
+        let mut h = self.handler.lock().unwrap();
+        match h.flush_all_dirty() {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    fn statfs(&mut self, _req: &Request, _ino: u64, reply: ReplyStatfs) {
-        let StatFs { files, ffree } = self.handler.ctrl().statfs();
+    fn statfs(&self, _req: &Request, _ino: INodeNo, reply: ReplyStatfs) {
+        let StatFs { files, ffree } = self.handler.lock().unwrap().ctrl().statfs();
         // TODO: real implementation of this
         reply.statfs(
             10_000,
@@ -665,48 +701,48 @@ impl Filesystem for BackupFS {
     }
 
     fn setxattr(
-        &mut self,
-        request: &Request<'_>,
-        inode: u64,
-        key: &OsStr,
+        &self,
+        request: &Request,
+        ino: INodeNo,
+        name: &OsStr,
         value: &[u8],
         _flags: i32,
         _position: u32,
         reply: ReplyEmpty,
     ) {
-        match self
-            .handler
-            .setxattr(request, Inode(inode), key.as_bytes(), value)
-        {
+        let mut h = self.handler.lock().unwrap();
+        match h.setxattr(request, Inode(ino.into()), name.as_bytes(), value) {
             Ok(()) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn getxattr(
-        &mut self,
-        request: &Request<'_>,
-        inode: u64,
-        key: &OsStr,
+        &self,
+        request: &Request,
+        ino: INodeNo,
+        name: &OsStr,
         size: u32,
         reply: ReplyXattr,
     ) {
-        match self.handler.getxattr(request, Inode(inode), key.as_bytes()) {
+        let h = self.handler.lock().unwrap();
+        match h.getxattr(request, Inode(ino.into()), name.as_bytes()) {
             Ok(data) => {
                 if size == 0 {
                     reply.size(data.len() as u32);
                 } else if data.len() <= size as usize {
                     reply.data(&data);
                 } else {
-                    reply.error(libc::ERANGE)
+                    reply.error(errno(libc::ERANGE))
                 }
             }
-            Err(e) => reply.error(e.to_errno()),
+            Err(e) => reply.error(errno(e.to_errno())),
         }
     }
 
-    fn listxattr(&mut self, request: &Request<'_>, inode: u64, size: u32, reply: ReplyXattr) {
-        match self.handler.listxattr(request, Inode(inode)) {
+    fn listxattr(&self, request: &Request, ino: INodeNo, size: u32, reply: ReplyXattr) {
+        let h = self.handler.lock().unwrap();
+        match h.listxattr(request, Inode(ino.into())) {
             Ok(attrs) => {
                 let mut bytes = vec![];
                 // Convert to concatenated null-terminated strings
@@ -719,113 +755,113 @@ impl Filesystem for BackupFS {
                 } else if bytes.len() <= size as usize {
                     reply.data(&bytes);
                 } else {
-                    reply.error(libc::ERANGE);
+                    reply.error(errno(libc::ERANGE));
                 }
             }
-            Err(_) => reply.error(libc::EBADF),
+            Err(_) => reply.error(errno(libc::EBADF)),
         }
     }
 
-    fn removexattr(&mut self, request: &Request<'_>, inode: u64, key: &OsStr, reply: ReplyEmpty) {
-        match self
-            .handler
-            .removexattr(request, Inode(inode), key.as_bytes())
-        {
+    fn removexattr(&self, request: &Request, ino: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+        let mut h = self.handler.lock().unwrap();
+        match h.removexattr(request, Inode(ino.into()), name.as_bytes()) {
             Ok(_) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    fn access(&mut self, req: &Request, inode: u64, mask: i32, reply: ReplyEmpty) {
+    fn access(&self, req: &Request, ino: INodeNo, mask: AccessFlags, reply: ReplyEmpty) {
         // peek_inode consults open Contents and the dirty cache before
         // disk; ctrl.load alone returns ENOENT for inodes that have only
         // ever lived in the dirty cache (e.g. a just-mkdir'd directory),
         // which the kernel would then propagate to path-walk callers like
         // chdir — breaking rsync --mkpath into a fresh mount.
-        let idmap = self.handler.ctrl().config().idmapped_root.clone();
-        match self.handler.peek_inode(Inode(inode), |inode| {
-            inode.attrs.check_access(&idmap, req.uid(), req.gid(), mask)
+        let h = self.handler.lock().unwrap();
+        let idmap = h.ctrl().config().idmapped_root.clone();
+        match h.peek_inode(Inode(ino.into()), |inode| {
+            inode
+                .attrs
+                .check_access(&idmap, req.uid(), req.gid(), mask.bits())
         }) {
             Ok(_) => reply.ok(),
-            Err(e) => reply.error(e.to_errno()),
+            Err(e) => reply.error(errno(e.to_errno())),
         }
     }
 
     fn create(
-        &mut self,
+        &self,
         req: &Request,
-        parent: u64,
+        parent: INodeNo,
         name: &OsStr,
         mode: u32,
         umask: u32,
         flags: i32,
         reply: ReplyCreate,
     ) {
-        match self
-            .handler
-            .create(req, Inode(parent), name, mode, umask, flags)
-        {
-            Ok((attrs, handle)) => {
-                reply.created(&Duration::new(0, 0), &(&attrs).into(), 0, handle.0, 0)
-            }
-            Err(e) => reply.error(e.to_errno_log()),
+        let mut h = self.handler.lock().unwrap();
+        match h.create(req, Inode(parent.into()), name, mode, umask, flags) {
+            Ok((attrs, handle)) => reply.created(
+                &Duration::new(0, 0),
+                &(&attrs).into(),
+                Generation(0),
+                FileHandle(handle.0),
+                FopenFlags::empty(),
+            ),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
-    #[cfg(target_os = "linux")]
     fn fallocate(
-        &mut self,
-        req: &Request<'_>,
-        inode: u64,
-        fh: u64,
-        offset: i64,
-        length: i64,
+        &self,
+        req: &Request,
+        ino: INodeNo,
+        fh: FileHandle,
+        offset: u64,
+        length: u64,
         mode: i32,
         reply: ReplyEmpty,
     ) {
-        if offset < 0 || length < 0 {
-            reply.error(libc::EINVAL);
-            return;
-        }
-        match self.handler.fallocate(
+        let mut h = self.handler.lock().unwrap();
+        match h.fallocate(
             req,
-            Inode(inode),
-            FileHandleId(fh),
-            offset as u64,
-            length as u64,
+            Inode(ino.into()),
+            FileHandleId(fh.into()),
+            offset,
+            length,
             mode,
         ) {
             Ok(_) => reply.ok(),
-            Err(e) => reply.error(e.to_errno_log()),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 
     fn copy_file_range(
-        &mut self,
-        req: &Request<'_>,
-        src_inode: u64,
-        src_fh: u64,
-        src_offset: i64,
-        dest_inode: u64,
-        dest_fh: u64,
-        dest_offset: i64,
-        size: u64,
-        flags: u32,
+        &self,
+        req: &Request,
+        ino_in: INodeNo,
+        fh_in: FileHandle,
+        offset_in: u64,
+        ino_out: INodeNo,
+        fh_out: FileHandle,
+        offset_out: u64,
+        len: u64,
+        flags: CopyFileRangeFlags,
         reply: ReplyWrite,
     ) {
-        match self.handler.copy_file_range(
+        let mut h = self.handler.lock().unwrap();
+        match h.copy_file_range(
             req,
-            Inode(src_inode),
-            FileHandleId(src_fh),
-            src_offset as u64,
-            Inode(dest_inode),
-            FileHandleId(dest_fh),
-            dest_offset as u64,
-            size as usize,
-            flags,
+            Inode(ino_in.into()),
+            FileHandleId(fh_in.into()),
+            offset_in,
+            Inode(ino_out.into()),
+            FileHandleId(fh_out.into()),
+            offset_out,
+            len as usize,
+            flags.bits() as u32,
         ) {
-            Ok(len) => reply.written(len as u32),
-            Err(e) => reply.error(e.to_errno_log()),
+            Ok(written) => reply.written(written as u32),
+            Err(e) => reply.error(errno(e.to_errno_log())),
         }
     }
 }

--- a/projects/start-os/backup-fs/src/lib.rs
+++ b/projects/start-os/backup-fs/src/lib.rs
@@ -4,11 +4,9 @@
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
-use std::num::ParseIntError;
 use std::os::raw::c_int;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
@@ -27,7 +25,7 @@ fn errno(e: c_int) -> Errno {
 
 use crate::ctrl::{Controller, StatFs};
 use crate::directory::DirectoryContents;
-use crate::error::{BkfsError, BkfsResult};
+use crate::error::BkfsResult;
 use crate::handle::{FileHandleId, Handler};
 use crate::inode::{FileData, Inode, InodeAttributes, BLOCK_SIZE};
 
@@ -66,8 +64,6 @@ pub(crate) static SYNCFS_CALL_COUNT: std::sync::atomic::AtomicU64 =
 pub(crate) static FSYNCDIR_CALL_COUNT: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
-const FMODE_EXEC: i32 = 0x20;
-
 pub(crate) fn open_direct(
     path: &Path,
     create: bool,
@@ -93,33 +89,12 @@ pub struct BackupFSOptions {
     pub file_size_padding: Option<f64>,
     #[cfg_attr(feature = "cli", arg(short, long))]
     pub readonly: bool,
-    #[cfg_attr(feature = "cli", arg(long))]
-    pub idmapped_root: Vec<IdMappedRoot>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct IdMappedRoot {
-    root_uid: u32,
-    range: u32,
-}
-impl IdMappedRoot {
-    pub fn is_root_for(&self, uid: u32, uids: impl IntoIterator<Item = u32>) -> bool {
-        self.root_uid == uid
-            && uids
-                .into_iter()
-                .all(|uid| uid >= self.root_uid && uid < self.root_uid + self.range)
-    }
-}
-impl FromStr for IdMappedRoot {
-    type Err = BkfsError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (root_uid, range) = s
-            .split_once(":")
-            .map(|(uid, range)| Ok::<(u32, u32), ParseIntError>((uid.parse()?, range.parse()?)))
-            .ok_or_else(|| BkfsError::wrap(io::Error::other("invalid idmap")))?
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-        Ok(Self { root_uid, range })
-    }
+    /// True for the production mount, which start-core wraps in a kernel
+    /// idmapped mount and mounts with default_permissions. Gates the
+    /// FUSE_ALLOW_IDMAP request — asking for it on a plain mount (no
+    /// default_permissions) aborts the FUSE connection.
+    #[cfg_attr(feature = "cli", arg(skip))]
+    pub idmapped: bool,
 }
 
 // Stores inode metadata data in "$data_dir/inodes" and file contents in "$data_dir/contents"
@@ -182,6 +157,12 @@ impl Filesystem for BackupFS {
         config
             .add_capabilities(InitFlags::FUSE_HANDLE_KILLPRIV)
             .unwrap();
+        // Only request idmap support on the production (kernel-idmapped,
+        // default_permissions) mount — requesting it on a plain mount aborts
+        // the FUSE connection. Tolerant: pre-6.12 kernels lack the cap.
+        if self.handler.get_mut().unwrap().ctrl().config().idmapped {
+            let _ = config.add_capabilities(InitFlags::FUSE_ALLOW_IDMAP);
+        }
 
         log::info!("filesystem initialized");
 
@@ -770,22 +751,8 @@ impl Filesystem for BackupFS {
         }
     }
 
-    fn access(&self, req: &Request, ino: INodeNo, mask: AccessFlags, reply: ReplyEmpty) {
-        // peek_inode consults open Contents and the dirty cache before
-        // disk; ctrl.load alone returns ENOENT for inodes that have only
-        // ever lived in the dirty cache (e.g. a just-mkdir'd directory),
-        // which the kernel would then propagate to path-walk callers like
-        // chdir — breaking rsync --mkpath into a fresh mount.
-        let h = self.handler.lock().unwrap();
-        let idmap = h.ctrl().config().idmapped_root.clone();
-        match h.peek_inode(Inode(ino.into()), |inode| {
-            inode
-                .attrs
-                .check_access(&idmap, req.uid(), req.gid(), mask.bits())
-        }) {
-            Ok(_) => reply.ok(),
-            Err(e) => reply.error(errno(e.to_errno())),
-        }
+    fn access(&self, _req: &Request, _ino: INodeNo, _mask: AccessFlags, reply: ReplyEmpty) {
+        reply.ok()
     }
 
     fn create(
@@ -881,26 +848,6 @@ fn as_file_kind(mut mode: u32) -> FileKind {
     }
 }
 */
-
-pub fn get_groups(pid: u32) -> Vec<u32> {
-    #[cfg(not(target_os = "macos"))]
-    {
-        let path = format!("/proc/{pid}/task/{pid}/status");
-        let file = File::open(path).unwrap();
-        for line in BufReader::new(file).lines() {
-            let line = line.unwrap();
-            if line.starts_with("Groups:") {
-                return line["Groups: ".len()..]
-                    .split(' ')
-                    .filter(|x| !x.trim().is_empty())
-                    .map(|x| x.parse::<u32>().unwrap())
-                    .collect();
-            }
-        }
-    }
-
-    vec![]
-}
 
 pub fn fuse_allow_other_enabled() -> BkfsResult<bool> {
     let file = File::open("/etc/fuse.conf")?;

--- a/projects/start-os/backup-fs/src/main.rs
+++ b/projects/start-os/backup-fs/src/main.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use backupfs::error::BkfsErrorKind;
 use backupfs::{BackupFS, BackupFSOptions};
 use clap::{CommandFactory, FromArgMatches, Parser};
-use fuser::MountOption;
+use fuser::{Config, MountOption, SessionACL};
 use log::{error, info};
 
 #[derive(clap::Parser)]
@@ -13,14 +13,14 @@ struct MountOptions {
     #[command(flatten)]
     backup_opts: BackupFSOptions,
     #[arg(short = 'o', value_delimiter = ',')]
-    opt: Vec<MountOption>,
+    opt: Vec<String>,
     mountpoint: PathBuf,
 }
 
 #[derive(clap::Parser)]
 struct BasicMountOptions {
     #[arg(short = 'o', value_delimiter = ',')]
-    opt: Vec<MountOption>,
+    opt: Vec<String>,
     data_dir: PathBuf,
     mountpoint: PathBuf,
 }
@@ -31,6 +31,37 @@ struct ChangePasswordOptions {
     backup_opts: BackupFSOptions,
     #[arg(long)]
     new_password: String,
+}
+
+enum ParsedOption {
+    Mount(MountOption),
+    AllowOther,
+    AllowRoot,
+}
+
+fn parse_option(s: &str) -> ParsedOption {
+    match s {
+        "allow_other" => ParsedOption::AllowOther,
+        "allow_root" => ParsedOption::AllowRoot,
+        "auto_unmount" => ParsedOption::Mount(MountOption::AutoUnmount),
+        "default_permissions" => ParsedOption::Mount(MountOption::DefaultPermissions),
+        "dev" => ParsedOption::Mount(MountOption::Dev),
+        "nodev" => ParsedOption::Mount(MountOption::NoDev),
+        "suid" => ParsedOption::Mount(MountOption::Suid),
+        "nosuid" => ParsedOption::Mount(MountOption::NoSuid),
+        "ro" => ParsedOption::Mount(MountOption::RO),
+        "rw" => ParsedOption::Mount(MountOption::RW),
+        "exec" => ParsedOption::Mount(MountOption::Exec),
+        "noexec" => ParsedOption::Mount(MountOption::NoExec),
+        "atime" => ParsedOption::Mount(MountOption::Atime),
+        "noatime" => ParsedOption::Mount(MountOption::NoAtime),
+        "dirsync" => ParsedOption::Mount(MountOption::DirSync),
+        "sync" => ParsedOption::Mount(MountOption::Sync),
+        "async" => ParsedOption::Mount(MountOption::Async),
+        x if x.starts_with("fsname=") => ParsedOption::Mount(MountOption::FSName(x[7..].into())),
+        x if x.starts_with("subtype=") => ParsedOption::Mount(MountOption::Subtype(x[8..].into())),
+        x => ParsedOption::Mount(MountOption::CUSTOM(x.into())),
+    }
 }
 
 fn main() {
@@ -56,7 +87,7 @@ fn main() {
                 [OsString::from("mount.backup-fs")]
                     .into_iter()
                     .chain(opt.iter().filter_map(|opt| {
-                        if let MountOption::CUSTOM(opt) = opt {
+                        if let ParsedOption::Mount(MountOption::CUSTOM(opt)) = parse_option(opt) {
                             Some::<OsString>(format!("--{opt}").into())
                         } else {
                             None
@@ -66,7 +97,7 @@ fn main() {
             ),
             opt: opt
                 .into_iter()
-                .filter(|o| !matches!(o, MountOption::CUSTOM(_)))
+                .filter(|o| !matches!(parse_option(o), ParsedOption::Mount(MountOption::CUSTOM(_))))
                 .collect(),
             mountpoint,
         });
@@ -104,29 +135,46 @@ fn new_fs(opts: BackupFSOptions) -> BackupFS {
 fn mount(
     MountOptions {
         mut backup_opts,
-        mut opt,
+        opt,
         mountpoint,
     }: MountOptions,
 ) {
-    opt.push(MountOption::FSName("backup-fs".to_string()));
+    let mut config = Config::default();
+    for o in &opt {
+        match parse_option(o) {
+            ParsedOption::Mount(m) => config.mount_options.push(m),
+            ParsedOption::AllowOther => config.acl = SessionACL::All,
+            ParsedOption::AllowRoot => config.acl = SessionACL::RootAndOwner,
+        }
+    }
+
+    config
+        .mount_options
+        .push(MountOption::FSName("backup-fs".to_string()));
 
     if backup_opts.setuid_support {
         info!("setuid bit support enabled");
-        opt.push(MountOption::Suid);
-    } else if opt.contains(&MountOption::Suid) {
+        config.mount_options.push(MountOption::Suid);
+    } else if config.mount_options.contains(&MountOption::Suid) {
         info!("setuid bit support enabled");
         backup_opts.setuid_support = true;
     } else {
-        opt.push(MountOption::AutoUnmount);
+        config.mount_options.push(MountOption::AutoUnmount);
     }
 
     if backup_opts.readonly {
-        opt.push(MountOption::RO);
-    } else if opt.contains(&MountOption::RO) {
+        config.mount_options.push(MountOption::RO);
+    } else if config.mount_options.contains(&MountOption::RO) {
         backup_opts.readonly = true;
     }
 
-    let result = fuser::Session::new(new_fs(backup_opts), &mountpoint, &opt);
+    // AutoUnmount requires a non-Owner acl in 0.17 (fusermount needs
+    // allow_other/allow_root); the old fuser injected allow_other here.
+    if config.mount_options.contains(&MountOption::AutoUnmount) && config.acl == SessionACL::Owner {
+        config.acl = SessionACL::All;
+    }
+
+    let result = fuser::Session::new(new_fs(backup_opts), &mountpoint, &config);
     match result {
         Err(e) => {
             error!("{:?}", e);
@@ -137,14 +185,17 @@ fn mount(
             }
             std::process::exit(1);
         }
-        Ok(mut s) => {
-            let mut umount = s.unmount_callable();
-            ctrlc::set_handler(move || {
-                let _ = umount.unmount();
-            })
-            .unwrap();
+        Ok(s) => {
+            // daemon() forks; only the calling thread survives, so spawn the
+            // session loop in the child. Normal shutdown is an external
+            // unmount (StartOS `umount`), which makes the loop exit via
+            // ENODEV and join() return. On SIGINT/SIGTERM just exit and let
+            // AutoUnmount tear the mount down — an explicit umount deadlocks
+            // against AutoUnmount under spawn().
             nix::unistd::daemon(true, true).unwrap();
-            s.run().unwrap()
+            let bg = s.spawn().unwrap();
+            ctrlc::set_handler(|| std::process::exit(0)).unwrap();
+            bg.join().unwrap()
         }
     }
 }

--- a/projects/start-os/backup-fs/src/main.rs
+++ b/projects/start-os/backup-fs/src/main.rs
@@ -151,6 +151,8 @@ fn mount(
     config
         .mount_options
         .push(MountOption::FSName("backup-fs".to_string()));
+    config.mount_options.push(MountOption::DefaultPermissions);
+    backup_opts.idmapped = true;
 
     if backup_opts.setuid_support {
         info!("setuid bit support enabled");

--- a/projects/start-os/backup-fs/src/tests.rs
+++ b/projects/start-os/backup-fs/src/tests.rs
@@ -4,7 +4,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
-use fuser::MountOption;
+use fuser::{Config, MountOption};
 use tempdir::TempDir;
 use tokio::task::JoinSet;
 
@@ -57,46 +57,34 @@ fn with_backupfs(
     func: impl FnOnce(&Path),
     file_size_padding: Option<f64>,
 ) {
-    struct Unmounter(fuser::SessionUnmounter);
-    impl Drop for Unmounter {
-        fn drop(&mut self) {
-            let _ = self.0.unmount();
-        }
-    }
-
     let mnt = tempdir::TempDir::new("backupfs_mnt").unwrap();
-    let opt = vec![
-        MountOption::FSName("backup-fs".to_string()),
-        MountOption::AutoUnmount,
-    ];
-    let data_dir = data.to_owned();
-    let mnt_dir = mnt.path().to_owned();
-    let (ready_sender, ready_reciever) = oneshot::channel();
-    let thread = std::thread::spawn(move || {
-        let fs = BackupFS::new(BackupFSOptions {
-            data_dir,
-            setuid_support: false,
-            password,
-            file_size_padding,
-            readonly: false,
-            idmapped_root: vec![],
-        })
-        .unwrap();
-        let mut fs = {
-            let _guard = mount_lock().lock().unwrap_or_else(|e| e.into_inner());
-            fuser::Session::new(fs, mnt_dir, &opt).unwrap()
-        };
-        ready_sender.send(Unmounter(fs.unmount_callable())).unwrap();
-        fs.run().unwrap();
-    });
-    if let Ok(umount) = ready_reciever.recv() {
-        func(mnt.path());
-        drop(umount);
-    }
-    match thread.join() {
-        Ok(()) => (),
-        Err(err) => std::panic::resume_unwind(err),
+    let mut config = Config::default();
+    // No AutoUnmount: with 0.17's spawn(), the auto-unmount helper deadlocks
+    // an explicit umount. umount_and_join (and BackgroundSession's Drop, which
+    // unmounts via Mount on a panic) tear the mount down cleanly instead.
+    config.mount_options = vec![MountOption::FSName("backup-fs".to_string())];
+    let fs = BackupFS::new(BackupFSOptions {
+        data_dir: data.to_owned(),
+        setuid_support: false,
+        password,
+        file_size_padding,
+        readonly: false,
+        idmapped_root: vec![],
+    })
+    .unwrap();
+    // 0.17's spawn() moves the mount into the BackgroundSession, so an
+    // unmounter taken from the Session beforehand is dead. Drive the whole
+    // lifecycle through the BackgroundSession: run in the background, then
+    // umount_and_join. (A panic in func drops `bg`, whose Mount unmounts.)
+    let bg = {
+        let _guard = mount_lock().lock().unwrap_or_else(|e| e.into_inner());
+        fuser::Session::new(fs, mnt.path(), &config)
+            .unwrap()
+            .spawn()
+            .unwrap()
     };
+    func(mnt.path());
+    bg.umount_and_join().unwrap();
 }
 
 fn with_backupfs_async<F: Future<Output = ()> + Send + 'static>(

--- a/projects/start-os/backup-fs/src/tests.rs
+++ b/projects/start-os/backup-fs/src/tests.rs
@@ -62,6 +62,12 @@ fn with_backupfs(
     // No AutoUnmount: with 0.17's spawn(), the auto-unmount helper deadlocks
     // an explicit umount. umount_and_join (and BackgroundSession's Drop, which
     // unmounts via Mount on a panic) tear the mount down cleanly instead.
+    //
+    // No default_permissions either: these tests run unprivileged against a
+    // non-idmapped mount whose root dir the fs owns as a different uid, so
+    // kernel-side permission checks would EACCES every op. Production
+    // (main.rs) sets default_permissions — its enforcement is covered by the
+    // VM backup/restore test, where the mount is kernel-idmapped.
     config.mount_options = vec![MountOption::FSName("backup-fs".to_string())];
     let fs = BackupFS::new(BackupFSOptions {
         data_dir: data.to_owned(),
@@ -69,7 +75,7 @@ fn with_backupfs(
         password,
         file_size_padding,
         readonly: false,
-        idmapped_root: vec![],
+        idmapped: false,
     })
     .unwrap();
     // 0.17's spawn() moves the mount into the BackgroundSession, so an
@@ -237,7 +243,7 @@ fn checksum() {
         password: "rtns".to_owned(),
         file_size_padding: None,
         readonly: false,
-        idmapped_root: vec![],
+        idmapped: false,
     });
     match res {
         Ok(_) => panic!(),
@@ -264,7 +270,7 @@ fn change_password() {
             password: "ohea".to_owned(),
             file_size_padding: None,
             readonly: false,
-            idmapped_root: vec![],
+            idmapped: false,
         })
         .unwrap();
         fs.change_password("rtns").unwrap();
@@ -1382,7 +1388,7 @@ fn opts(data: &Path, password: &str) -> BackupFSOptions {
         password: password.to_owned(),
         file_size_padding: None,
         readonly: false,
-        idmapped_root: vec![],
+        idmapped: false,
     }
 }
 

--- a/shared-libs/crates/start-core/src/disk/mount/backup.rs
+++ b/shared-libs/crates/start-core/src/disk/mount/backup.rs
@@ -117,11 +117,8 @@ impl<G: GenericMountGuard> BackupMountGuard<G> {
                 )
             })?;
         }
-        let encrypted_guard = TmpMountGuard::mount(
-            &BackupFS::new(&crypt_path, &enc_key),
-            ReadWrite,
-        )
-        .await?;
+        let encrypted_guard =
+            TmpMountGuard::mount(&BackupFS::new(&crypt_path, &enc_key), ReadWrite).await?;
 
         let metadata_path = encrypted_guard.path().join("metadata.json");
         let metadata: BackupInfo = if tokio::fs::metadata(&metadata_path).await.is_ok() {

--- a/shared-libs/crates/start-core/src/disk/mount/backup.rs
+++ b/shared-libs/crates/start-core/src/disk/mount/backup.rs
@@ -118,7 +118,7 @@ impl<G: GenericMountGuard> BackupMountGuard<G> {
             })?;
         }
         let encrypted_guard = TmpMountGuard::mount(
-            &BackupFS::new(&crypt_path, &enc_key, vec![(100000, 65536)]),
+            &BackupFS::new(&crypt_path, &enc_key),
             ReadWrite,
         )
         .await?;

--- a/shared-libs/crates/start-core/src/disk/mount/filesystem/backupfs.rs
+++ b/shared-libs/crates/start-core/src/disk/mount/filesystem/backupfs.rs
@@ -12,15 +12,10 @@ use crate::prelude::*;
 pub struct BackupFS<DataDir: AsRef<Path>, Password: fmt::Display> {
     data_dir: DataDir,
     password: Password,
-    idmapped_root: Vec<(u32, u32)>,
 }
 impl<DataDir: AsRef<Path>, Password: fmt::Display> BackupFS<DataDir, Password> {
-    pub fn new(data_dir: DataDir, password: Password, idmapped_root: Vec<(u32, u32)>) -> Self {
-        BackupFS {
-            data_dir,
-            password,
-            idmapped_root,
-        }
+    pub fn new(data_dir: DataDir, password: Password) -> Self {
+        BackupFS { data_dir, password }
     }
 }
 impl<DataDir: AsRef<Path> + Send + Sync, Password: fmt::Display + Send + Sync> FileSystem
@@ -30,17 +25,14 @@ impl<DataDir: AsRef<Path> + Send + Sync, Password: fmt::Display + Send + Sync> F
         Some("backup-fs")
     }
     fn mount_options(&self) -> impl IntoIterator<Item = impl Display> {
+        // default_permissions + FUSE_ALLOW_IDMAP (set by the mount.backup-fs
+        // binary) let the container's backup bind be a real kernel idmapped
+        // mount — replacing the old FUSE-internal idmapped-root translation.
         [
             Cow::Owned(format!("password={}", self.password)),
             Cow::Borrowed("file-size-padding=0.05"),
             Cow::Borrowed("allow_other"),
         ]
-        .into_iter()
-        .chain(
-            self.idmapped_root
-                .iter()
-                .map(|(root, range)| Cow::Owned(format!("idmapped-root={root}:{range}"))),
-        )
     }
     async fn source(&self) -> Result<Option<impl AsRef<Path>>, Error> {
         Ok(Some(&self.data_dir))

--- a/shared-libs/crates/start-core/src/service/persistent_container.rs
+++ b/shared-libs/crates/start-core/src/service/persistent_container.rs
@@ -328,18 +328,19 @@ impl PersistentContainer {
             .rootfs_dir()
             .join("media/startos/backup");
         tokio::fs::create_dir_all(&mountpoint).await?;
-        Command::new("chown")
-            .arg("100000:100000")
-            .arg(mountpoint.as_os_str())
-            .invoke(ErrorKind::Filesystem)
-            .await?;
         tokio::fs::create_dir_all(backup_path).await?;
-        Command::new("chown")
-            .arg("100000:100000")
-            .arg(backup_path)
-            .invoke(ErrorKind::Filesystem)
-            .await?;
-        let bind = Bind::new(backup_path);
+        // Idmap the container's backup bind like a volume (on-disk 0-based
+        // <-> container userns 100000+), so backup-fs stores container-space
+        // ids and the container-root owns its backup tree. Replaces the old
+        // chown-to-100000 + backup-fs's FUSE-internal idmapped-root.
+        let bind = IdMapped::new(
+            Bind::new(backup_path),
+            vec![IdMap {
+                from_id: 0,
+                to_id: 100000,
+                range: 65536,
+            }],
+        );
         MountGuard::mount(&bind, &mountpoint, mount_type).await
     }
 


### PR DESCRIPTION
Switches `startos-backup-fs` from its FUSE-internal `idmapped_root` uid-translation to a real **kernel idmapped mount**, removing the whole `is_root_for` permission machinery — including the `system.posix_acl_*` `EPERM` where an idmapped container-root couldn't set ACLs (`xattr_access_check` branch `C` ignored the idmap and denied any non-literal-uid-0 caller).

Depends on **Start9Labs/fuser#1** (merged; `master` now upstream fuser 0.17 + our `FUSE_SYNCFS`). Pins `4ef196b`.

### Commits
1. **`refactor(backup-fs): migrate to fuser 0.17 API`** — `handler: Mutex<Handler>` for the `&self` methods (`init`/`destroy` stay `&mut self`); newtype/bitflag/`Errno` conversions across the adapter; `Config`-based mount. Also fixes a real deadlock: under 0.17 `spawn()` an `unmount_callable()` taken before spawn is dead (spawn `mem::take`s the mount) and `AutoUnmount` deadlocks an explicit umount — the daemon now exits on external unmount / signal.
2. **`feat(backup-fs): hand permission enforcement to the kernel`** — `default_permissions` + `FUSE_ALLOW_IDMAP` (gated on an `idmapped` flag: requesting it without `default_permissions` aborts the FUSE connection, so unprivileged tests stay on a plain mount). Removes `check_access`/`check_sticky`/`is_root_for`/`xattr_access_check` + the `setattr` uid guards + the `idmapped_root` plumbing. Kept: suid/sgid side-effects (now `uid==0`), `creation_gid`, the fh-truncate write check.
3. **`feat(start-core): idmap the container's backup bind`** — the container's bind into the backup fs (`persistent_container.mount_backup`) becomes an `IdMapped` bind `{from_id:0,to_id:100000,range:65536}` (mirroring volumes) instead of a plain bind + chown-to-100000; drops the `idmapped-root=` mount option + `vec![(100000,65536)]`.

### On-disk id-space (please sanity-check)
Mirroring the volume idmap means backup-fs now stores **container-space (0-based)** ownership instead of host-space (100000+). The container's backup procedure copies volume→backup, both 0-based in its view; StartOS (root=0) writing metadata also stores 0-based. **No migration** — the backup format is an unreleased break, so now is the window.

### Validation
- ✅ fuser: build/clippy/53 tests. backup-fs: build/clippy + **all 72 tests** (incl. FUSE mount/remount round-trips). start-core: `cargo check` clean.
- ⛔ **Merge gate — needs a VM:** unprivileged non-idmapped tests can't exercise the kernel-idmap path. Before merge: backup→restore round-trip on a 6.12+ host with an idmapped LXC + ACLs, confirming chmod/chown/sticky-unlink and the ACL-set case (the original bug) all work under kernel enforcement, and that ownership round-trips.