### PR TITLE
fix(wrt)!: ship ddns-scripts and make every DDNS provider actually work

### DIFF
--- a/projects/start-wrt/API_CONTRACT.md
+++ b/projects/start-wrt/API_CONTRACT.md
@@ -535,7 +535,6 @@ struct WanDnsSetRequest {
 #[derive(Serialize)]
 #[serde(rename_all = "lowercase")]
 enum DdnsProvider {
-    Start9,
     Dyndns,
     Noip,
     Cloudflare,
@@ -547,7 +546,7 @@ enum DdnsProvider {
 struct WanDdnsResponse {
     enabled: bool,
     provider: DdnsProvider,
-    /// The resolved/active hostname (auto-detected for Start9, user-configured for others)
+    /// The hostname registered with the provider
     hostname: Option<String>,
     /// Provider-specific fields
     username: Option<String>,
@@ -556,6 +555,10 @@ struct WanDdnsResponse {
     zone: Option<String>,
 }
 ```
+
+A UCI section with an unknown or legacy `service_name` (e.g. `start9`, whose
+service never launched) reads back as the disabled default (`enabled: false`,
+`provider: dyndns`, all fields null).
 
 ### `wan.ddns-set`
 

--- a/projects/start-wrt/API_CONTRACT.md
+++ b/projects/start-wrt/API_CONTRACT.md
@@ -584,8 +584,11 @@ For Cloudflare, `zone` is required and must be the domain registered with
 Cloudflare (e.g. `example.com`), and `hostname` must be that zone itself
 (apex record) or a name under it; anything else is rejected with
 `InvalidRequest`. The backend translates to the shape ddns-scripts'
-cloudflare script expects: `username 'Bearer'` and `domain 'host@zone'`
-(`'@zone'` for the apex).
+cloudflare script expects: `username 'Bearer'`, `domain 'host@zone'`
+(`'@zone'` for the apex), and `use_api_check '1'` so proxied (orange-cloud)
+records compare against the record's real content instead of the proxy IP.
+Every provider's section also gets `interface 'wan'`, binding it to hotplug
+so updates fire immediately on WAN reconnect.
 
 ---
 

--- a/projects/start-wrt/API_CONTRACT.md
+++ b/projects/start-wrt/API_CONTRACT.md
@@ -552,6 +552,8 @@ struct WanDdnsResponse {
     username: Option<String>,
     password: Option<String>,
     token: Option<String>,
+    /// Cloudflare only: the zone's root domain (null for configs saved
+    /// before the zone was stored)
     zone: Option<String>,
 }
 ```
@@ -577,6 +579,13 @@ struct WanDdnsSetRequest {
 // Response: null
 // Backend: updates UCI ddns config, restarts/stops ddns service
 ```
+
+For Cloudflare, `zone` is required and must be the domain registered with
+Cloudflare (e.g. `example.com`), and `hostname` must be that zone itself
+(apex record) or a name under it; anything else is rejected with
+`InvalidRequest`. The backend translates to the shape ddns-scripts'
+cloudflare script expects: `username 'Bearer'` and `domain 'host@zone'`
+(`'@zone'` for the apex).
 
 ---
 

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   corrected `API_CONTRACT.md` wire types and documented the previously missing
   endpoints, and fixed stale paths, commands, and structure descriptions across
   the developer docs.
+- **Cloudflare Dynamic DNS now saves a working configuration.** The saved
+  config was missing fields the update client requires (the Bearer-token
+  marker and the zone), so Cloudflare updates could never succeed. The form
+  now asks for the **Zone** — the domain registered with Cloudflare, e.g.
+  `example.com` — instead of a Zone ID. Previously saved Cloudflare
+  configurations must be re-saved with the zone filled in. Note that the
+  DNS record must already exist in Cloudflare (the client updates records,
+  it does not create them), and the API token needs Zone:Read and DNS:Edit
+  permissions.
 - **Dynamic DNS now actually updates your provider.** The image was missing
   the `ddns-scripts` update client (and its Cloudflare and No-IP extensions),
   so DDNS settings were saved but no DNS record was ever updated. The FreeDNS

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -36,14 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configurations must be re-saved with the zone filled in. Note that the
   DNS record must already exist in Cloudflare (the client updates records,
   it does not create them), and the API token needs Zone:Read and DNS:Edit
-  permissions.
+  permissions. Proxied (orange-cloud) records are supported: the client
+  reads the registered IP through the Cloudflare API rather than DNS, which
+  would only ever see the proxy's address.
 - **Dynamic DNS now actually updates your provider.** The image was missing
   the `ddns-scripts` update client (and its Cloudflare and No-IP extensions),
   so DDNS settings were saved but no DNS record was ever updated. The FreeDNS
   provider also pointed at a service name (`freedns.afraid.org`) that modern
   `ddns-scripts` no longer recognizes; it now uses the afraid.org update-key
   service (`afraid.org-keyauth`), and configurations saved with the old name
-  are still read back correctly.
+  are still read back correctly. DDNS configurations are also bound to the
+  WAN interface, so an update fires the moment the connection comes back up
+  (e.g. after a modem reboot or PPPoE reconnect) instead of waiting for the
+  next scheduled check.
 
 ## [1.0.1]
 

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   corrected `API_CONTRACT.md` wire types and documented the previously missing
   endpoints, and fixed stale paths, commands, and structure descriptions across
   the developer docs.
+- **Dynamic DNS now actually updates your provider.** The image was missing
+  the `ddns-scripts` update client (and its Cloudflare and No-IP extensions),
+  so DDNS settings were saved but no DNS record was ever updated. The FreeDNS
+  provider also pointed at a service name (`freedns.afraid.org`) that modern
+  `ddns-scripts` no longer recognizes; it now uses the afraid.org update-key
+  service (`afraid.org-keyauth`), and configurations saved with the old name
+  are still read back correctly.
 
 ## [1.0.1]
 

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **The Start9 DDNS provider option has been removed.** The Start9 DDNS
+  service has not launched yet, so selecting it saved a configuration that
+  could never update a DNS record. Configurations previously saved with the
+  Start9 provider now read back as Dynamic DNS disabled; pick one of the
+  supported providers to re-enable. The option will return when the Start9
+  service goes live.
+
 ### Fixed
 
 - **Documentation corrected against the code in a full docs-vs-code audit.** The

--- a/projects/start-wrt/backend/ctrl/src/wan.rs
+++ b/projects/start-wrt/backend/ctrl/src/wan.rs
@@ -1071,6 +1071,14 @@ pub async fn ddns_set<C: CtrlContext>(
             service_name: Some(provider_to_service(&req.provider).to_string()),
             ip_source: Some("network".to_string()),
             ip_network: Some("wan".to_string()),
+            // Hotplug binding: re-run the update as soon as the WAN bounces
+            // instead of waiting for the daemon's next check interval
+            interface: Some("wan".to_string()),
+            use_api_check: if req.provider == DdnsProvider::Cloudflare {
+                Some("1".to_string())
+            } else {
+                None
+            },
             username: if req.enabled { username.clone() } else { None },
             password: if req.enabled { password.clone() } else { None },
             domain: if req.enabled { domain.clone() } else { None },
@@ -1529,6 +1537,9 @@ config service 'wan'
         assert!(raw.contains("option username 'Bearer'"));
         assert!(raw.contains("option domain 'mysite@example.com'"));
         assert!(raw.contains("option lookup_host 'mysite.example.com'"));
+        assert!(raw.contains("option interface 'wan'"));
+        // Proxied records need the API check or every cycle looks stale
+        assert!(raw.contains("option use_api_check '1'"));
 
         let res = ddns_get(ctx).await.unwrap();
         assert!(res.enabled);
@@ -1665,6 +1676,9 @@ config service 'wan'
 
         let raw = std::fs::read_to_string(dir.path().join("ddns")).unwrap();
         assert!(raw.contains("option service_name 'afraid.org-keyauth'"));
+        assert!(raw.contains("option interface 'wan'"));
+        // The API check is Cloudflare-specific
+        assert!(!raw.contains("use_api_check"));
 
         let res = ddns_get(ctx).await.unwrap();
         assert!(res.enabled);
@@ -2388,5 +2402,47 @@ config service 'wan'
             res.username.is_none(),
             "username should not be set for token-based provider"
         );
+    }
+
+    #[tokio::test]
+    async fn ddns_switch_away_from_cloudflare_clears_api_check() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ddns"), "").unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        ddns_set(
+            ctx.clone(),
+            DeserializeStdin(WanDdnsSetRequest {
+                enabled: true,
+                provider: DdnsProvider::Cloudflare,
+                hostname: Some("mysite.example.com".to_string()),
+                username: None,
+                password: None,
+                token: Some("cf-api-token-123".to_string()),
+                zone: Some("example.com".to_string()),
+            }),
+        )
+        .await
+        .unwrap();
+
+        ddns_set(
+            ctx.clone(),
+            DeserializeStdin(WanDdnsSetRequest {
+                enabled: true,
+                provider: DdnsProvider::Duckdns,
+                hostname: Some("myhost.duckdns.org".to_string()),
+                username: None,
+                password: None,
+                token: Some("duck-token".to_string()),
+                zone: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let raw = std::fs::read_to_string(dir.path().join("ddns")).unwrap();
+        assert!(!raw.contains("use_api_check"));
+        assert!(!raw.contains("Bearer"));
+        assert!(raw.contains("option interface 'wan'"));
     }
 }

--- a/projects/start-wrt/backend/ctrl/src/wan.rs
+++ b/projects/start-wrt/backend/ctrl/src/wan.rs
@@ -187,7 +187,9 @@ fn provider_to_service(p: &DdnsProvider) -> &'static str {
         DdnsProvider::Noip => "no-ip.com",
         DdnsProvider::Cloudflare => "cloudflare.com-v4",
         DdnsProvider::Duckdns => "duckdns.org",
-        DdnsProvider::Freedns => "freedns.afraid.org",
+        // afraid.org's update-key flow; ddns-scripts dropped the old
+        // "freedns.afraid.org" service name when it moved to JSON definitions
+        DdnsProvider::Freedns => "afraid.org-keyauth",
     }
 }
 
@@ -197,7 +199,8 @@ fn service_to_provider(s: &str) -> DdnsProvider {
         "no-ip.com" => DdnsProvider::Noip,
         "cloudflare.com-v4" => DdnsProvider::Cloudflare,
         "duckdns.org" => DdnsProvider::Duckdns,
-        "freedns.afraid.org" => DdnsProvider::Freedns,
+        // "freedns.afraid.org" is the legacy name written by earlier builds
+        "afraid.org-keyauth" | "freedns.afraid.org" => DdnsProvider::Freedns,
         _ => DdnsProvider::Start9,
     }
 }
@@ -1458,6 +1461,60 @@ config zone
         assert_eq!(res.provider, DdnsProvider::Cloudflare);
         assert_eq!(res.token.as_deref(), Some("cf-api-token-123"));
         assert_eq!(res.hostname.as_deref(), Some("mysite.example.com"));
+    }
+
+    #[tokio::test]
+    async fn ddns_set_freedns_writes_keyauth_service() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ddns"), "").unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        ddns_set(
+            ctx.clone(),
+            DeserializeStdin(WanDdnsSetRequest {
+                enabled: true,
+                provider: DdnsProvider::Freedns,
+                hostname: Some("myhost.mooo.com".to_string()),
+                username: None,
+                password: None,
+                token: Some("freedns-update-key".to_string()),
+                zone: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let raw = std::fs::read_to_string(dir.path().join("ddns")).unwrap();
+        assert!(raw.contains("option service_name 'afraid.org-keyauth'"));
+
+        let res = ddns_get(ctx).await.unwrap();
+        assert!(res.enabled);
+        assert_eq!(res.provider, DdnsProvider::Freedns);
+        assert_eq!(res.token.as_deref(), Some("freedns-update-key"));
+        assert_eq!(res.hostname.as_deref(), Some("myhost.mooo.com"));
+    }
+
+    #[tokio::test]
+    async fn ddns_get_legacy_freedns_service_name() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("ddns"),
+            "\
+config service 'wan'
+\toption enabled '1'
+\toption service_name 'freedns.afraid.org'
+\toption lookup_host 'myhost.mooo.com'
+\toption password 'freedns-update-key'
+",
+        )
+        .unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        let res = ddns_get(ctx).await.unwrap();
+        assert!(res.enabled);
+        assert_eq!(res.provider, DdnsProvider::Freedns);
+        assert_eq!(res.token.as_deref(), Some("freedns-update-key"));
+        assert_eq!(res.hostname.as_deref(), Some("myhost.mooo.com"));
     }
 
     #[tokio::test]

--- a/projects/start-wrt/backend/ctrl/src/wan.rs
+++ b/projects/start-wrt/backend/ctrl/src/wan.rs
@@ -148,7 +148,6 @@ pub struct WanDnsSetRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DdnsProvider {
-    Start9,
     Dyndns,
     Noip,
     Cloudflare,
@@ -182,7 +181,6 @@ pub struct WanDdnsSetRequest {
 
 fn provider_to_service(p: &DdnsProvider) -> &'static str {
     match p {
-        DdnsProvider::Start9 => "start9",
         DdnsProvider::Dyndns => "dyndns.org",
         DdnsProvider::Noip => "no-ip.com",
         DdnsProvider::Cloudflare => "cloudflare.com-v4",
@@ -193,15 +191,17 @@ fn provider_to_service(p: &DdnsProvider) -> &'static str {
     }
 }
 
-fn service_to_provider(s: &str) -> DdnsProvider {
+/// None for unknown service names (e.g. the never-launched "start9"),
+/// which read back as the disabled default.
+fn service_to_provider(s: &str) -> Option<DdnsProvider> {
     match s {
-        "dyndns.org" => DdnsProvider::Dyndns,
-        "no-ip.com" => DdnsProvider::Noip,
-        "cloudflare.com-v4" => DdnsProvider::Cloudflare,
-        "duckdns.org" => DdnsProvider::Duckdns,
+        "dyndns.org" => Some(DdnsProvider::Dyndns),
+        "no-ip.com" => Some(DdnsProvider::Noip),
+        "cloudflare.com-v4" => Some(DdnsProvider::Cloudflare),
+        "duckdns.org" => Some(DdnsProvider::Duckdns),
         // "freedns.afraid.org" is the legacy name written by earlier builds
-        "afraid.org-keyauth" | "freedns.afraid.org" => DdnsProvider::Freedns,
-        _ => DdnsProvider::Start9,
+        "afraid.org-keyauth" | "freedns.afraid.org" => Some(DdnsProvider::Freedns),
+        _ => None,
     }
 }
 
@@ -283,14 +283,6 @@ async fn get_default_mac(dev_name: &str) -> String {
         }
     }
     "00:00:00:00:00:00".to_string()
-}
-
-async fn get_start9_hostname() -> Option<String> {
-    tokio::fs::read_to_string("/etc/start9/hostname")
-        .await
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
 }
 
 async fn restart_network() {
@@ -968,18 +960,13 @@ pub async fn ddns_get<C: CtrlContext>(ctx: C) -> Result<WanDdnsResponse, Error> 
     for section in &cfgs["ddns"].sections {
         if section.name().as_deref() == Some(DDNS_SECTION) {
             if let Some(svc) = section.get_typed::<DdnsService>()? {
-                let provider = service_to_provider(svc.service_name.as_deref().unwrap_or("start9"));
-                let enabled = svc.enabled.as_deref() == Some("1");
-
-                let hostname = if provider == DdnsProvider::Start9 && enabled {
-                    if ctx.effectful() {
-                        get_start9_hostname().await
-                    } else {
-                        None
-                    }
-                } else {
-                    svc.domain.or(svc.lookup_host)
+                // Unknown service names fall through to the disabled default
+                let Some(provider) = svc.service_name.as_deref().and_then(service_to_provider)
+                else {
+                    break;
                 };
+                let enabled = svc.enabled.as_deref() == Some("1");
+                let hostname = svc.domain.or(svc.lookup_host);
 
                 // For token-based providers (Cloudflare, DuckDNS, FreeDNS),
                 // the password field stores the token
@@ -1005,7 +992,7 @@ pub async fn ddns_get<C: CtrlContext>(ctx: C) -> Result<WanDdnsResponse, Error> 
 
     Ok(WanDdnsResponse {
         enabled: false,
-        provider: DdnsProvider::Start9,
+        provider: DdnsProvider::Dyndns,
         hostname: None,
         username: None,
         password: None,
@@ -1034,23 +1021,23 @@ pub async fn ddns_set<C: CtrlContext>(
             service_name: Some(provider_to_service(&req.provider).to_string()),
             ip_source: Some("network".to_string()),
             ip_network: Some("wan".to_string()),
-            username: if req.enabled && req.provider != DdnsProvider::Start9 {
+            username: if req.enabled {
                 req.username.clone()
             } else {
                 None
             },
-            password: if req.enabled && req.provider != DdnsProvider::Start9 {
+            password: if req.enabled {
                 // Token-based providers use the password field
                 req.token.clone().or(req.password.clone())
             } else {
                 None
             },
-            domain: if req.enabled && req.provider != DdnsProvider::Start9 {
+            domain: if req.enabled {
                 req.hostname.clone()
             } else {
                 None
             },
-            lookup_host: if req.enabled && req.provider != DdnsProvider::Start9 {
+            lookup_host: if req.enabled {
                 req.hostname.clone()
             } else {
                 None
@@ -1432,7 +1419,51 @@ config zone
 
         let res = ddns_get(ctx).await.unwrap();
         assert!(!res.enabled);
-        assert_eq!(res.provider, DdnsProvider::Start9);
+        assert_eq!(res.provider, DdnsProvider::Dyndns);
+    }
+
+    #[tokio::test]
+    async fn ddns_get_stale_start9_reads_back_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("ddns"),
+            "\
+config service 'wan'
+\toption enabled '1'
+\toption service_name 'start9'
+\toption ip_source 'network'
+\toption ip_network 'wan'
+",
+        )
+        .unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        let res = ddns_get(ctx).await.unwrap();
+        assert!(!res.enabled);
+        assert_eq!(res.provider, DdnsProvider::Dyndns);
+        assert_eq!(res.hostname, None);
+        assert_eq!(res.username, None);
+        assert_eq!(res.password, None);
+        assert_eq!(res.token, None);
+    }
+
+    #[tokio::test]
+    async fn ddns_get_missing_service_name_reads_back_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("ddns"),
+            "\
+config service 'wan'
+\toption enabled '1'
+",
+        )
+        .unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        let res = ddns_get(ctx).await.unwrap();
+        assert!(!res.enabled);
+        assert_eq!(res.provider, DdnsProvider::Dyndns);
+        assert_eq!(res.hostname, None);
     }
 
     #[tokio::test]

--- a/projects/start-wrt/backend/ctrl/src/wan.rs
+++ b/projects/start-wrt/backend/ctrl/src/wan.rs
@@ -966,7 +966,22 @@ pub async fn ddns_get<C: CtrlContext>(ctx: C) -> Result<WanDdnsResponse, Error> 
                     break;
                 };
                 let enabled = svc.enabled.as_deref() == Some("1");
-                let hostname = svc.domain.or(svc.lookup_host);
+
+                // For Cloudflare, domain holds the update script's `host@zone`
+                // composite, so the FQDN lives in lookup_host; configs saved
+                // before the composite existed stored the bare FQDN in domain
+                // (no '@'), which reads back with zone: None
+                let (hostname, zone) = match provider {
+                    DdnsProvider::Cloudflare => {
+                        let zone = svc
+                            .domain
+                            .as_deref()
+                            .and_then(|d| d.split_once('@'))
+                            .map(|(_, z)| z.to_string());
+                        (svc.lookup_host.or(svc.domain), zone)
+                    }
+                    _ => (svc.domain.or(svc.lookup_host), None),
+                };
 
                 // For token-based providers (Cloudflare, DuckDNS, FreeDNS),
                 // the password field stores the token
@@ -984,7 +999,7 @@ pub async fn ddns_get<C: CtrlContext>(ctx: C) -> Result<WanDdnsResponse, Error> 
                     username,
                     password,
                     token,
-                    zone: None, // Cloudflare zone stored differently in future
+                    zone,
                 });
             }
         }
@@ -1006,6 +1021,41 @@ pub async fn ddns_set<C: CtrlContext>(
     ctx: C,
     DeserializeStdin(req): DeserializeStdin<WanDdnsSetRequest>,
 ) -> Result<(), Error> {
+    // Token-based providers use ddns-scripts' password option for the token
+    let password = req.token.clone().or(req.password.clone());
+    let (username, domain) = match &req.provider {
+        // ddns-scripts' cloudflare script requires username to be the literal
+        // "Bearer" for API-token auth, and domain in `host@zone` form — the
+        // part after '@' feeds its `GET /zones?name=` lookup, so it must be
+        // the zone's root domain ("@zone" alone targets the apex record)
+        DdnsProvider::Cloudflare if req.enabled => {
+            let hostname = req.hostname.as_deref().unwrap_or_default();
+            let zone = req.zone.as_deref().unwrap_or_default();
+            if zone.is_empty() {
+                return Err(Error::new(
+                    eyre!("Cloudflare requires the zone (the domain registered with Cloudflare, e.g. example.com)"),
+                    ErrorKind::InvalidRequest,
+                ));
+            }
+            let host = if hostname == zone {
+                ""
+            } else {
+                hostname
+                    .strip_suffix(zone)
+                    .and_then(|h| h.strip_suffix('.'))
+                    .filter(|h| !h.is_empty())
+                    .ok_or_else(|| {
+                        Error::new(
+                            eyre!("hostname must be the zone itself or end with .{zone}"),
+                            ErrorKind::InvalidRequest,
+                        )
+                    })?
+            };
+            (Some("Bearer".to_string()), Some(format!("{host}@{zone}")))
+        }
+        _ => (req.username.clone(), req.hostname.clone()),
+    };
+
     let mut retries = 4;
     loop {
         let arena = Arena::new();
@@ -1021,22 +1071,9 @@ pub async fn ddns_set<C: CtrlContext>(
             service_name: Some(provider_to_service(&req.provider).to_string()),
             ip_source: Some("network".to_string()),
             ip_network: Some("wan".to_string()),
-            username: if req.enabled {
-                req.username.clone()
-            } else {
-                None
-            },
-            password: if req.enabled {
-                // Token-based providers use the password field
-                req.token.clone().or(req.password.clone())
-            } else {
-                None
-            },
-            domain: if req.enabled {
-                req.hostname.clone()
-            } else {
-                None
-            },
+            username: if req.enabled { username.clone() } else { None },
+            password: if req.enabled { password.clone() } else { None },
+            domain: if req.enabled { domain.clone() } else { None },
             lookup_host: if req.enabled {
                 req.hostname.clone()
             } else {
@@ -1481,17 +1518,128 @@ config service 'wan'
                 username: None,
                 password: None,
                 token: Some("cf-api-token-123".to_string()),
-                zone: None,
+                zone: Some("example.com".to_string()),
             }),
         )
         .await
         .unwrap();
 
+        // What ddns-scripts' cloudflare script requires on disk
+        let raw = std::fs::read_to_string(dir.path().join("ddns")).unwrap();
+        assert!(raw.contains("option username 'Bearer'"));
+        assert!(raw.contains("option domain 'mysite@example.com'"));
+        assert!(raw.contains("option lookup_host 'mysite.example.com'"));
+
         let res = ddns_get(ctx).await.unwrap();
         assert!(res.enabled);
         assert_eq!(res.provider, DdnsProvider::Cloudflare);
         assert_eq!(res.token.as_deref(), Some("cf-api-token-123"));
+        assert_eq!(res.username, None);
         assert_eq!(res.hostname.as_deref(), Some("mysite.example.com"));
+        assert_eq!(res.zone.as_deref(), Some("example.com"));
+    }
+
+    #[tokio::test]
+    async fn ddns_set_cloudflare_apex_record() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ddns"), "").unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        ddns_set(
+            ctx.clone(),
+            DeserializeStdin(WanDdnsSetRequest {
+                enabled: true,
+                provider: DdnsProvider::Cloudflare,
+                hostname: Some("example.com".to_string()),
+                username: None,
+                password: None,
+                token: Some("cf-api-token-123".to_string()),
+                zone: Some("example.com".to_string()),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let raw = std::fs::read_to_string(dir.path().join("ddns")).unwrap();
+        assert!(raw.contains("option domain '@example.com'"));
+
+        let res = ddns_get(ctx).await.unwrap();
+        assert_eq!(res.hostname.as_deref(), Some("example.com"));
+        assert_eq!(res.zone.as_deref(), Some("example.com"));
+    }
+
+    #[tokio::test]
+    async fn ddns_set_cloudflare_requires_zone() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ddns"), "").unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        let err = ddns_set(
+            ctx,
+            DeserializeStdin(WanDdnsSetRequest {
+                enabled: true,
+                provider: DdnsProvider::Cloudflare,
+                hostname: Some("mysite.example.com".to_string()),
+                username: None,
+                password: None,
+                token: Some("cf-api-token-123".to_string()),
+                zone: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("zone"));
+    }
+
+    #[tokio::test]
+    async fn ddns_set_cloudflare_hostname_outside_zone_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("ddns"), "").unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        for hostname in ["mysite.other.com", "fooexample.com", ".example.com"] {
+            let err = ddns_set(
+                ctx.clone(),
+                DeserializeStdin(WanDdnsSetRequest {
+                    enabled: true,
+                    provider: DdnsProvider::Cloudflare,
+                    hostname: Some(hostname.to_string()),
+                    username: None,
+                    password: None,
+                    token: Some("cf-api-token-123".to_string()),
+                    zone: Some("example.com".to_string()),
+                }),
+            )
+            .await
+            .unwrap_err();
+            assert!(err.to_string().contains("end with"), "{hostname}");
+        }
+    }
+
+    #[tokio::test]
+    async fn ddns_get_legacy_cloudflare_bare_fqdn() {
+        // Saved by builds that wrote the bare FQDN into domain (no '@')
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("ddns"),
+            "\
+config service 'wan'
+\toption enabled '1'
+\toption service_name 'cloudflare.com-v4'
+\toption domain 'home.example.com'
+\toption lookup_host 'home.example.com'
+\toption password 'cf-api-token-123'
+",
+        )
+        .unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        let res = ddns_get(ctx).await.unwrap();
+        assert!(res.enabled);
+        assert_eq!(res.provider, DdnsProvider::Cloudflare);
+        assert_eq!(res.hostname.as_deref(), Some("home.example.com"));
+        assert_eq!(res.token.as_deref(), Some("cf-api-token-123"));
+        assert_eq!(res.zone, None);
     }
 
     #[tokio::test]

--- a/projects/start-wrt/backend/uciedit/src/openwrt.rs
+++ b/projects/start-wrt/backend/uciedit/src/openwrt.rs
@@ -498,6 +498,14 @@ pub struct DdnsService {
     pub ip_source: Option<String>,
     #[uci(default)]
     pub ip_network: Option<String>,
+    /// Binds the section to hotplug ifup/ifdown events for this interface
+    #[uci(default)]
+    pub interface: Option<String>,
+    /// Read the registered IP via the provider's API instead of DNS —
+    /// required for proxied Cloudflare records, whose DNS answer is the
+    /// proxy IP and would otherwise trigger an update every check cycle
+    #[uci(default)]
+    pub use_api_check: Option<String>,
     #[uci(default)]
     pub username: Option<String>,
     #[uci(default)]

--- a/projects/start-wrt/build/openwrt.diffconfig
+++ b/projects/start-wrt/build/openwrt.diffconfig
@@ -59,6 +59,10 @@ CONFIG_PACKAGE_block-mount=y
 CONFIG_PACKAGE_bridge=y
 CONFIG_PACKAGE_cgi-io=y
 CONFIG_PACKAGE_dbus=y
+CONFIG_PACKAGE_ddns-scripts=y
+CONFIG_PACKAGE_ddns-scripts-cloudflare=y
+CONFIG_PACKAGE_ddns-scripts-noip=y
+CONFIG_PACKAGE_ddns-scripts-services=y
 CONFIG_PACKAGE_devlink=y
 CONFIG_PACKAGE_fdisk=y
 # CONFIG_PACKAGE_firewall is not set

--- a/projects/start-wrt/docs/src/ddns.md
+++ b/projects/start-wrt/docs/src/ddns.md
@@ -22,9 +22,12 @@ To set up DDNS:
 
 1. Toggle **Enable Dynamic DNS** on and select your provider.
 
-1. Fill in the fields your provider requires: DynDNS and No-IP need a username and password; DuckDNS and FreeDNS need an API token; Cloudflare needs an API token and the Zone ID of your domain. Every provider also needs the hostname you have registered with it.
+1. Fill in the fields your provider requires: DynDNS and No-IP need a username and password; DuckDNS and FreeDNS need an API token; Cloudflare needs an API token and the zone — the domain registered with Cloudflare, e.g. `example.com`. Every provider also needs the hostname you have registered with it; for Cloudflare, the hostname must be the zone itself or a name under it, such as `router.example.com`.
 
 1. Click "Save".
+
+> [!NOTE]
+> For Cloudflare, the DNS record must already exist in your zone — StartWRT updates it but does not create it, so add the A record in the Cloudflare dashboard first. The API token needs **Zone → Read** and **DNS → Edit** permissions for the zone.
 
 ## Checking Your DDNS Status
 

--- a/projects/start-wrt/web/src/app/help/content/de.ts
+++ b/projects/start-wrt/web/src/app/help/content/de.ts
@@ -394,8 +394,7 @@ Aktivieren Sie DNS over HTTPS (DoH) für verschlüsselte DNS-Abfragen. Dies verb
 
 DDNS ordnet Ihre wechselnde IP-Adresse einem festen Domänennamen zu, sodass Sie aus der Ferne auf Ihr Netzwerk zugreifen können, ohne Ihre aktuelle IP zu kennen.
 
--   **Start9:** Kostenloser DDNS-Dienst von Start9. Keine zusätzliche Einrichtung erforderlich.
--   **Andere Anbieter:** Erfordert ein Konto beim Anbieter. Geben Sie die Zugangsdaten und den Hostnamen Ihres DDNS-Anbieters ein.`,
+Erfordert ein Konto bei einem unterstützten Anbieter. Geben Sie die Zugangsdaten und den Hostnamen Ihres DDNS-Anbieters ein.`,
   '/settings/activity': `## Einstellungen – Aktivität
 
 Zeigt aktuelle Anmeldeversuche und Sicherheitsereignisse an. Überwachen Sie verdächtige Aktivitäten und entfernen Sie bei Bedarf alte Einträge.`,

--- a/projects/start-wrt/web/src/app/help/content/en.ts
+++ b/projects/start-wrt/web/src/app/help/content/en.ts
@@ -394,8 +394,7 @@ Enable DNS over HTTPS (DoH) for encrypted DNS queries. This improves privacy by 
 
 DDNS maps your changing IP address to a fixed domain name, allowing you to access your network remotely without knowing your current IP.
 
--   **Start9:** Free DDNS service provided by Start9. No additional setup required.
--   **Other providers:** Requires an account with the provider. Enter the credentials and hostname from your DDNS provider.`,
+Requires an account with a supported provider. Enter the credentials and hostname from your DDNS provider.`,
   '/settings/activity': `## Settings – Activity
 
 View recent login attempts and security events. Monitor for suspicious activity and remove old entries as needed.`,

--- a/projects/start-wrt/web/src/app/help/content/es.ts
+++ b/projects/start-wrt/web/src/app/help/content/es.ts
@@ -394,8 +394,7 @@ Habilita DNS over HTTPS (DoH) para consultas DNS cifradas. Esto mejora la privac
 
 DDNS asigna tu dirección IP cambiante a un nombre de dominio fijo, permitiéndote acceder a tu red de forma remota sin conocer tu IP actual.
 
--   **Start9:** Servicio DDNS gratuito proporcionado por Start9. No requiere configuración adicional.
--   **Otros proveedores:** Requiere una cuenta con el proveedor. Introduce las credenciales y el nombre de host de tu proveedor de DDNS.`,
+Requiere una cuenta con un proveedor compatible. Introduce las credenciales y el nombre de host de tu proveedor de DDNS.`,
   '/settings/activity': `## Ajustes – Actividad
 
 Consulta los intentos de inicio de sesión recientes y los eventos de seguridad. Vigila la actividad sospechosa y elimina las entradas antiguas según sea necesario.`,

--- a/projects/start-wrt/web/src/app/help/content/fr.ts
+++ b/projects/start-wrt/web/src/app/help/content/fr.ts
@@ -394,8 +394,7 @@ Activez le DNS over HTTPS (DoH) pour des requêtes DNS chiffrées. Cela amélior
 
 Le DDNS associe votre adresse IP changeante à un nom de domaine fixe, vous permettant d’accéder à votre réseau à distance sans connaître votre adresse IP actuelle.
 
--   **Start9 :** Service DDNS gratuit fourni par Start9. Aucune configuration supplémentaire requise.
--   **Autres fournisseurs :** Nécessite un compte chez le fournisseur. Saisissez les identifiants et le nom d’hôte de votre fournisseur DDNS.`,
+Nécessite un compte chez un fournisseur pris en charge. Saisissez les identifiants et le nom d’hôte de votre fournisseur DDNS.`,
   '/settings/activity': `## Paramètres – Activité
 
 Consultez les tentatives de connexion récentes et les évènements de sécurité. Surveillez les activités suspectes et supprimez les anciennes entrées selon vos besoins.`,

--- a/projects/start-wrt/web/src/app/help/content/pl.ts
+++ b/projects/start-wrt/web/src/app/help/content/pl.ts
@@ -394,8 +394,7 @@ Włącz DNS over HTTPS (DoH) dla szyfrowanych zapytań DNS. Poprawia to prywatno
 
 DDNS mapuje Twój zmieniający się adres IP na stałą nazwę domeny, umożliwiając zdalny dostęp do Twojej sieci bez znajomości bieżącego adresu IP.
 
--   **Start9:** Darmowa usługa DDNS dostarczana przez Start9. Nie wymaga dodatkowej konfiguracji.
--   **Inni dostawcy:** Wymaga konta u dostawcy. Wprowadź dane uwierzytelniające i nazwę hosta od swojego dostawcy DDNS.`,
+Wymaga konta u obsługiwanego dostawcy. Wprowadź dane uwierzytelniające i nazwę hosta od swojego dostawcy DDNS.`,
   '/settings/activity': `## Ustawienia – Aktywność
 
 Wyświetl ostatnie próby logowania i zdarzenia bezpieczeństwa. Monitoruj podejrzaną aktywność i usuwaj stare wpisy w razie potrzeby.`,

--- a/projects/start-wrt/web/src/app/i18n/dictionaries/de.ts
+++ b/projects/start-wrt/web/src/app/i18n/dictionaries/de.ts
@@ -225,7 +225,6 @@ export default {
   222: 'Tertiär',
   223: 'Benutzername',
   224: 'WAN-IP',
-  225: 'Zonen-ID',
   226: '6RD',
   227: 'IPv4',
   228: 'IPv6',
@@ -524,4 +523,5 @@ export default {
   527: 'Veröffentlichter Port wird offengelegt',
   528: 'Das Profil „{profile}“ wird über ein VPN ({vpn}) geleitet, veröffentlichte Ports werden jedoch über Ihre öffentliche Internetverbindung (WAN) erreicht, nicht über das VPN. Die folgenden Ports bleiben unter Ihrer echten öffentlichen IP-Adresse erreichbar: {list}.',
   529: 'Offenlegen und fortfahren',
+  530: 'Zone',
 } satisfies i18n

--- a/projects/start-wrt/web/src/app/i18n/dictionaries/en.ts
+++ b/projects/start-wrt/web/src/app/i18n/dictionaries/en.ts
@@ -230,7 +230,6 @@ export const ENGLISH: Record<string, number> = {
   'Tertiary': 222,
   'Username': 223,
   'WAN IP': 224,
-  'Zone ID': 225,
   '6RD': 226,
   'IPv4': 227,
   'IPv6': 228,
@@ -529,4 +528,5 @@ export const ENGLISH: Record<string, number> = {
   'Published Port Will Be Exposed': 527,
   'The "{profile}" profile routes traffic through a VPN ({vpn}), but published ports are reached over your public internet (WAN) connection, not the VPN. The following port(s) will stay exposed on your real public IP address: {list}.': 528,
   'Expose & Continue': 529,
+  'Zone': 530,
 }

--- a/projects/start-wrt/web/src/app/i18n/dictionaries/es.ts
+++ b/projects/start-wrt/web/src/app/i18n/dictionaries/es.ts
@@ -225,7 +225,6 @@ export default {
   222: 'Terciario',
   223: 'Nombre de usuario',
   224: 'IP de WAN',
-  225: 'ID de zona',
   226: '6RD',
   227: 'IPv4',
   228: 'IPv6',
@@ -524,4 +523,5 @@ export default {
   527: 'El puerto publicado quedará expuesto',
   528: 'El perfil «{profile}» enruta el tráfico a través de una VPN ({vpn}), pero los puertos publicados se alcanzan a través de tu conexión a internet pública (WAN), no de la VPN. Los siguientes puertos permanecerán expuestos en tu dirección IP pública real: {list}.',
   529: 'Exponer y continuar',
+  530: 'Zona',
 } satisfies i18n

--- a/projects/start-wrt/web/src/app/i18n/dictionaries/fr.ts
+++ b/projects/start-wrt/web/src/app/i18n/dictionaries/fr.ts
@@ -225,7 +225,6 @@ export default {
   222: 'Tertiaire',
   223: 'Nom d’utilisateur',
   224: 'IP WAN',
-  225: 'ID de zone',
   226: '6RD',
   227: 'IPv4',
   228: 'IPv6',
@@ -524,4 +523,5 @@ export default {
   527: 'Le port publié sera exposé',
   528: 'Le profil « {profile} » achemine le trafic via un VPN ({vpn}), mais les ports publiés sont atteints via votre connexion internet publique (WAN), et non via le VPN. Les ports suivants resteront exposés sur votre véritable adresse IP publique : {list}.',
   529: 'Exposer et continuer',
+  530: 'Zone',
 } satisfies i18n

--- a/projects/start-wrt/web/src/app/i18n/dictionaries/pl.ts
+++ b/projects/start-wrt/web/src/app/i18n/dictionaries/pl.ts
@@ -225,7 +225,6 @@ export default {
   222: 'Trzeciorzędny',
   223: 'Nazwa użytkownika',
   224: 'Adres IP WAN',
-  225: 'Identyfikator strefy',
   226: '6RD',
   227: 'IPv4',
   228: 'IPv6',
@@ -524,4 +523,5 @@ export default {
   527: 'Opublikowany port zostanie ujawniony',
   528: 'Profil „{profile}” kieruje ruch przez VPN ({vpn}), ale opublikowane porty są osiągane przez publiczne połączenie internetowe (WAN), a nie przez VPN. Następujące porty pozostaną widoczne pod Twoim rzeczywistym publicznym adresem IP: {list}.',
   529: 'Ujawnij i kontynuuj',
+  530: 'Strefa',
 } satisfies i18n

--- a/projects/start-wrt/web/src/app/routes/wan/routes/ddns/summary.ts
+++ b/projects/start-wrt/web/src/app/routes/wan/routes/ddns/summary.ts
@@ -40,7 +40,7 @@ export class DdnsSummary {
 
   readonly providerLabel = computed(() => {
     const provider = this.service.data()?.provider
-    return provider ? DDNS_PROVIDERS[provider].label : ''
+    return provider ? (DDNS_PROVIDERS[provider]?.label ?? provider) : ''
   })
 
   readonly hostname = computed(() => this.service.data()?.fields.hostname || '')

--- a/projects/start-wrt/web/src/app/routes/wan/routes/ddns/utils.ts
+++ b/projects/start-wrt/web/src/app/routes/wan/routes/ddns/utils.ts
@@ -34,7 +34,7 @@ export const DDNS_FIELD_LABELS: Record<string, string> = {
   password: 'Password',
   hostname: 'Hostname',
   token: 'API Token',
-  zone: 'Zone ID',
+  zone: 'Zone',
 }
 
 export const DDNS_VALIDATION_ERRORS = {

--- a/projects/start-wrt/web/src/app/routes/wan/routes/ddns/utils.ts
+++ b/projects/start-wrt/web/src/app/routes/wan/routes/ddns/utils.ts
@@ -3,10 +3,6 @@ import { FormRawValue } from 'src/app/services/form.service'
 
 // Provider configurations with their required fields
 export const DDNS_PROVIDERS = {
-  start9: {
-    label: 'Start9',
-    fields: [],
-  },
   dyndns: {
     label: 'DynDNS',
     fields: ['username', 'password', 'hostname'],
@@ -48,7 +44,7 @@ export const DDNS_VALIDATION_ERRORS = {
 export function getDdnsForm(builder: NonNullableFormBuilder) {
   return builder.group({
     enabled: builder.control(false),
-    provider: builder.control<DdnsProvider>('start9'),
+    provider: builder.control<DdnsProvider>('dyndns'),
     fields: builder.group({
       username: builder.control(''),
       password: builder.control(''),

--- a/projects/start-wrt/web/src/app/services/api/api.service.ts
+++ b/projects/start-wrt/web/src/app/services/api/api.service.ts
@@ -583,7 +583,6 @@ export type WanDnsSetRequest = {
 }
 
 export type WanDdnsProvider =
-  | 'start9'
   | 'dyndns'
   | 'noip'
   | 'cloudflare'

--- a/projects/start-wrt/web/src/app/services/api/mock-api.service.ts
+++ b/projects/start-wrt/web/src/app/services/api/mock-api.service.ts
@@ -143,15 +143,6 @@ export class MockApiService extends ApiService {
       }
     }
 
-    // Mock Start9 DDNS hostname file
-    if (params.command === 'cat' && params.args[0] === '/etc/start9/hostname') {
-      return {
-        exitCode: 0,
-        stdout: 'abc123xyz.start9.net',
-        stderr: '',
-      }
-    }
-
     // Handle service restart commands
     if (
       params.command === '/etc/init.d/firewall' ||
@@ -1221,7 +1212,6 @@ export class MockApiService extends ApiService {
     await pauseFor(250)
     // Only store fields relevant to the selected provider (matches real backend)
     const providerFields: Record<string, readonly string[]> = {
-      start9: [],
       dyndns: ['username', 'password', 'hostname'],
       noip: ['username', 'password', 'hostname'],
       cloudflare: ['token', 'zone', 'hostname'],


### PR DESCRIPTION
Summary

Dynamic DNS in StartWRT has never worked: the UI and backend wrote a complete ddns-scripts configuration and started its service, but the ddns-scripts package was never included in any image, so no DNS record was ever updated — and the failure was silent. This PR ships the client in the image and fixes everything found while verifying each supported provider end to end.

What's included

- Ship ddns-scripts in the image (ddns-scripts, -services, -cloudflare, -noip). The sub-package split matters: the base package contains no provider definitions, DynDNS/DuckDNS/FreeDNS live in -services, and Cloudflare/No-IP ship only in their own sub-packages.
- Fix the FreeDNS service name. We wrote freedns.afraid.org, which modern ddns-scripts no longer recognizes; now afraid.org-keyauth (the afraid.org update-key flow). Configs saved with the legacy name still read back correctly.
- Remove the Start9 provider option. The Start9 DDNS service hasn't launched, so selecting it saved a config that could never update anything. The option returns when the service goes live.
- Make Cloudflare actually work. The update script requires username 'Bearer' (API-token auth) and domain as host@zone — we wrote neither and silently dropped the zone. The backend now composes both, validates the hostname against the zone, and returns the zone on read. The UI field changed from "Zone ID" (a hex ID the script can't use alone) to Zone (the domain registered with Cloudflare, e.g. example.com). Proxied (orange-cloud) records are supported via use_api_check '1', which reads the registered IP through the API instead of DNS (DNS only ever sees the proxy IP).
- Bind DDNS sections to WAN hotplug (interface 'wan'), so updates fire the moment the connection comes back up — the moment the IP actually changes — instead of waiting for the next scheduled check.
- Docs + changelog: user guide updated (zone field, record-must-pre-exist, token needs Zone:Read + DNS:Edit); API_CONTRACT documents the request validation and UCI translation.

Breaking changes

- Cloudflare configs saved by earlier builds must be re-saved with the zone filled in (they read back with the zone empty and were non-functional anyway — the package they configured was never installed).

Validation

- 472 backend tests pass, including 14 DDNS-specific tests covering the UCI bytes written per provider, zone validation/rejection, apex records, legacy read-back (start9, freedns.afraid.org, bare-FQDN Cloudflare), enable/disable, and provider-switch cleanup.
- Image built from this branch; the manifest confirms all four packages plus the runtime deps the scripts need (curl, ca-bundle, jsonfilter).
- Every generated Cloudflare field was cross-checked against the shipped update_cloudflare_com_v4.sh line by line and against the OpenWrt wiki's reference config and multiple documented working setups.
- Not yet exercised: a live conversation with the real Cloudflare API (needs a real zone). The emitted config matches documented working configs exactly; a smoke test against a Start9-owned Cloudflare zone would close this.