### PR TITLE
fix(docs): pin StartOS release links + repair consolidation-stale doc URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Already enforced or checked elsewhere (listed here for completeness; documented 
 - **User-facing strings ↔ all five locale dictionaries** (`en_US`/`de_DE`/`es_ES`/`fr_FR`/`pl_PL`) — compile-checked for `start-core`; `npm run check:i18n` for the web libs.
 - **`patchdb-ui-seed.json` ↔ `patchdb-ui-seed.beta.json`** — keep both seeds in sync (see [`projects/start-os/AGENTS.md`](projects/start-os/AGENTS.md)).
 - **A crate's `version` bump ↔ its `CHANGELOG.md`** — versions are read from each manifest; bump the changelog in the same change.
+- **StartOS install/update docs' GitHub release link ↔ the OS release.** `projects/start-os/docs/src/installing-startos.md` and `update-040.md` pin the release URL to the shipping version — a repo-wide `releases/latest` resolves to whichever product released most recently (e.g. StartTunnel), not StartOS. `manage-release.sh pre-check start-os` fails if a doc still links to `releases/latest` or pins a stale version, so bump these links with the release like the changelog.
 - **User-facing changes ↔ that product's `docs/`** — docs are part of the change (see each product's AGENTS/CONTRIBUTING).
 
 ## Sub-scopes

--- a/projects/start-docs/bitcoin-guides/book.toml
+++ b/projects/start-docs/bitcoin-guides/book.toml
@@ -20,7 +20,7 @@ additional-js = [
 ]
 admonitions = true
 default-theme = "ayu"
-edit-url-template = "https://github.com/Start9Labs/start-technologies/edit/master/docs/bitcoin-guides/{path}"
+edit-url-template = "https://github.com/Start9Labs/start-technologies/edit/master/projects/start-docs/bitcoin-guides/{path}"
 git-repository-url = "https://github.com/Start9Labs/start-technologies"
 no-section-label = false
 preferred-dark-theme = "ayu"

--- a/projects/start-os/docs/src/installing-startos.md
+++ b/projects/start-os/docs/src/installing-startos.md
@@ -8,7 +8,7 @@ This guide is for flashing StartOS to a USB drive, then installing it onto a des
 
 ## Download
 
-1.  Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/latest) to find the latest version of StartOS.
+1.  Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/v0.4.0-beta.9) to find the latest version of StartOS.
 
 1.  Under "ISO Downloads", select the ISO for your architecture. StartOS is available in x86_64 (AMD64), aarch64 (ARM64), and RISC-V (RVA23). For x86_64 and aarch64, two variants are available:
     - **Standard**: Includes proprietary firmware and drivers for broader hardware compatibility, including display and wireless. Recommended for most users.

--- a/projects/start-os/docs/src/update-040.md
+++ b/projects/start-os/docs/src/update-040.md
@@ -9,7 +9,7 @@ StartOS 0.4.0 is a completely new operating system. It will eventually be availa
 
 ## Before You Begin
 
