### PR TITLE
fix(sdk): don't require a git index that a fresh repo doesn't have

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2.0.5 — StartOS 0.4.0-beta.10 (2026-07-13)
+## 2.0.6 — StartOS 0.4.0-beta.10 (2026-07-17)
+
+### Fixed
+
+- **`make` no longer fails in a git repository that has no index yet.** `s9pk.mk` listed `$(GIT_DIR)/index` as an unconditional prerequisite of the s9pk targets, but `git init` does not create an index until the first `git add` — so make aborted with `No rule to make target '.git/index', needed by '<id>_x86_64.s9pk'` before the pack step ever ran. This hit every freshly scaffolded package: `s9pk init-package` runs `git init` and stages nothing, and the generated `TODO.md` sends the packager straight to `make` as their first build, while the workflow guide tells them to iterate with a dirty tree and commit once at the end. The existing `$(if $(GIT_DIR),…)` guard asked only whether a repo exists, not whether these files do. `GIT_DEPS` now filters through `$(wildcard …)`, so a missing `HEAD` or `index` drops out of the prerequisite list instead of halting the build. Nothing else needed to change: `s9pk pack` already handles a commit-less repo, reporting `No git commit found in . — building without a commit hash in the manifest` and packing with a null `gitHash`. These entries are rebuild triggers, not build requirements
 
 ### Fixed
 

--- a/projects/start-sdk/package-lock.json
+++ b/projects/start-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",

--- a/projects/start-sdk/package.json
+++ b/projects/start-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/projects/start-sdk/s9pk.mk
+++ b/projects/start-sdk/s9pk.mk
@@ -6,7 +6,12 @@ INGREDIENTS := $(shell start-cli s9pk list-ingredients 2>/dev/null)
 # Resolve the actual git dir so this works inside git worktrees, where .git
 # is a file pointing at <main>/.git/worktrees/<name> rather than a directory.
 GIT_DIR := $(shell git rev-parse --git-dir 2>/dev/null)
-GIT_DEPS := $(if $(GIT_DIR),$(GIT_DIR)/HEAD $(GIT_DIR)/index)
+# These are rebuild triggers (the manifest embeds the commit hash), not build
+# requirements — pack degrades to a null gitHash on its own. $(wildcard) drops
+# whichever don't exist: a freshly `git init`ed repo has no index until the
+# first `git add`, and a hard prerequisite on it halts make with "No rule to
+# make target".
+GIT_DEPS := $(if $(GIT_DIR),$(wildcard $(GIT_DIR)/HEAD $(GIT_DIR)/index))
 ARCHES ?= x86 arm riscv
 # TARGETS is the list of leaf make-targets the build matrix fans out over.
 # Defaults to the arches; variant packages override (e.g. immich, ollama, vllm


### PR DESCRIPTION
`make` fails on every freshly scaffolded package, before the pack step ever runs:

```
make: *** No rule to make target `.git/index', needed by `fix-test_x86_64.s9pk'.  Stop.
```

`s9pk.mk` lists `$(GIT_DIR)/index` as an unconditional prerequisite of the s9pk targets, but `git init` does not create an index until the first `git add`. `s9pk init-package` runs `git init` and stages nothing, so the index does not exist yet.

This is on the documented golden path, not an edge case:

- `s9pk init-package` runs `git init` and stages nothing ([`init.rs:250`](https://github.com/Start9Labs/start-technologies/blob/master/shared-libs/crates/start-core/src/s9pk/init.rs#L250))
- the generated `TODO.md` sends the packager straight to `make` — *"First test build: `make` (or `start-cli s9pk pack`)"*
- `workflow.md` § *Iterate with a dirty working tree* tells them to leave the tree dirty and commit **once**, at the end

So the first `make` a new packager runs is, by design, in a repo with no index. It fails for all of them.

## Reproduction

Against `master` (`e59dd8a6`), on macOS, GNU Make 3.81:

```sh
start-cli s9pk init-workspace ws && cd ws
start-cli s9pk init-package "Fix Test" && cd fix-test-startos
make
```

```
> check
> tsc --noEmit                      # passes — #3496's fix is good
> build
2576kB  [2799ms] - ncc 0.38.4       # passes
make: *** No rule to make target `.git/index', needed by `fix-test_x86_64.s9pk'.  Stop.
```

The scaffold's `.git/` contains `HEAD config description hooks info objects refs` — no `index`.

Workaround for anyone hitting this today: `git add -A` before `make`.

## Root cause

```make
GIT_DIR  := $(shell git rev-parse --git-dir 2>/dev/null)
GIT_DEPS := $(if $(GIT_DIR),$(GIT_DIR)/HEAD $(GIT_DIR)/index)
```

The `$(if $(GIT_DIR),…)` guard asks whether a **repo** exists. It never asks whether these **files** exist. A freshly-initialized repo passes that test, so make is handed a prerequisite nothing can build, and stops.

## Why this is the right layer to fix

`GIT_DEPS` entries are **rebuild triggers**, not build requirements — they exist so the s9pk rebuilds when git state moves, because the manifest embeds the commit hash. A repo with no index simply has no state to track yet; that should drop the trigger, not halt the build.

Everything below make already agrees. `s9pk pack` handles a commit-less repo deliberately and gracefully:

```
No git commit found in . — building without a commit hash in the manifest.
Commit your work (or check that git is set up) to include it.
 Git:        null
