### PR TITLE
fix(start-os): disable Address Requirements gear on a disabled address

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/actions.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/actions.component.ts
@@ -38,6 +38,7 @@ import { DomainHealthService } from './domain-health.service'
           tuiIconButton
           appearance="flat-grayscale"
           iconStart="@tui.settings"
+          [disabled]="!address().enabled"
           (click)="showDnsValidation()"
         >
           {{ 'Address Requirements' | i18n }}
@@ -48,6 +49,7 @@ import { DomainHealthService } from './domain-health.service'
           tuiIconButton
           appearance="flat-grayscale"
           iconStart="@tui.settings"
+          [disabled]="!address().enabled"
           (click)="showPrivateDnsValidation()"
         >
           {{ 'Address Requirements' | i18n }}
@@ -62,6 +64,7 @@ import { DomainHealthService } from './domain-health.service'
           tuiIconButton
           appearance="flat-grayscale"
           iconStart="@tui.settings"
+          [disabled]="!address().enabled"
           (click)="showPortForwardValidation()"
         >
           {{ 'Address Requirements' | i18n }}
@@ -152,6 +155,7 @@ import { DomainHealthService } from './domain-health.service'
             <button
               tuiOption
               iconStart="@tui.settings"
+              [disabled]="!address().enabled"
               (click)="showDnsValidation()"
             >
               {{ 'Address Requirements' | i18n }}
@@ -161,6 +165,7 @@ import { DomainHealthService } from './domain-health.service'
             <button
               tuiOption
               iconStart="@tui.settings"
+              [disabled]="!address().enabled"
               (click)="showPrivateDnsValidation()"
             >
               {{ 'Address Requirements' | i18n }}
@@ -174,6 +179,7 @@ import { DomainHealthService } from './domain-health.service'
             <button
               tuiOption
               iconStart="@tui.settings"
+              [disabled]="!address().enabled"
               (click)="showPortForwardValidation()"
             >
               {{ 'Address Requirements' | i18n }}


### PR DESCRIPTION
When an interface address is disabled it isn't served, so its DNS / port-forward / firewall requirements can't be tested and the Address Requirements modal has nothing actionable to show. Disable the gear that opens it whenever the address is disabled.

Applies to all three requirement kinds — public-domain, private-domain, and public IPv4 — in both layouts: the desktop icon buttons and the mobile actions menu. Uses the same `!address().enabled` predicate that already gates the address's Open UI link, via native `[disabled]` on the `<button>` (the anchor uses a `.disabled` class only because an `<a>` can't be natively disabled).

UI-only; no backend, type, or i18n changes.