### PR TITLE
fix(install): stop re-polling sideload progress oneshot after it resolves

### DIFF
--- a/shared-libs/crates/start-core/src/install/mod.rs
+++ b/shared-libs/crates/start-core/src/install/mod.rs
@@ -7,7 +7,7 @@ use clap::builder::ValueParserFactory;
 use clap::{CommandFactory, FromArgMatches, Parser, value_parser};
 use color_eyre::eyre::eyre;
 use exver::VersionRange;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use imbl_value::{InternedString, json};
 use itertools::Itertools;
 use reqwest::Url;
@@ -198,7 +198,9 @@ pub async fn sideload(
     ctx: RpcContext,
     SideloadParams { session }: SideloadParams,
 ) -> Result<SideloadResponse, Error> {
-    let (err_send, mut err_recv) = oneshot::channel::<Error>();
+    let (err_send, err_recv) = oneshot::channel::<Error>();
+    // fused: the select! loop below re-polls this, which panics on a bare oneshot once resolved
+    let mut err_recv = err_recv.fuse();
     let progress = Guid::new();
     let progress_tracker = FullProgressTracker::new();
     let (upload, file) = upload(
@@ -244,6 +246,7 @@ pub async fn sideload(
                                         ws.close_result(Err::<&str, _>(e.clone_output())).await?;
                                         return Err(e)
                                     }
+                                    // Err = sender dropped, install succeeded; keep streaming
                                 }
                             }
                         }


### PR DESCRIPTION
## Problem

Every **successful** `start-cli package install -s <s9pk>` (sideload) can panic the progress-websocket task, resetting the TCP connection with no close handshake. The client then reports a phantom network error and exits non-zero **even though the install completed**. `make install` in the SDK's `s9pk.mk` fails the same way (exit 9) on successful deploys. Reproduced 4/4 on a `0.4.0-beta.10` box.

Client:
```
Network Error: WebSocket protocol error: Connection reset without closing handshake
make: *** [.../s9pk.mk:80: install] Error 9
```

Server (`start-cli server logs`):
```
The application panicked (crashed).
Message:  called after complete
Location: .../tokio-1.52.1/src/sync/oneshot.rs:1289
```

## Root cause

In `sideload()` (`shared-libs/crates/start-core/src/install/mod.rs`):

- The spawned install task sends on `err_send` **only on failure**; on success it ends and drops `err_send` without sending.
- The progress-websocket loops over a `tokio::select!` whose error arm is `err = (&mut err_recv) => { if let Ok(e) = err { … } }`.
- When the sender drops on success, `err_recv` resolves **once** with `Err(RecvError)`. The `if let Ok` doesn't match, the arm falls through, and the **next** loop iteration re-polls `&mut err_recv`.
- A tokio `oneshot::Receiver` sets `inner = None` after its first `Ready` and `panic!("called after complete")` on any subsequent poll (`oneshot.rs:1289`). The panic unwinds the ws task → TCP reset with no close frame → the client's "Connection reset without closing handshake".

It's reliable in practice because the progress stream only ticks every 200 ms while `err_send` drops the instant the install task finishes, so the receiver almost always resolves inside a tick window and the re-poll wins the race.

## Fix

Fuse the receiver (`let mut err_recv = err_recv.fuse();`) so that once it resolves it yields `Pending` forever instead of panicking on re-poll — the `select!` arm then simply stops firing. The arm body is otherwise unchanged.

On the success (`Err(RecvError)`) path we deliberately **don't** return: the final `is_complete` progress frame may not have been flushed yet, so the loop keeps draining the progress stream until the completion message (or stream end) closes the socket normally via `ws.normal_close("complete")`. The real-error path (`Ok(e)`) is unchanged.

## Verification

- Confirmed against tokio 1.52.1 source: `Receiver::poll` sets `self.inner = None` after first `Ready` and panics on re-poll; `Sender::drop → Inner::complete()` makes the receiver resolve `Ready(Err(RecvError))` on the success path. `futures`' `Fuse` returns `Pending` after completion, so re-polling is safe.
- `cargo check -p start-core` passes (only pre-existing warnings).
- Swept the repo for the same footgun (`&mut <oneshot::Receiver>` re-polled in a `select!` loop). `install/mod.rs` is the only occurrence. The one look-alike, `update/diagnostic.rs:180` (`res = &mut done_rx`), is safe — it `break`s the loop unconditionally on resolve, so it never re-polls.

## Notes

- Scope: this bug is on the `master` / `0.4.0-beta.10` line. The `next/*` branches use a different single-`await` sideload implementation and are unaffected.