### PR TITLE
chore(net): gate best-effort / benign failure log noise behind the dev feature

### DIFF
--- a/shared-libs/crates/start-core/src/net/dns_update/mod.rs
+++ b/shared-libs/crates/start-core/src/net/dns_update/mod.rs
@@ -302,7 +302,7 @@ async fn apply(fqdn: &Name, server: IpAddr, ip: IpAddr, signer: Option<&TSigner>
     let add = append(rrset, zone, false, false);
     for msg in [delete, add] {
         if let Err(e) = send(server, ip, &msg, signer).await {
-            tracing::debug!("RFC 2136 update of {fqdn} on {server} failed: {e}");
+            crate::dev_log!(debug, "RFC 2136 update of {fqdn} on {server} failed: {e}");
             return;
         }
     }
@@ -316,7 +316,7 @@ async fn withdraw(fqdn: &Name, server: IpAddr, ip: IpAddr, signer: Option<&TSign
         false,
     );
     if let Err(e) = send(server, ip, &msg, signer).await {
-        tracing::debug!("RFC 2136 delete of {fqdn} on {server} failed: {e}");
+        crate::dev_log!(debug, "RFC 2136 delete of {fqdn} on {server} failed: {e}");
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -2309,7 +2309,7 @@ async fn poll_ip_info(
             match crate::net::port_map::upnp::get_external_ipv4(local_ipv4).await {
                 Ok(Some(ip)) => wan_ip = Some(ip),
                 Ok(None) => (),
-                Err(e) => tracing::debug!("UPnP WAN IP probe on {iface} failed: {e}"),
+                Err(e) => crate::dev_log!(debug, "UPnP WAN IP probe on {iface} failed: {e}"),
             }
         }
     }

--- a/shared-libs/crates/start-core/src/net/port_map/client.rs
+++ b/shared-libs/crates/start-core/src/net/port_map/client.rs
@@ -384,7 +384,10 @@ impl State {
                     if renew_due(std::time::Instant::now(), m.expiration(), m.lifetime()) =>
                 {
                     if let Err(e) = m.renew().await {
-                        tracing::debug!("PCP/NAT-PMP renew for {key:?} failed, re-mapping: {e}");
+                        crate::dev_log!(
+                            debug,
+                            "PCP/NAT-PMP renew for {key:?} failed, re-mapping: {e}"
+                        );
                         self.teardown(key.clone()).await;
                         self.apply(key).await;
                     }
@@ -417,7 +420,7 @@ impl State {
         match self.active.remove(&key) {
             Some(Active::Pcp(m)) => {
                 if let Err((e, _)) = m.try_drop().await {
-                    tracing::debug!("PCP/NAT-PMP unmap for {key:?} failed: {e}");
+                    crate::dev_log!(debug, "PCP/NAT-PMP unmap for {key:?} failed: {e}");
                 }
             }
             Some(Active::Upnp { .. }) => {
@@ -464,7 +467,10 @@ impl State {
                     .gateway_supports_hostname(local_ip, *gw, *scope_id)
                     .await
                 {
-                    tracing::debug!("PCP HOSTNAME skip {gw}: no ANNOUNCE confirmation of support");
+                    crate::dev_log!(
+                        debug,
+                        "PCP HOSTNAME skip {gw}: no ANNOUNCE confirmation of support"
+                    );
                     continue;
                 }
                 match pcp::port_mapping(
@@ -499,7 +505,8 @@ impl State {
                     Ok(m) => {
                         let _ = m.try_drop().await;
                     }
-                    Err(e) => tracing::debug!(
+                    Err(e) => crate::dev_log!(
+                        debug,
                         "PCP HOSTNAME map {local_ip}:{external_port} {hostname} via {gw} failed: {e}"
                     ),
                 }
@@ -554,7 +561,8 @@ impl State {
                             self.active.insert(key, Active::Pcp(m));
                             return;
                         }
-                        tracing::debug!(
+                        crate::dev_log!(
+                            debug,
                             "gateway {gw} granted {granted}/{range_size} PORT_SET ports for {local_ip}:{external_port}; skipping range"
                         );
                         let _ = m.try_drop().await;
@@ -562,7 +570,8 @@ impl State {
                     Ok(m) => {
                         let _ = m.try_drop().await;
                     }
-                    Err(e) => tracing::debug!(
+                    Err(e) => crate::dev_log!(
+                        debug,
                         "PCP PORT_SET map {local_ip}:{external_port} via {gw} failed: {e}"
                     ),
                 }
@@ -603,7 +612,8 @@ impl State {
                     let _ = m.try_drop().await;
                 }
                 Err(e) => {
-                    tracing::debug!(
+                    crate::dev_log!(
+                        debug,
                         "PCP/NAT-PMP map {local_ip}:{external_port} via {gw} failed: {e}"
                     )
                 }
@@ -623,7 +633,10 @@ impl State {
                             true
                         }
                         Err(e) => {
-                            tracing::debug!("UPnP map {local_v4}:{external_port} failed: {e}");
+                            crate::dev_log!(
+                                debug,
+                                "UPnP map {local_v4}:{external_port} failed: {e}"
+                            );
                             false
                         }
                     }
@@ -653,7 +666,7 @@ impl State {
                     self.upnp_cache.insert(local_ip, (g, Instant::now()));
                 }
                 Err(e) => {
-                    tracing::debug!("no UPnP gateway on {local_ip}: {e}");
+                    crate::dev_log!(debug, "no UPnP gateway on {local_ip}: {e}");
                     self.upnp_cache.remove(&local_ip);
                     return None;
                 }

--- a/shared-libs/crates/start-core/src/net/tls.rs
+++ b/shared-libs/crates/start-core/src/net/tls.rs
@@ -184,7 +184,7 @@ where
                                 }
                             }
                             Err(_) => {
-                                tracing::debug!("TLS ClientHello timed out");
+                                crate::dev_log!(debug, "TLS ClientHello timed out");
                                 return Ok(None);
                             }
                         };
@@ -230,8 +230,11 @@ where
                                         ))
                                     }
                                     Err(e) => {
-                                        tracing::trace!("Error completing TLS handshake: {e}");
-                                        tracing::trace!("{e:?}");
+                                        crate::dev_log!(
+                                            trace,
+                                            "Error completing TLS handshake: {e}"
+                                        );
+                                        crate::dev_log!(trace, "{e:?}");
                                         None
                                     }
                                 },
@@ -254,7 +257,7 @@ where
                             )));
                         }
                         None => {
-                            tracing::debug!("no certificate for SNI {:?}", sni);
+                            crate::dev_log!(debug, "no certificate for SNI {:?}", sni);
                             let _ = mid
                                 .io
                                 .write_all(&[

--- a/shared-libs/crates/start-core/src/prelude.rs
+++ b/shared-libs/crates/start-core/src/prelude.rs
@@ -24,3 +24,18 @@ macro_rules! dbg {
         ),+)
     }
 }
