### PR TITLE
fix(net): stable, predictable IPv6 address (EUI-64) across reboots

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -71,6 +71,12 @@ file tracks notable changes since the move to the monorepo.
 
 ### Changed
 
+- **Stable IPv6 addresses (EUI64, privacy extensions off).** NetworkManager now
+  derives each interface's IPv6 address from a fixed EUI-64 interface identifier
+  and turns off RFC 4941 privacy extensions, so the server keeps one stable
+  global-unicast address (GUA) rather than rotating temporary ones. This gives
+  the GUA-based clearnet and public-domain features a predictable address to
+  advertise (`AAAA`) and pinhole.
 - **External ports 9050 and 9051 are no longer restricted (#3407).** The port
   allocator reserved 9050/9051 for the 0.3.x host Tor daemon, which no longer
   exists. Freeing 9050 lets the tor service bind its SOCKS proxy with

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -71,12 +71,13 @@ file tracks notable changes since the move to the monorepo.
 
 ### Changed
 
-- **Stable IPv6 addresses (EUI64, privacy extensions off).** NetworkManager now
-  derives each interface's IPv6 address from a fixed EUI-64 interface identifier
-  and turns off RFC 4941 privacy extensions, so the server keeps one stable
-  global-unicast address (GUA) rather than rotating temporary ones. This gives
-  the GUA-based clearnet and public-domain features a predictable address to
-  advertise (`AAAA`) and pinhole.
+- **Stable IPv6 address across reboots.** NetworkManager is configured for
+  EUI-64 IPv6 addressing with RFC 4941 privacy extensions off, and its per-host
+  state — the stable-address seed and the DHCPv6 DUID — is now persisted to the
+  data partition instead of the tmpfs root overlay. The server therefore keeps
+  one predictable global-unicast address (GUA) across reboots rather than
+  drawing a new one each boot, giving the GUA-based clearnet and public-domain
+  features a stable address to advertise (`AAAA`) and pinhole.
 - **External ports 9050 and 9051 are no longer restricted (#3407).** The port
   allocator reserved 9050/9051 for the 0.3.x host Tor daemon, which no longer
   exists. Freeing 9050 lets the tor service bind its SOCKS proxy with

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -71,13 +71,14 @@ file tracks notable changes since the move to the monorepo.
 
 ### Changed
 
-- **Stable IPv6 address across reboots.** NetworkManager is configured for
-  EUI-64 IPv6 addressing with RFC 4941 privacy extensions off, and its per-host
-  state — the stable-address seed and the DHCPv6 DUID — is now persisted to the
-  data partition instead of the tmpfs root overlay. The server therefore keeps
-  one predictable global-unicast address (GUA) across reboots rather than
-  drawing a new one each boot, giving the GUA-based clearnet and public-domain
-  features a stable address to advertise (`AAAA`) and pinhole.
+- **Stable, predictable IPv6 address (EUI-64).** NetworkManager is set to derive
+  each interface's IPv6 address from its MAC (modified EUI-64) with RFC 4941
+  privacy extensions off. StartOS applies this to existing network connections
+  on every boot, not just newly-created ones, so upgraded servers pick it up too.
+  The server therefore keeps one stable global-unicast address (GUA) across
+  reboots instead of the default rotating stable-privacy address, giving the
+  GUA-based clearnet and public-domain features a predictable address to
+  advertise (`AAAA`) and pinhole.
 - **External ports 9050 and 9051 are no longer restricted (#3407).** The port
   allocator reserved 9050/9051 for the 0.3.x host Tor daemon, which no longer
   exists. Freeing 9050 lets the tor service bind its SOCKS proxy with

--- a/projects/start-os/debian/postinst
+++ b/projects/start-os/debian/postinst
@@ -142,6 +142,10 @@ dns=systemd-resolved
 
 [ifupdown]
 managed=true
+
+[connection]
+ipv6.addr-gen-mode=eui64
+ipv6.ip6-privacy=0
 EOF
 $SYSTEMCTL enable startd.service
 $SYSTEMCTL enable startos-shutdown.service

--- a/shared-libs/crates/start-core/src/net/wifi.rs
+++ b/shared-libs/crates/start-core/src/net/wifi.rs
@@ -1057,6 +1057,15 @@ pub async fn synchronize_network_manager<P: AsRef<Path>>(
     crate::disk::mount::util::bind(&persistent, "/etc/NetworkManager/system-connections", false)
         .await?;
 
+    // Persist NM's per-host state — the stable-privacy address seed and the
+    // DHCPv6 DUID — so the box keeps the same IPv6 address across reboots; the
+    // root overlay's upper is tmpfs, so this dir would otherwise reset each boot.
+    let nm_state = main_datadir.as_ref().join("NetworkManager");
+    if tokio::fs::metadata(&nm_state).await.is_err() {
+        tokio::fs::create_dir_all(&nm_state).await?;
+    }
+    crate::disk::mount::util::bind(&nm_state, "/var/lib/NetworkManager", false).await?;
+
     if !wifi.enabled {
         Command::new("rfkill")
             .arg("block")

--- a/shared-libs/crates/start-core/src/net/wifi.rs
+++ b/shared-libs/crates/start-core/src/net/wifi.rs
@@ -1057,15 +1057,6 @@ pub async fn synchronize_network_manager<P: AsRef<Path>>(
     crate::disk::mount::util::bind(&persistent, "/etc/NetworkManager/system-connections", false)
         .await?;
 
-    // Persist NM's per-host state — the stable-privacy address seed and the
-    // DHCPv6 DUID — so the box keeps the same IPv6 address across reboots; the
-    // root overlay's upper is tmpfs, so this dir would otherwise reset each boot.
-    let nm_state = main_datadir.as_ref().join("NetworkManager");
-    if tokio::fs::metadata(&nm_state).await.is_err() {
-        tokio::fs::create_dir_all(&nm_state).await?;
-    }
-    crate::disk::mount::util::bind(&nm_state, "/var/lib/NetworkManager", false).await?;
-
     if !wifi.enabled {
         Command::new("rfkill")
             .arg("block")
@@ -1143,6 +1134,8 @@ pub async fn synchronize_network_manager<P: AsRef<Path>>(
         .await
         .log_err();
 
+    force_ipv6_addr_gen_eui64().await;
+
     Command::new("systemctl")
         .arg("restart")
         .arg("NetworkManager")
@@ -1176,6 +1169,43 @@ pub async fn synchronize_network_manager<P: AsRef<Path>>(
             .await?;
     }
     Ok(())
+}
+
+/// Force EUI-64 IPv6 addressing (privacy extensions off) onto existing physical
+/// NetworkManager connections. Connection defaults in NetworkManager.conf only
+/// fill in unset properties, so a profile created before those defaults existed
+/// keeps its stable-privacy addressing and draws a new address every boot.
+async fn force_ipv6_addr_gen_eui64() {
+    let Ok(out) = Command::new("nmcli")
+        .arg("-t")
+        .arg("-f")
+        .arg("UUID,TYPE")
+        .arg("connection")
+        .arg("show")
+        .invoke(ErrorKind::Network)
+        .await
+    else {
+        return;
+    };
+    for line in String::from_utf8_lossy(&out).lines() {
+        let mut fields = split_nmcli_terse_line(line).into_iter();
+        let (Some(uuid), Some(kind)) = (fields.next(), fields.next()) else {
+            continue;
+        };
+        if kind == "802-3-ethernet" || kind == "802-11-wireless" {
+            Command::new("nmcli")
+                .arg("connection")
+                .arg("modify")
+                .arg(&uuid)
+                .arg("ipv6.addr-gen-mode")
+                .arg("eui64")
+                .arg("ipv6.ip6-privacy")
+                .arg("0")
+                .invoke(ErrorKind::Network)
+                .await
+                .log_err();
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Makes a StartOS server keep one stable, predictable IPv6 global-unicast address (GUA) across reboots, instead of drawing a new one each boot.

### Two parts

1. **NetworkManager IPv6 defaults** — adds a `[connection]` defaults section to the base `/etc/NetworkManager/NetworkManager.conf` written by `debian/postinst`, so **newly-created** connections use EUI-64 + no privacy extensions:
   ```ini
   [connection]
   ipv6.addr-gen-mode=eui64
   ipv6.ip6-privacy=0
   ```

2. **Apply it to existing connections** (the actual fix) — `synchronize_network_manager` now forces `ipv6.addr-gen-mode eui64` + `ipv6.ip6-privacy 0` onto every physical (`802-3-ethernet` / `802-11-wireless`) connection via `nmcli connection modify`, and the existing NetworkManager restart re-activates them.

### Why part 2 is needed

Connection defaults in `NetworkManager.conf` only fill in properties a connection leaves *unset*. A profile created before the default existed keeps its old `stable-privacy` addressing — and StartOS persists connection profiles across reboots (the `system-connections` bind-mount). Confirmed on a live box: the link-local was `fe80::81bc:876:83b3:57fd`, not the MAC-derived `fe80::2e0:4cff:fe05:17f3`, and each prefix had a different (hashed) IID — i.e. still `stable-privacy`, not `eui64`. Its IID is `hash(prefix, ifname, secret_key)`, and `secret_key` lives on the root overlay's tmpfs upper, so it regenerates every boot → new address. Forcing the property onto the existing connection fixes both new and upgraded servers.

Since real EUI-64 addressing is MAC-derived, the seed is irrelevant, so this does **not** persist `/var/lib/NetworkManager` (an earlier commit did; it was dropped).

### Testing
- `cargo check -p start-core` and `cargo fmt --check` — clean; `bash -n` on `postinst` passes.
- Real validation is a reboot on actual IPv6 (SLAAC) connectivity confirming the GUA is unchanged and MAC-derived — needs a built image on real IPv6, which I can't exercise here.

Requested by @dr-bonez.