-StartOS 0.4.0 is currently in beta. The latest beta release is available on the [GitHub releases page](https://github.com/Start9Labs/start-technologies/releases/latest).
+StartOS 0.4.0 is currently in beta. The latest beta release is available on the [GitHub releases page](https://github.com/Start9Labs/start-technologies/releases/tag/v0.4.0-beta.9).
 
 ### Services with special handling
 
@@ -34,7 +34,7 @@ If you use a password manager, before updating, make sure your saved passwords h
 
 ## Step 1: Flash the USB Drive
 
-Download the 0.4.0-beta ISO for your platform from the [GitHub releases page](https://github.com/Start9Labs/start-technologies/releases/latest). Under "ISO Downloads" at the top of the release notes, select the ISO for your hardware:
+Download the 0.4.0-beta ISO for your platform from the [GitHub releases page](https://github.com/Start9Labs/start-technologies/releases/tag/v0.4.0-beta.9). Under "ISO Downloads" at the top of the release notes, select the ISO for your hardware:
 
 - **Server One (2023)** or other x86_64 hardware — download the **x86_64 (AMD64)** ISO
 - **Server Pure** — download the **x86_64 (AMD64) Slim (FOSS-only)** ISO

--- a/projects/start-wrt/docs/book.toml
+++ b/projects/start-wrt/docs/book.toml
@@ -20,8 +20,8 @@ additional-js = [
 ]
 admonitions = true
 default-theme = "ayu"
-edit-url-template = "https://github.com/Start9Labs/start-os/edit/master/projects/start-wrt/docs/{path}"
-git-repository-url = "https://github.com/Start9Labs/start-os"
+edit-url-template = "https://github.com/Start9Labs/start-technologies/edit/master/projects/start-wrt/docs/{path}"
+git-repository-url = "https://github.com/Start9Labs/start-technologies"
 no-section-label = false
 preferred-dark-theme = "ayu"
 sidebar-header-nav = false

--- a/projects/start-wrt/docs/init-reflash.md
+++ b/projects/start-wrt/docs/init-reflash.md
@@ -273,7 +273,7 @@ The WiFi passphrase is never displayed in the admin interface. The sticker is th
 | Source                                     | Reuse                                             |
 | ------------------------------------------ | ------------------------------------------------- |
 | `auth.rs` — `rpassword::prompt_password()` | No-echo prompting in `set-wifi-password --manual` |
-| `start-os::util::io::AtomicFile`           | Atomic write pattern for `/etc/shadow`, conffiles |
+| `start-core::util::io::AtomicFile`         | Atomic write pattern for `/etc/shadow`, conffiles |
 | `uciedit` crate                            | UCI config writing                                |
 | `wifi.rs`                                  | WiFi PSK + dynamic VLAN structure                 |
 | `projects/start-os/web/setup-wizard/`      | Angular wizard reference                          |

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -325,6 +325,32 @@ cmd_pre_check() {
         echo "  ✓ changelog documents ${VERSION}"
     fi
 
+    # 1b. StartOS install/update docs pin the GitHub release link to the version
+    # being shipped — a repo-wide releases/latest resolves to whichever product
+    # released most recently (e.g. StartTunnel), not to StartOS. Enforce the bump
+    # like the changelog: fail if any doc still says releases/latest, links to no
+    # ${TAG} release, or pins a stale version. See root AGENTS.md "Coupled changes".
+    if [ "$KIND" = os ]; then
+        local docs_src total good
+        docs_src="$REPO_ROOT/projects/start-os/docs/src"
+        if grep -rqF "releases/latest" "$docs_src" 2>/dev/null; then
+            >&2 echo "  ✗ start-os docs still link to releases/latest — pin to https://github.com/${REPO}/releases/tag/${TAG}"
+            errors=1
+        fi
+        total=$(grep -rohF "${REPO}/releases/tag/" "$docs_src" 2>/dev/null | wc -l | tr -d ' ')
+        good=$(grep -rohF "${REPO}/releases/tag/${TAG}" "$docs_src" 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$good" -eq 0 ]; then
+            >&2 echo "  ✗ start-os docs link to no ${TAG} release — pin to https://github.com/${REPO}/releases/tag/${TAG}"
+            errors=1
+        elif [ "$total" -ne "$good" ]; then
+            >&2 echo "  ✗ start-os docs pin a stale release link (expected releases/tag/${TAG}):"
+            grep -rnF "${REPO}/releases/tag/" "$docs_src" 2>/dev/null | grep -vF "releases/tag/${TAG}" | sed 's/^/      /' >&2
+            errors=1
+        else
+            echo "  ✓ start-os docs pin the release link to ${TAG}"
+        fi
+    fi
+
     # 2. Git tag must not already exist on the remote (idempotent: FORCE re-tags).
     if git ls-remote --tags origin "refs/tags/${TAG}" 2>/dev/null | grep -q .; then
         release_guard "tag ${TAG} already exists on origin" || errors=1


### PR DESCRIPTION
## What & why

Follow-up to the request to stop linking docs at `/latest` GitHub releases, extended into a full audit of **all mdBook books** for links broken by the **monorepo consolidation** (old `start-os`/`start-cli`/`start-sdk`/… repos folded into `start-technologies`, source paths moved, release tags now namespaced `<project>/v<version>`).

The key problem: a repo-wide `.../releases/latest` resolves to whichever **product** released most recently — right now that's **StartTunnel v1.1.0**, not StartOS — so the StartOS install and 0.4.0 upgrade guides were sending users to the wrong release entirely.

## Changes

**Pin the floating release links** (`projects/start-os/docs/src/`)
- `installing-startos.md` ×1 and `update-040.md` ×2: `releases/latest` → `releases/tag/v0.4.0-beta.9` (the current latest StartOS release, which carries the `# ISO Downloads` section the docs reference).

**Wire the bump into the release flow** (so the now-fragile pins stay current, like the changelog)
- `scripts/manage-release.sh` `pre-check` (start-os only): fails if any start-os doc still links to `releases/latest`, links to no release for the version being shipped, or pins a *stale* version. Mirrors the existing changelog guard; runs on every `manage-release.sh release start-os`. Not invoked by CI, so it only gates maintainer releases.
- Documented the coupling in the root `AGENTS.md` “Coupled changes → already enforced” list.

**Repair other consolidation-stale references found in the audit**
- `projects/start-wrt/docs/book.toml`: `git-repository-url` + `edit-url-template` still pointed at the archived **`start-os`** repo → `start-technologies` (these generate the per-page GitHub / “Suggest an edit” links).
- `projects/start-docs/bitcoin-guides/book.toml`: `edit-url-template` used the pre-move path `docs/bitcoin-guides/` → `projects/start-docs/bitcoin-guides/`.
- `projects/start-wrt/docs/init-reflash.md`: stale crate path `start-os::util::io::AtomicFile` → `start-core::util::io::AtomicFile` (the `core/` crate is now `shared-libs/crates/start-core`).

## Audit scope & confidence

Swept all five books (start-os, packaging/start-sdk, start-tunnel, start-wrt, bitcoin-guides) + landing/theme/`book.toml`s for old-repo URLs, moved source paths, floating release links, and stale edit-URL templates, then ran an independent 6-way re-audit to cross-check. The rest of the docs are already consolidated correctly. One re-audit finding was **rejected on verification** as a false positive: `init-reflash.md`'s `projects/start-os/web/setup-wizard/` reference is correct (that wizard exists and is intentionally referenced as reuse).

> Note: I pinned to the exact release tag rather than a `?q=v0.4` search link, per the original ask (“link to the actual latest version … include updating them into the release flow”), which explicitly wants a version-pinned link the release flow keeps current.

## Testing

- `projects/start-docs/build.sh` builds all four published books cleanly; start-wrt book built separately (excluded from `versions.conf`).
- Verified in the **built HTML**: start-wrt & bitcoin-guides edit-links now resolve to `start-technologies` with correct paths; start-os pages show `releases/tag/v0.4.0-beta.9` and no `releases/latest`.
- `bash -n scripts/manage-release.sh` passes; guard logic tested — PASS when the pin matches the release tag, FAIL on a stale/mismatched tag.