### PR TITLE
chore(start-wrt): verify ISA via the build container, not host riscv binutils

### DIFF
--- a/.github/workflows/start-wrt.yaml
+++ b/.github/workflows/start-wrt.yaml
@@ -89,10 +89,8 @@ jobs:
           nodejs-version: ${{ env.NODEJS_VERSION }}
 
       # build/verify-isa.sh disassembles the binary to reject instructions the
-      # SpaceMiT K1 can't run; it needs a riscv64 binutils objdump on the host.
-      - name: Install riscv64 binutils
-        run: sudo apt-get update && sudo apt-get install -y binutils-riscv64-linux-gnu
-
+      # SpaceMiT K1 can't run; it runs llvm-objdump inside the same
+      # start9/cargo-zigbuild container as the build — no host riscv binutils.
       - name: Make start-wrt
         run: make start-wrt
         env:
@@ -122,11 +120,7 @@ jobs:
 
       # Host deps for the OpenWrt build, restored from the old standalone
       # repo's setup-build action (the monorepo's shared setup-build serves
-      # every product, so this install lives here instead). The riscv64
-      # binutils also serve build/verify-isa.sh, which runs in this job too:
-      # the image depends on the startwrt binary (build.mk: files/.staged),
-      # and at verify time the in-tree toolchain doesn't exist yet (the
-      # binary builds before `make -C openwrt`).
+      # every product, so this install lives here instead).
       - name: Install OpenWrt build dependencies
         run: |
           sudo apt-get update
@@ -134,8 +128,7 @@ jobs:
             build-essential clang flex bison g++ gawk gcc-multilib \
             g++-multilib gettext git libncurses-dev libssl-dev \
             python3-setuptools rsync swig unzip \
-            zlib1g-dev file wget device-tree-compiler \
-            binutils-riscv64-linux-gnu
+            zlib1g-dev file wget device-tree-compiler
 
       # Restored BEFORE openwrt-setup.sh runs — the script rebuilds openwrt/
       # around the cached dl/ (which also caches the pinned source tarball).

--- a/projects/start-wrt/build/verify-isa.sh
+++ b/projects/start-wrt/build/verify-isa.sh
@@ -20,19 +20,20 @@ fi
 # uses (its llvm-objdump targets riscv64), so the host needs no riscv binutils.
 # Set RISCV_OBJDUMP to a native riscv64-capable objdump to skip docker.
 #
-# --mattr forces the banned extensions on in the decoder so their instructions
-# print as mnemonics (not <unknown>) even if the ELF arch attributes omit them.
-# zacas is spelled +experimental-zacas until LLVM 20; unrecognized names are
-# warn-ignored, so list both spellings.
-MATTR=+m,+a,+f,+d,+c,+v,+zicond,+zfa,+zacas,+experimental-zacas,+zfh,+zcmop,+zimop,+zcb
-
+# The decoder follows the binary's ELF arch attributes (like GNU objdump), so
+# this check catches exactly its target: compiler-emitted instructions from a
+# misconfigured RUSTFLAGS/-mcpu, which always carry matching attributes. Do
+# NOT force extensions on via --mattr to "see more": deps ship hand-written
+# runtime-dispatched asm (e.g. vendored OpenSSL's RVV routines) whose inline
+# constant tables then decode as banned mnemonics — false positives — while
+# the asm itself stays out of the attributes and out of this check's scope.
 disassemble() {
     if [ -n "${RISCV_OBJDUMP:-}" ]; then
         "$RISCV_OBJDUMP" -d -M no-aliases "$BINARY"
     else
         docker run --rm -v "$(realpath "$BINARY")":/verify/binary:ro \
             start9/cargo-zigbuild \
-            sh -c 'set -- /usr/lib/llvm-*/bin/llvm-objdump; exec "$1" -d -M no-aliases --mattr='"$MATTR"' /verify/binary'
+            sh -c 'set -- /usr/lib/llvm-*/bin/llvm-objdump; exec "$1" -d -M no-aliases /verify/binary'
     fi
 }
 
@@ -57,9 +58,9 @@ VSET_RE='\bvset(i?vli|vl)\b'
 
 echo "==> Verifying $(basename "$BINARY") against K1 ISA (via ${RISCV_OBJDUMP:-containerized llvm-objdump})..."
 
-# Disassemble once; scan the text for both failure classes. stderr (decoder
-# warnings, e.g. the ignored zacas spelling) is suppressed unless the
-# disassembly itself fails — then it's the docker/objdump error we need.
+# Disassemble once; scan the text for both failure classes. Decoder warnings
+# on stderr are suppressed unless the disassembly itself fails — then it's
+# the docker/objdump error we need.
 DISASM="$(mktemp)"
 trap 'rm -f "$DISASM" "$DISASM.err"' EXIT
 if ! disassemble 2>"$DISASM.err" > "$DISASM"; then

--- a/projects/start-wrt/build/verify-isa.sh
+++ b/projects/start-wrt/build/verify-isa.sh
@@ -16,31 +16,25 @@ if [ ! -f "$BINARY" ]; then
     exit 1
 fi
 