+
+/// Emit a tracing event only in `dev` builds (the `dev` cargo feature). For
+/// best-effort/expected failures — e.g. PCP/UPnP/NAT-PMP port-mapping attempts
+/// against gateways that don't support them — which are pure noise in
+/// production but useful when developing. `$level` is a tracing level macro
+/// name (`debug`/`warn`/`error`/…); `if cfg!` keeps the arguments type-checked
+/// while release builds drop the branch.
+#[macro_export]
+macro_rules! dev_log {
+    ($level:ident, $($arg:tt)*) => {
+        if cfg!(feature = "dev") {
+            tracing::$level!($($arg)*);
+        }
+    };
+}

--- a/shared-libs/crates/start-core/src/tunnel/redirect.rs
+++ b/shared-libs/crates/start-core/src/tunnel/redirect.rs
@@ -87,7 +87,7 @@ fn spawn_listener(addr: SocketAddr, listener: TcpListener) -> NonDetachingJoinHa
                 Ok((stream, _)) => {
                     tokio::spawn(async move {
                         if let Err(e) = crate::net::http::handle_http_on_https(stream).await {
-                            tracing::debug!("http redirect on {addr} closed: {e}");
+                            crate::dev_log!(debug, "http redirect on {addr} closed: {e}");
                         }
                     });
                 }


### PR DESCRIPTION
Adds a `dev_log!` macro and routes the backend's *expected/benign* failure logs through it, so they emit only in `dev` builds. These fire on normal external conditions (a gateway that doesn't support an optional feature, random internet clients on a public listener) rather than a fault on our side — noise in prod, useful while developing. Per @dr-bonez.

### The macro (prelude)
```rust
macro_rules! dev_log {
    ($level:ident, $($arg:tt)*) => {
        if cfg!(feature = "dev") { tracing::$level!($($arg)*); }
    };
}
```
`if cfg!(...)` (vs `#[cfg]` per site) keeps every argument type-checked and avoids unused-var churn in non-dev builds; the disabled branch is an `if false { … }` the optimizer drops.

### What's gated

**Commit 1 — client PCP/NAT-PMP/UPnP port mapping** (`net/port_map/client.rs`): the best-effort map / renew / unmap / HOSTNAME-skip / PORT_SET-skip / no-gateway `debug!` lines. Success lines left as-is.

**Commit 2 — sibling best-effort / benign noise:**
- **Best-effort LAN-gateway ops** (direct analog — a gateway that doesn't support the optional feature):
  - `net/gateway.rs` — UPnP WAN-IP probe failure (the genuine "couldn't determine WAN IP" stays an un-gated `error!`).
  - `net/dns_update/mod.rs` — RFC 2136 update/withdraw failures (best-effort by design; falls back to StartOS's own resolver).
- **Benign external-client noise on public listeners** (scanners, aborted handshakes, misrouted SNI, hangups):
  - `net/tls.rs` — ClientHello timeout, handshake-completion error, no cert for SNI.
  - `tunnel/redirect.rs` — HTTP→HTTPS redirect connection closed (the accept error on the same loop stays an un-gated `warn!`).

### Deliberately left visible in prod
The tunnel-server IGD/PCP logs (`tunnel/forward/{pcp,igd}.rs`) — those errors are genuinely unexpected. Also untouched: `s9pk` manifest compat warnings (package-format, different domain).

No functional change; only log verbosity in non-dev builds. No changelog/docs — these are diagnostic `debug!`/`trace!`/best-effort lines with no user-facing behavior change.

### Verification
- `cargo check -p start-core` and `--features dev` both clean (no new warnings in either config).
- `cargo test -p start-core --features dev --lib port_map::client` — 12/12.
- `cargo fmt` applied.