### PR TITLE
fix(net): accept legacy null packageId in PluginHostnameInfo (beta.9 compat)

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -92,9 +92,11 @@ file tracks notable changes since the move to the monorepo.
   re-points the tor package's persisted hidden-service identity for the admin
   UI (`STARTOS`/`startos-ui` → `start-os`/`admin`), preserving the server's
   existing `.onion` address across the identity change.
-- **SDK (breaking):** `PluginHostnameInfo.packageId` is required — url plugins
-  (e.g. tor) must export the StartOS UI's urls as `start-os`/`admin` instead of
-  `packageId: null`.
+- **SDK:** `PluginHostnameInfo.packageId` is required in the type — url plugins
+  (e.g. tor) should export the StartOS UI's urls as `start-os`/`admin` instead of
+  `packageId: null`. For backwards compatibility during the beta.10 transition,
+  the host still accepts the legacy `packageId: null` (or an absent field) over
+  the effects socket and maps it to `start-os`.
 - **OS Logs and Kernel Logs moved into System settings.** The top-level Logs tab
   is removed; OS Logs and Kernel Logs are now entries at the bottom of the System
   menu.

--- a/shared-libs/crates/start-core/src/net/service_interface.rs
+++ b/shared-libs/crates/start-core/src/net/service_interface.rs
@@ -104,11 +104,23 @@ impl HostnameMetadata {
     }
 }
 
+// TEMPORARY beta.9 compat: `packageId` was `Option`, `null`/absent meant the OS UI — map to `start-os`. Remove after beta.10.
+fn deserialize_os_ui_package_id<'de, D>(deserializer: D) -> Result<PackageId, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<PackageId>::deserialize(deserializer)?.unwrap_or_else(PackageId::start_os))
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginHostnameInfo {
     /// [`PackageId::start_os`] identifies the server's own host (the StartOS UI).
+    #[serde(
+        default = "PackageId::start_os",
+        deserialize_with = "deserialize_os_ui_package_id"
+    )]
     pub package_id: PackageId,
     pub host_id: HostId,
     pub internal_port: u16,


### PR DESCRIPTION
## What

Restores backwards compatibility for the package→host **plugin url RPCs** (`plugin.url.clear-urls`, `plugin.url.export-url`) with s9pks built against the **beta.9** SDK.

## Why

Between beta.9 and beta.10, #3387 changed the type of `PluginHostnameInfo.package_id` from `Option<PackageId>` → required `PackageId` (TS binding: `packageId: PackageId | null` → `packageId: PackageId`). In beta.9, `null`/absent meant *the server's own host (the StartOS admin UI)*; #3387 moved that to the reserved `start-os` id.

The problem: a beta.9-era package still sends `packageId: null` in its `except`/`hostname_info` entries. On a beta.10 host the field is neither `Option` nor `#[serde(default)]`, so `null` (and omission) now **fail to deserialize** — a silent breaking change for url plugins (e.g. tor) built on the old SDK.

## How

Minimal, **temporary** deser-layer shim on the shared `PluginHostnameInfo` type:

```rust
#[serde(default = "PackageId::start_os", deserialize_with = "deserialize_os_ui_package_id")]
pub package_id: PackageId,
```

The helper deserializes `Option<PackageId>` and maps `None` → `PackageId::start_os`, so `null`, an absent field, and a real id all deserialize correctly. Because `PluginHostnameInfo` is shared, this fixes both the `clear-urls` `except` set and the `export-url` `hostname_info` in one place.

- **Serialize side and the generated TS binding are unchanged** (still non-null) — new packages must supply `packageId`; only old wire payloads benefit.
- Marked `// TEMPORARY … Remove after beta.10.` per request.
- CHANGELOG #3387 entry softened to note the host still accepts legacy `packageId: null` during the beta.10 transition (mirrors the existing `{ value }`-compat precedent for pre-2.0 task inputs).

## Verification

- `cargo check -p start-core` — clean (pre-existing warnings only).
- `make start-core-ts-bindings` (LC_ALL=C) regenerated bindings → **no `osBindings` drift**, confirming the serde attributes don't change the exported TS type.