```

Only the make prerequisite disagreed with the tool it fronts.

## The fix

Filter through `$(wildcard)`, so non-existent entries drop out instead of becoming unsatisfiable prerequisites:

```make
GIT_DEPS := $(if $(GIT_DIR),$(wildcard $(GIT_DIR)/HEAD $(GIT_DIR)/index))
```

## Evidence

Resolved `GIT_DEPS`, measured three ways (via a harness that `include`s `s9pk.mk` and echoes the variable):

| build | index | `GIT_DEPS` resolves to | result |
| --- | --- | --- | --- |
| **fixed** | present *(normal case)* | `[.git/HEAD .git/index]` | trigger fully intact — **identical to baseline** |
| **fixed** | absent *(fresh scaffold)* | `[.git/HEAD]` | missing entry drops; build proceeds |
| baseline | absent | `[.git/HEAD .git/index]` | prerequisite can't exist → **make halts** |

The first row is the non-regression result: when the files exist, the fixed and unfixed variables are byte-identical, so rebuild behaviour in the normal case is unchanged.

**End-to-end, fresh scaffold, no `git add`, with this exact `s9pk.mk`:**

```
📦 Final Check   v1.0.0:0
 Filename:   final-check_aarch64.s9pk
 Size:       4.2M
 Arch:       aarch64
 SDK:        2.0.5
 Git:        null
```

Both arches produced (`final-check_x86_64.s9pk` 4.0M, `final-check_aarch64.s9pk` 4.2M).

**Rebuild trigger still fires** — after `git add -A` + `git commit`, `make` re-packs and the hash is embedded rather than null:

```
 Git:        3d3d87b89527c82d5d0be3b66e88ff425aefa556
```

**Repo gates:** `make test` → 5 suites, 80 tests passing. `prettier --check` on the changelog → clean.

## Notes for the reviewer

**The template pin is deliberately *not* synced in this PR.** [start-sdk `AGENTS.md` § Cutting a release](https://github.com/Start9Labs/start-technologies/blob/master/projects/start-sdk/AGENTS.md) has `make sync-template` in step 1, alongside the bump. Doing that here would pin the template to `2.0.6` while `2.0.6` is unpublished, so `init-package` (which runs `npm install`) would fail for anyone on `master` for the whole review window — reintroducing exactly the class of breakage this PR fixes, in a new place. `pre-check` already enforces `pin == VERSION` at release, with the fix command in its failure message, so the sync is safe to do at release time. Happy to fold it in if you'd rather; flagging because the documented order arguably has a gap here worth a separate look.

**Version bump:** `start-sdk/v2.0.5` is tagged on origin, so per the root `AGENTS.md` changelog rule the top heading is released and this cuts a new `2.0.6` heading + manifest bump. If another change lands first and establishes `2.0.6`, this entry should move under that heading instead — happy to rebase.

## The gap that let this through

#3496's own commit message names it:

> *Nothing caught either, since the monorepo never builds the template.*

That fix added a guard for **pin drift** and **committed lockfiles**, which is real progress. But nothing builds the template — which is why this bug survived a PR that touched the same file, fixing the same command, in the same first minute of a new packager's life. Three bugs in that path have now been found by hand in a week: the stale pin, the missing `ready`, and this.

A job that scaffolds and builds would have caught the latter two together, and will catch the next one:

```sh
start-cli s9pk init-workspace ws
cd ws && start-cli s9pk init-package "CI Test"
cd ci-test-startos && make
```

Deliberately **not** included here: it needs Docker, squashfs and a compiled `start-cli` in the runner, and there is no `start-sdk` workflow to hang it on (`test.yaml` runs `make test`, which never touches the template). That's a cost/placement call for maintainers who know the CI budget, and I'd rather not bundle an untested workflow with a verified one-line fix. Filing as a follow-up if useful.

Until then, `docs/package-template/` remains the one piece of live code in this repo that ships to every new packager and is never once exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