-OBJDUMP=""
-for candidate in \
-    "${RISCV_OBJDUMP:-}" \
-    riscv64-linux-gnu-objdump \
-    riscv64-openwrt-linux-musl-objdump \
-    riscv64-unknown-linux-musl-objdump; do
-    if [ -n "$candidate" ] && command -v "$candidate" >/dev/null 2>&1; then
-        OBJDUMP="$candidate"
-        break
+# Disassembly runs in the same start9/cargo-zigbuild container the cross-build
+# uses (its llvm-objdump targets riscv64), so the host needs no riscv binutils.
+# Set RISCV_OBJDUMP to a native riscv64-capable objdump to skip docker.
+#
+# --mattr forces the banned extensions on in the decoder so their instructions
+# print as mnemonics (not <unknown>) even if the ELF arch attributes omit them.
+# zacas is spelled +experimental-zacas until LLVM 20; unrecognized names are
+# warn-ignored, so list both spellings.
+MATTR=+m,+a,+f,+d,+c,+v,+zicond,+zfa,+zacas,+experimental-zacas,+zfh,+zcmop,+zimop,+zcb
+
+disassemble() {
+    if [ -n "${RISCV_OBJDUMP:-}" ]; then
+        "$RISCV_OBJDUMP" -d -M no-aliases "$BINARY"
+    else
+        docker run --rm -v "$(realpath "$BINARY")":/verify/binary:ro \
+            start9/cargo-zigbuild \
+            sh -c 'set -- /usr/lib/llvm-*/bin/llvm-objdump; exec "$1" -d -M no-aliases --mattr='"$MATTR"' /verify/binary'
     fi
-done
-if [ -z "$OBJDUMP" ]; then
-    # Script-relative so the fallback works from any cwd (the build runs from
-    # the monorepo root, where a bare openwrt/ would miss projects/start-wrt/).
-    for f in "$(dirname "$0")/../openwrt"/staging_dir/toolchain-riscv64*/bin/*-objdump; do
-        if [ -x "$f" ]; then
-            OBJDUMP="$f"
-            break
-        fi
-    done
-fi
-if [ -z "$OBJDUMP" ]; then
-    echo "ERROR: no riscv64 objdump found (install binutils-riscv64-linux-gnu or set RISCV_OBJDUMP)" >&2
-    exit 1
-fi
+}
 
 # RVA23-only instructions that SIGILL on K1:
 #   Zicond:  czero.eqz, czero.nez
@@ -61,12 +55,24 @@ BANNED_RE='\b(czero\.(eqz|nez)|fli\.[sdhq]|fround(nx)?\.[sdhq]|fmaxm\.[sdhq]|fmi
 # detecting those catches any vectorised code.
 VSET_RE='\bvset(i?vli|vl)\b'
 
-echo "==> Verifying $(basename "$BINARY") against K1 ISA (via $(basename "$OBJDUMP"))..."
+echo "==> Verifying $(basename "$BINARY") against K1 ISA (via ${RISCV_OBJDUMP:-containerized llvm-objdump})..."
 
-# Disassemble once; scan the text for both failure classes.
+# Disassemble once; scan the text for both failure classes. stderr (decoder
+# warnings, e.g. the ignored zacas spelling) is suppressed unless the
+# disassembly itself fails — then it's the docker/objdump error we need.
 DISASM="$(mktemp)"
-trap 'rm -f "$DISASM"' EXIT
-"$OBJDUMP" -d -M no-aliases "$BINARY" 2>/dev/null > "$DISASM"
+trap 'rm -f "$DISASM" "$DISASM.err"' EXIT
+if ! disassemble 2>"$DISASM.err" > "$DISASM"; then
+    cat "$DISASM.err" >&2
+    echo "ERROR: disassembly of $BINARY failed" >&2
+    exit 1
+fi
+
+# An empty disassembly would vacuously pass both scans below.
+if [ ! -s "$DISASM" ]; then
+    echo "ERROR: disassembly of $BINARY produced no output" >&2
+    exit 1
+fi
 
 FOUND=$(grep -oE "$BANNED_RE" "$DISASM" | sort -u || true)
 if [ -n "$FOUND" ]; then


### PR DESCRIPTION
## What

`build/verify-isa.sh` previously required a riscv64-capable `objdump` on the build machine (`binutils-riscv64-linux-gnu`, or the OpenWrt staging toolchain that only exists after a full image build). It now disassembles with `llvm-objdump` inside the same `start9/cargo-zigbuild` container the cross-build itself runs in — guaranteed present wherever the build can run — so the host needs no riscv binutils. `RISCV_OBJDUMP` remains as an explicit native override.

The `binutils-riscv64-linux-gnu` installs are dropped from both CI jobs (`compile`, and the `image` job's OpenWrt apt list, where it only served verify-isa).

Decoding follows the binary's ELF arch attributes, like the old GNU-objdump path: the check targets compiler-emitted instructions from a misconfigured RUSTFLAGS/`-mcpu`, which always carry matching attributes. The first revision instead force-enabled the banned extensions in the decoder via `--mattr`, and that failed CI on a binary identical to master's: startwrt embeds vendored OpenSSL's hand-written vector-crypto asm (runtime-gated on Zvk* extensions the K1 doesn't have, so unreachable there), and byte sequences inside those regions — constant tables and instructions from extensions the decoder wasn't given — misdecoded as Zcb/Zfh mnemonics. The script now documents why `--mattr` must not be reintroduced.

## Hardening that came along

- Disassembly failures (docker error, bad `RISCV_OBJDUMP`) now surface stderr and fail the check; previously stderr was discarded unconditionally.
- An empty disassembly is rejected instead of vacuously passing both scans.

## Testing

Exercised the script end-to-end against riscv64 ELFs:

- the actual `startwrt` binary from master's latest CI run (artifact) → passes, matching the old check
- clean `zig cc` static binary → passes
- binary with arch attributes declaring zicond/zcb and containing `czero.eqz` / `c.mul` (the compiler-emitted scenario) → fails the RVA23 scan listing those mnemonics
- binary with arch attributes declaring v and containing `vsetvli` → fails the vector scan
- bad `RISCV_OBJDUMP` → clean error instead of a false pass