### PR TITLE
ci: free disk space on the format job (fix recurring 'no space left on device')

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,7 +105,9 @@ jobs:
       - uses: ./.github/actions/setup-build
         with:
           nodejs-version: ${{ env.NODEJS_VERSION }}
-          free-space: 'false'
+          # the rustfmt-container docker build below needs the disk headroom —
+          # extracting the musl-cross-make toolchain has hit "no space left on device".
+          free-space: 'true'
           setup-docker: 'false'
           setup-sccache: 'false'
       # `npm ci` fails if a lockfile is out of sync with its package.json, unlike the


### PR DESCRIPTION
## Why

The **Formatting & Lockfiles** job builds the rustfmt container (`build/fmt/fmtenv.Dockerfile`), which extracts the large musl-cross-make toolchain layer. On a default GitHub runner this recurringly fails with:

```
#5 ERROR: failed to register layer: write /opt/musl-cross-make/libexec/gcc/aarch64-linux-musl/15.1.0/lto1: no space left on device
```

Seen across multiple PRs (most recently #3483), and it's a pure infra flake — the format checks never get to run.

## Fix

Flip the format job's `setup-build` to `free-space: 'true'`, which runs the action's disk-cleanup (removes the preinstalled dotnet/android/ghc/swift/etc. SDKs) before the docker build. The `generated` job already uses this and builds start-core in a container without issue, so it's a proven pattern here; only `test` and `format` were still on `'false'`, and `format` is the one doing the heavy docker build.

One-line change; costs ~30–60s of cleanup on that job in exchange for not flaking out. No user- or developer-facing effect (CI-only), so no docs/changelog.
