### PR TITLE
fix: auto-forward public IPv4 on addSsl interfaces + tunnel SNI fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7899,7 +7899,7 @@ dependencies = [
 
 [[package]]
 name = "start-tunnel"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "include_dir",
  "start-core",

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -135,6 +135,13 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **Enabling a public IPv4 address on an SSL service interface now opens the
+  gateway port automatically.** Only a public _domain_ on an SSL-terminated port
+  used to trigger automatic port forwarding (PCP/NAT-PMP/UPnP); turning on the
+  bare public IPv4 left the port closed until it was forwarded by hand. StartOS
+  now requests the pinhole for the SSL port the same way it already did for
+  public domains and IPv6 GUAs, so a public IPv4 on an `addSsl` interface (the
+  StartOS UI included) is reachable from the Internet without a manual forward.
 - **IPv6 services exposed through a tunnel are now reachable, and outbound IPv6 no longer leaks around a gateway.** StartOS now applies the full IPv4 policy-routing layer to IPv6, including CONNMARK reply-routing: a reply to an inbound IPv6 connection that arrived over a tunnel — whether terminated on the host or DNAT'd to a service container — is pinned back out the interface it arrived on, so exposing a service over a StartTunnel's delegated IPv6 actually works. Previously those replies had no route back and were blackholed, so inbound IPv6 over a tunnel was dead. Outbound, the server's IPv6 default is now chosen by route metric exactly like IPv4, and leak prevention is per-gateway: an outbound gateway that is explicitly selected but can't carry IPv6 drops the server's IPv6 via a blackhole in that gateway's own routing table — so your real address never leaks out the ISP link — without blackholing the reply traffic that keeps inbound tunnel services working.
 - **Updating a WireGuard gateway's config no longer drops its preshared key.** The in-place update path (`net tunnel update` / the **Update config** UI action, NetworkManager `Update2` + `Reapply`) persisted the interface private key but silently dropped each peer's preshared key, so a re-issued PSK-using tunnel failed its handshake and went dead (taking tunnel-routed DNS down with it). The peer secret is now flagged system-owned so the update persists it, and the settings (peer secrets inline) are passed to `Reapply` explicitly — an empty-dict `Reapply` still stripped the PSK from the _running_ device even with the profile persisted correctly, hanging all traffic through the tunnel (e.g. forwarded ports) until the next reboot.
 - **Dev builds bricked by an empty persisted host id (#3387).** Builds between

--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to StartTunnel are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.2]
+
+### Fixed
+
+- **A bare public IP and named domains can now share one external port.** When a
+  connected device publishes both a hostname-less forward and one or more SNI
+  hostnames on the same external port, the hostname-less forward now acts as the
+  fallback: a connection whose TLS SNI matches a named route reaches that route's
+  device, and everything else — a bare-IP client, or an unmatched or absent SNI —
+  reaches the fallback device. The two used to conflict, so whichever was
+  requested second was rejected.
+
 ## [1.1.1]
 
 ### Changed

--- a/projects/start-tunnel/Cargo.toml
+++ b/projects/start-tunnel/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-tunnel"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "1.1.1"                                               # VERSION_BUMP
+version = "1.1.2"                                               # VERSION_BUMP
 
 [[bin]]
 name = "tunnelbox"

--- a/projects/start-tunnel/web/src/app/routes/home/routes/published-ports/utils.ts
+++ b/projects/start-tunnel/web/src/app/routes/home/routes/published-ports/utils.ts
@@ -41,17 +41,34 @@ export function mapForwards(
 ): MappedForward[] {
   return Object.entries(portForwards).flatMap(([source, forward]) =>
     forward.kind === 'sni'
-      ? Object.entries(forward.routes).map(([hostname, route]) =>
-          toRow(
-            source,
-            route.target,
-            route.label,
-            route.enabled,
-            route.auto,
-            hostname,
-            1,
+      ? [
+          ...Object.entries(forward.routes).map(([hostname, route]) =>
+            toRow(
+              source,
+              route.target,
+              route.label,
+              route.enabled,
+              route.auto,
+              hostname,
+              1,
+            ),
           ),
-        )
+          // The hostname-less fallback: a catch-all row on the shared port,
+          // reachable by a bare IP or any SNI that matches no named route.
+          ...(forward.fallback
+            ? [
+                toRow(
+                  source,
+                  forward.fallback.target,
+                  forward.fallback.label,
+                  forward.fallback.enabled,
+                  forward.fallback.auto,
+                  null,
+                  1,
+                ),
+              ]
+            : []),
+        ]
       : [
           toRow(
             source,

--- a/projects/start-tunnel/web/src/app/services/api/mock-api.service.ts
+++ b/projects/start-tunnel/web/src/app/services/api/mock-api.service.ts
@@ -339,7 +339,11 @@ export class MockApiService extends ApiService {
         }
       }
 
-      const value: T.Tunnel.PortForward = { kind: 'sni', routes }
+      const value: T.Tunnel.PortForward = {
+        kind: 'sni',
+        routes,
+        fallback: null,
+      }
       forwards[source] = value
       this.mockRevision([
         {

--- a/projects/start-tunnel/web/src/app/services/patch-db/data-model.ts
+++ b/projects/start-tunnel/web/src/app/services/patch-db/data-model.ts
@@ -85,6 +85,14 @@ export const mockTunnelData: TunnelData = {
           auto: false,
         },
       },
+      // Hostname-less fallback: catches bare-IP / non-matching-SNI traffic on
+      // this shared port.
+      fallback: {
+        target: '10.59.0.2:443',
+        label: 'App (fallback)',
+        enabled: true,
+        auto: false,
+      },
     },
   },
   pinholes6: {

--- a/shared-libs/crates/start-core/src/net/forward.rs
+++ b/shared-libs/crates/start-core/src/net/forward.rs
@@ -918,6 +918,10 @@ enum InterfaceForwardCommand {
 
 pub struct InterfacePortForwardController {
     req: mpsc::UnboundedSender<InterfaceForwardCommand>,
+    /// A clone of the shared `PortMapController`, so this controller owns the
+    /// upstream pinhole of a v6 GUA DNAT ([`Self::forward6`]) the same way the v4
+    /// path does inside [`InterfaceForwardEntry::update`].
+    pmap: PortMapController,
     _thread: NonDetachingJoinHandle<()>,
 }
 
@@ -927,6 +931,7 @@ impl InterfacePortForwardController {
         pmap: PortMapController,
     ) -> Self {
         let port_forward = PortForwardController::new();
+        let v6_pmap = pmap.clone();
 
         let (req_send, mut req_recv) = mpsc::unbounded_channel::<InterfaceForwardCommand>();
         let thread = NonDetachingJoinHandle::from(tokio::spawn(async move {
@@ -961,8 +966,50 @@ impl InterfacePortForwardController {
 
         Self {
             req: req_send,
+            pmap: v6_pmap,
             _thread: thread,
         }
+    }
+
+    /// DNAT a host GUA to a container ULA (v6 counterpart of a v4 forward) and, for
+    /// a WAN forward (`src_filter == None`), open its upstream firewall pinhole —
+    /// so the DNAT and its pinhole are owned together, as in the v4 path.
+    /// `gateways` are the PCP candidates for the pinhole (ignored for a LAN-only
+    /// forward). Best-effort pinhole: it is a fire-and-forget port-map request.
+    pub async fn forward6(
+        &self,
+        source: SocketAddrV6,
+        target: SocketAddrV6,
+        target_prefix: u8,
+        src_filter: Option<IpNet>,
+        gateways: Vec<(IpAddr, Option<u32>)>,
+    ) -> Result<(), Error> {
+        forward6(source, target, target_prefix, src_filter.as_ref()).await?;
+        if src_filter.is_none() && !gateways.is_empty() {
+            self.pmap.ensure(
+                IpAddr::V6(*source.ip()),
+                source.port(),
+                source.port(),
+                gateways,
+            );
+        }
+        Ok(())
+    }
+
+    /// Tear down a [`Self::forward6`] — the nft DNAT and, for a WAN forward, its
+    /// upstream pinhole.
+    pub async fn unforward6(
+        &self,
+        source: SocketAddrV6,
+        target: SocketAddrV6,
+        target_prefix: u8,
+        src_filter: Option<IpNet>,
+    ) -> Result<(), Error> {
+        unforward6(source, target, target_prefix, src_filter.as_ref()).await?;
+        if src_filter.is_none() {
+            self.pmap.remove(IpAddr::V6(*source.ip()), source.port());
+        }
+        Ok(())
     }
 
     pub async fn add(

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -295,24 +295,6 @@ struct HostBinds {
     forwards: BTreeMap<u16, (SocketAddrV4, u16, ForwardRequirements, Arc<()>)>,
     vhosts: BTreeMap<(Option<InternedString>, u16), (ProxyTarget, Arc<()>)>,
     private_dns: BTreeMap<InternedString, Arc<()>>,
-    /// `(GUA, listener port)` upstream firewall pinholes requested for LAN+WAN
-    /// GUAs. The host's own GUA is the listener (no DNAT), so this is a pure
-    /// PortMapController pinhole. Tracked so it is withdrawn when a GUA leaves
-    /// LAN+WAN or its binding goes away.
-    gua_pinholes: BTreeSet<(Ipv6Addr, u16)>,
-    /// `(box LAN IPv4, ssl listener port)` upstream pinholes for a bare public
-    /// IPv4 exposed on an `add_ssl` binding. The host's TLS `*` vhost is the
-    /// listener (no DNAT), so this is a pure PortMapController pinhole — the IPv4
-    /// analogue of `gua_pinholes`. A co-located public domain requests its own
-    /// SNI-keyed mapping, so the two coexist (the bare-IP forward is the SNI
-    /// fallback on a StartTunnel gateway). Tracked so it is withdrawn when the
-    /// operator disables the WAN IP or the binding goes away.
-    ssl_ip_pinholes: BTreeSet<(Ipv4Addr, u16)>,
-    /// GUAs we asked the gateway for an 80->443 redirect pinhole on. Tracked so
-    /// the redirect is withdrawn when 443 stops being exposed on that GUA, or 80
-    /// becomes a real pinhole. There is no IPv4 analogue: over IPv4 the upstream
-    /// gateway (e.g. StartTunnel) serves the port-80 HTTP→HTTPS redirect itself.
-    gua_redirect_maps: BTreeSet<Ipv6Addr>,
     /// Non-SSL v6 forwards: `(host GUA, external port) -> (container v6, internal
     /// port, LAN source filter)`. A non-SSL GUA has no host terminator, so its
     /// port is DNAT'd to the container (see `forward6`); tracked so a stale
@@ -344,11 +326,9 @@ impl NetServiceData {
         let mut forwards: BTreeMap<u16, (SocketAddrV4, u16, ForwardRequirements)> = BTreeMap::new();
         let mut vhosts: BTreeMap<(Option<InternedString>, u16), ProxyTarget> = BTreeMap::new();
         let mut private_dns: BTreeMap<InternedString, BTreeSet<GatewayId>> = BTreeMap::new();
-        let mut gua_pinholes: BTreeSet<(Ipv6Addr, u16)> = BTreeSet::new();
-        let mut ssl_ip_pinholes: BTreeSet<(Ipv4Addr, u16)> = BTreeSet::new();
-        // Candidate v6 gateways per GUA, so the post-loop 80->443 redirect can
-        // reach the same gateways the GUA's pinholes used.
-        let mut gua_gateways: BTreeMap<Ipv6Addr, Vec<(IpAddr, Option<u32>)>> = BTreeMap::new();
+        // Non-SSL v6 DNAT forwards to the container — net_controller's concern (no
+        // vhost owns them), but the forward controller opens their upstream pinhole
+        // together with the DNAT (see the reconcile below).
         let mut gua_forwards: BTreeMap<(Ipv6Addr, u16), (Ipv6Addr, u16, Option<IpNet>)> =
             BTreeMap::new();
         let binds = self.binds.entry(id.clone()).or_default();
@@ -368,41 +348,6 @@ impl NetServiceData {
             // to lo / lxcbr0 but never to a gateway (see `enabled_addresses`).
             let enabled_addresses = bind.enabled_addresses();
             let addr: SocketAddr = (self.ip, *port).into();
-
-            // LAN+WAN GUAs: the host's own GUA is the listener (no DNAT), so
-            // rather than a LAN forward we ask the upstream gateway(s) for a
-            // firewall pinhole to the GUA:port (best-effort PCP/NAT-PMP).
-            for a in enabled_addresses.iter().filter(|a| a.public) {
-                let Some(gua) = a.gua() else {
-                    continue;
-                };
-                // The WAN is never secure: no upstream pinhole for an insecure exposure
-                // (add_ssl terminates TLS on the ssl port → a.ssl).
-                if !(a.ssl || bind.options.secure.is_some()) {
-                    continue;
-                }
-                let v6_gateways: Vec<(IpAddr, Option<u32>)> = a
-                    .metadata
-                    .gateways()
-                    .filter_map(|gw| net_ifaces.get(gw))
-                    .flat_map(|info| candidate_gateways(info))
-                    .filter(|(g, _)| g.is_ipv6())
-                    .collect();
-                if v6_gateways.is_empty() {
-                    continue;
-                }
-                gua_gateways
-                    .entry(*gua.ip())
-                    .or_insert_with(|| v6_gateways.clone());
-                if gua_pinholes.insert((*gua.ip(), gua.port())) {
-                    ctrl.port_map.ensure(
-                        IpAddr::V6(*gua.ip()),
-                        gua.port(),
-                        gua.port(),
-                        v6_gateways,
-                    );
-                }
-            }
 
             // Key private DNS by its live gateways so the resolver only answers
             // locally over those gateways — works even when also public (split DNS).
@@ -448,21 +393,40 @@ impl NetServiceData {
                         .flat_map(|ip_info| ip_info.subnets.iter().map(|s| s.addr()))
                         .collect();
 
-                    // Collect public gateways from enabled WAN IP addresses
-                    // (public IPv4 WAN, or a GUA the operator set to LAN+WAN).
-                    let server_public_gateways: BTreeSet<GatewayId> = enabled_addresses
+                    // Public gateways, split by family: a bare public IPv4 (WAN IP)
+                    // and a LAN+WAN GUA are independently toggleable, and the vhost
+                    // must accept (and forward) each family only where that family
+                    // is actually public — so a GUA-only-public gateway never
+                    // accepts or forwards bare IPv4. The controller derives the IPv4
+                    // `*` pinhole from `public_v4`; the GUA needs no NAT.
+                    let server_public_v4: BTreeSet<GatewayId> = enabled_addresses
                         .iter()
-                        .filter(|a| a.public && a.metadata.is_ip())
+                        .filter(|a| a.public && matches!(a.metadata, HostnameMetadata::Ipv4 { .. }))
                         .flat_map(|a| a.metadata.gateways())
                         .cloned()
                         .collect();
+                    // Per-IP (per-GUA), not per-gateway: one gateway can carry
+                    // several GUAs that are independently Local vs Public, so only
+                    // the specific enabled-public GUAs accept WAN. Scoped to the SSL
+                    // exposure (`a.ssl`), since this `*` vhost terminates TLS on the
+                    // ssl port — a GUA public only on a non-SSL port is served by the
+                    // v6 DNAT forward, not this vhost.
+                    let server_public_v6: BTreeSet<Ipv6Addr> = enabled_addresses
+                        .iter()
+                        .filter(|a| a.public && a.ssl)
+                        .filter_map(|a| a.gua().map(|g| *g.ip()))
+                        .collect();
 
                     // * vhost (on assigned_ssl_port)
-                    if !server_private_ips.is_empty() || !server_public_gateways.is_empty() {
+                    if !server_private_ips.is_empty()
+                        || !server_public_v4.is_empty()
+                        || !server_public_v6.is_empty()
+                    {
                         vhosts.insert(
                             (None, assigned_ssl_port),
                             ProxyTarget {
-                                public: server_public_gateways.clone(),
+                                public_v4: server_public_v4,
+                                public_v6: server_public_v6,
                                 private: server_private_ips.clone(),
                                 acme: None,
                                 addr,
@@ -472,42 +436,6 @@ impl NetServiceData {
                                 passthrough: false,
                             },
                         );
-                    }
-
-                    // A bare public IPv4 (WAN IP) enabled on this add_ssl port has
-                    // no SNI to demux, so — like a GUA pinhole — ask the upstream
-                    // gateway(s) to forward the ssl port to the box's own LAN IPv4
-                    // (the `*` vhost is the listener; there is no local DNAT). A
-                    // public domain requests its own SNI-keyed mapping separately;
-                    // on a StartTunnel gateway the two share the port with this
-                    // bare-IP forward acting as the SNI fallback.
-                    for a in enabled_addresses.iter().filter(|a| a.public && a.ssl) {
-                        let HostnameMetadata::Ipv4 { gateway } = &a.metadata else {
-                            continue;
-                        };
-                        let Some(info) = net_ifaces.get(gateway) else {
-                            continue;
-                        };
-                        let Some(ip_info) = &info.ip_info else {
-                            continue;
-                        };
-                        let gateways = candidate_gateways(info);
-                        if gateways.is_empty() {
-                            continue;
-                        }
-                        for subnet in &ip_info.subnets {
-                            let IpAddr::V4(local_ip) = subnet.addr() else {
-                                continue;
-                            };
-                            if ssl_ip_pinholes.insert((local_ip, assigned_ssl_port)) {
-                                ctrl.port_map.ensure(
-                                    IpAddr::V4(local_ip),
-                                    assigned_ssl_port,
-                                    assigned_ssl_port,
-                                    gateways.clone(),
-                                );
-                            }
-                        }
                     }
                 }
 
@@ -527,7 +455,8 @@ impl NetServiceData {
                     };
                     let key = (Some(domain.clone()), domain_ssl_port);
                     let target = vhosts.entry(key).or_insert_with(|| ProxyTarget {
-                        public: BTreeSet::new(),
+                        public_v4: BTreeSet::new(),
+                        public_v6: BTreeSet::new(),
                         private: BTreeSet::new(),
                         acme: host_addresses
                             .iter()
@@ -541,9 +470,14 @@ impl NetServiceData {
                         passthrough: false,
                     });
                     if addr_info.public {
-                        for gw in addr_info.metadata.gateways() {
-                            target.public.insert(gw.clone());
-                        }
+                        // A public domain is dual-stack (A + AAAA): public on its
+                        // gateways' bare IPv4 and on each of their GUAs.
+                        let gws: BTreeSet<GatewayId> =
+                            addr_info.metadata.gateways().cloned().collect();
+                        target.public_v4.extend(gws.iter().cloned());
+                        target
+                            .public_v6
+                            .extend(crate::net::utils::gua_ips(&net_ifaces, &gws));
                     } else {
                         for gw in addr_info.metadata.gateways() {
                             if let Some(info) = net_ifaces.get(gw) {
@@ -646,6 +580,10 @@ impl NetServiceData {
                                 None => continue,
                             }
                         };
+                        // A public bare GUA is DNAT'd to the container, but no vhost
+                        // owns it (add_ssl builds the `*` vhost; passthroughs are
+                        // domain-only). The forward controller opens its upstream
+                        // pinhole together with the DNAT (see the reconcile below).
                         gua_forwards
                             .insert((*gua.ip(), gua.port()), (container_v6, *port, src_filter));
                     }
@@ -673,7 +611,8 @@ impl NetServiceData {
                     let domain = &addr_info.hostname;
                     let key = (Some(domain.clone()), pt_port);
                     let target = vhosts.entry(key).or_insert_with(|| ProxyTarget {
-                        public: BTreeSet::new(),
+                        public_v4: BTreeSet::new(),
+                        public_v6: BTreeSet::new(),
                         private: BTreeSet::new(),
                         acme: None,
                         addr,
@@ -683,9 +622,13 @@ impl NetServiceData {
                         passthrough: true,
                     });
                     if addr_info.public {
-                        for gw in addr_info.metadata.gateways() {
-                            target.public.insert(gw.clone());
-                        }
+                        // Passthrough domain is dual-stack, like the SSL domain vhost.
+                        let gws: BTreeSet<GatewayId> =
+                            addr_info.metadata.gateways().cloned().collect();
+                        target.public_v4.extend(gws.iter().cloned());
+                        target
+                            .public_v6
+                            .extend(crate::net::utils::gua_ips(&net_ifaces, &gws));
                     } else {
                         for gw in addr_info.metadata.gateways() {
                             if let Some(info) = net_ifaces.get(gw) {
@@ -770,119 +713,30 @@ impl NetServiceData {
             );
         }
 
-        // No IPv4 HTTP→HTTPS redirect map is requested: the upstream gateway
-        // (e.g. StartTunnel) serves the port-80 redirect itself. The IPv6
-        // 80->443 redirect pinhole below is still requested — over IPv6 the
-        // gateway has no port-80 listener of its own to do it.
+        // The vhost controller owns every upstream port map for its ports — the
+        // IPv6 GUA pinholes (bare `*` and public-domain vhosts) and their v6 80->443
+        // redirect included — deriving them from each ProxyTarget's `public_v6`. The
+        // non-vhost DNAT'd GUA pinholes are owned by the forward controller (with the
+        // DNAT). So net_controller itself requests no port maps. The IPv4 gateway
+        // serves its own port-80 HTTP->HTTPS redirect.
 
-        // Public domains are DualStack: the domain vhost already binds and
-        // SNI-routes on each gateway's GUA, but the upstream firewall must be
-        // opened for it. Request a GUA pinhole per public domain port — without
-        // exposing the bare GUA (never added to gua_wan), so SNI at our vhost
-        // disambiguates domain traffic from bare-IP traffic. Unlike the v4
-        // SNI-demux (hostname_maps) this needs no gateway-side demux: every host
-        // has its own GUA, so there is nothing to share.
-        for ((maybe_host, external), target) in vhosts.iter() {
-            if maybe_host.is_none() || target.public.is_empty() {
-                continue;
-            }
-            for gw_id in &target.public {
-                let Some(info) = net_ifaces.get(gw_id) else {
-                    continue;
-                };
-                let Some(ip_info) = &info.ip_info else {
-                    continue;
-                };
-                let v6_gateways: Vec<(IpAddr, Option<u32>)> = candidate_gateways(info)
-                    .into_iter()
-                    .filter(|(g, _)| g.is_ipv6())
-                    .collect();
-                if v6_gateways.is_empty() {
-                    continue;
-                }
-                for subnet in &ip_info.subnets {
-                    let IpAddr::V6(gua) = subnet.addr() else {
-                        continue;
-                    };
-                    if crate::net::utils::ipv6_is_local(gua) {
-                        continue;
-                    }
-                    gua_gateways
-                        .entry(gua)
-                        .or_insert_with(|| v6_gateways.clone());
-                    if gua_pinholes.insert((gua, *external)) {
-                        ctrl.port_map.ensure(
-                            IpAddr::V6(gua),
-                            *external,
-                            *external,
-                            v6_gateways.clone(),
-                        );
-                    }
-                }
-            }
-        }
-
-        // v6 HTTP→HTTPS redirect: for a GUA exposing 443, ask the gateway for an
-        // 80->443 redirect pinhole. Skipped when 80 is already a real pinhole on
-        // that GUA. (No IPv4 equivalent — the gateway redirects port 80 itself.)
-        let mut gua_redirects: BTreeSet<Ipv6Addr> = BTreeSet::new();
-        for (gua_ip, gws) in &gua_gateways {
-            if gua_pinholes.contains(&(*gua_ip, 443))
-                && !gua_pinholes.contains(&(*gua_ip, 80))
-                && gua_redirects.insert(*gua_ip)
-            {
-                ctrl.port_map
-                    .ensure(IpAddr::V6(*gua_ip), 80, 443, gws.clone());
-            }
-        }
-        let stale_redirects: Vec<Ipv6Addr> = binds
-            .gua_redirect_maps
-            .difference(&gua_redirects)
-            .copied()
-            .collect();
-        for ip in stale_redirects {
-            ctrl.port_map.remove(IpAddr::V6(ip), 80);
-        }
-        binds.gua_redirect_maps = gua_redirects;
-
-        // Withdraw GUA pinholes that no longer apply (GUA left LAN+WAN, or the
-        // binding went away).
-        let stale_gua: Vec<(Ipv6Addr, u16)> = binds
-            .gua_pinholes
-            .difference(&gua_pinholes)
-            .copied()
-            .collect();
-        for (ip, port) in stale_gua {
-            ctrl.port_map.remove(IpAddr::V6(ip), port);
-        }
-        binds.gua_pinholes = gua_pinholes;
-
-        // Withdraw bare-IPv4 SSL-port pinholes that no longer apply (WAN IP
-        // disabled, or the binding went away).
-        let stale_ssl_ips: Vec<(Ipv4Addr, u16)> = binds
-            .ssl_ip_pinholes
-            .difference(&ssl_ip_pinholes)
-            .copied()
-            .collect();
-        for (ip, port) in stale_ssl_ips {
-            ctrl.port_map.remove(IpAddr::V4(ip), port);
-        }
-        binds.ssl_ip_pinholes = ssl_ip_pinholes;
-
-        // Reconcile non-SSL v6 forwards: tear down any that changed or went
-        // away, then install new/changed ones. Best-effort — a nft failure on
-        // one forward is logged, not fatal to the whole update.
+        // Reconcile non-SSL v6 forwards: tear down any that changed or went away,
+        // then install new/changed ones. The forward controller owns each forward's
+        // DNAT *and* its upstream pinhole (WAN forwards only), just like the v4 path.
+        // Best-effort — a nft failure on one forward is logged, not fatal.
         for (key, spec) in &binds.gua_forwards {
             if gua_forwards.get(key) != Some(spec) {
                 let &(gua, ext) = key;
                 let &(tgt, int, ref src) = spec;
-                if let Err(e) = crate::net::forward::unforward6(
-                    SocketAddrV6::new(gua, ext, 0, 0),
-                    SocketAddrV6::new(tgt, int, 0, 0),
-                    64,
-                    src.as_ref(),
-                )
-                .await
+                if let Err(e) = ctrl
+                    .forward
+                    .unforward6(
+                        SocketAddrV6::new(gua, ext, 0, 0),
+                        SocketAddrV6::new(tgt, int, 0, 0),
+                        64,
+                        src.clone(),
+                    )
+                    .await
                 {
                     tracing::error!("failed to remove v6 forward [{gua}]:{ext}: {e}");
                     tracing::debug!("{e:?}");
@@ -893,13 +747,36 @@ impl NetServiceData {
             if binds.gua_forwards.get(key) != Some(spec) {
                 let &(gua, ext) = key;
                 let &(tgt, int, ref src) = spec;
-                if let Err(e) = crate::net::forward::forward6(
-                    SocketAddrV6::new(gua, ext, 0, 0),
-                    SocketAddrV6::new(tgt, int, 0, 0),
-                    64,
-                    src.as_ref(),
-                )
-                .await
+                // PCP candidates for the pinhole (only used for a WAN forward).
+                let gateways: Vec<(IpAddr, Option<u32>)> = if src.is_none() {
+                    net_ifaces
+                        .iter()
+                        .map(|(_, i)| i)
+                        .find(|info| {
+                            info.ip_info.as_ref().map_or(false, |i| {
+                                i.subnets.iter().any(|s| s.addr() == IpAddr::V6(gua))
+                            })
+                        })
+                        .map(|info| {
+                            candidate_gateways(info)
+                                .into_iter()
+                                .filter(|(g, _)| g.is_ipv6())
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                } else {
+                    Vec::new()
+                };
+                if let Err(e) = ctrl
+                    .forward
+                    .forward6(
+                        SocketAddrV6::new(gua, ext, 0, 0),
+                        SocketAddrV6::new(tgt, int, 0, 0),
+                        64,
+                        src.clone(),
+                        gateways,
+                    )
+                    .await
                 {
                     tracing::error!("failed to add v6 forward [{gua}]:{ext} -> [{tgt}]:{int}: {e}");
                     tracing::debug!("{e:?}");
@@ -954,45 +831,14 @@ impl NetServiceData {
         }
         ctrl.forward.gc().await?;
 
-        // PCP HOSTNAME mappings come only from PUBLIC domain vhosts: each binds
-        // its FQDN on the shared external port so the gateway demultiplexes
-        // inbound TLS by SNI. Computed before the drain loop consumes `vhosts`.
-        let mut hostname_maps: BTreeMap<
-            (Ipv4Addr, u16),
-            (u16, Vec<(IpAddr, Option<u32>)>, Vec<String>),
-        > = BTreeMap::new();
-        for ((maybe_host, external), target) in vhosts.iter() {
-            let Some(hostname) = maybe_host else { continue };
-            if target.public.is_empty() {
-                continue;
-            }
-            for gw_id in &target.public {
-                let Some(info) = net_ifaces.get(gw_id) else {
-                    continue;
-                };
-                let Some(ip_info) = &info.ip_info else {
-                    continue;
-                };
-                let gateways = candidate_gateways(info);
-                if gateways.is_empty() {
-                    continue;
-                }
-                for subnet in &ip_info.subnets {
-                    let IpAddr::V4(local_ip) = subnet.addr() else {
-                        continue;
-                    };
-                    let entry = hostname_maps
-                        .entry((local_ip, *external))
-                        .or_insert_with(|| (*external, gateways.clone(), Vec::new()));
-                    let name = hostname.to_string();
-                    if !entry.2.contains(&name) {
-                        entry.2.push(name);
-                    }
-                }
-            }
-        }
+        // The vhost controller owns every upstream IPv4 port map for its ports —
+        // PCP HOSTNAME for a public domain, a plain pinhole for a bare public IPv4
+        // (`*` vhost) — deriving them from the vhost targets themselves (their
+        // per-family `public_v4`). Called on the complete `vhosts` before the drain
+        // loop below consumes it, and on every update (even with none) so a host
+        // that dropped its exposure withdraws its prior mappings.
         ctrl.vhost
-            .sync_hostname_mappings((self.id.clone(), id.clone()), hostname_maps);
+            .reconcile_port_maps((self.id.clone(), id.clone()), &vhosts);
 
         let all = binds
             .vhosts

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -300,6 +300,14 @@ struct HostBinds {
     /// PortMapController pinhole. Tracked so it is withdrawn when a GUA leaves
     /// LAN+WAN or its binding goes away.
     gua_pinholes: BTreeSet<(Ipv6Addr, u16)>,
+    /// `(box LAN IPv4, ssl listener port)` upstream pinholes for a bare public
+    /// IPv4 exposed on an `add_ssl` binding. The host's TLS `*` vhost is the
+    /// listener (no DNAT), so this is a pure PortMapController pinhole — the IPv4
+    /// analogue of `gua_pinholes`. A co-located public domain requests its own
+    /// SNI-keyed mapping, so the two coexist (the bare-IP forward is the SNI
+    /// fallback on a StartTunnel gateway). Tracked so it is withdrawn when the
+    /// operator disables the WAN IP or the binding goes away.
+    ssl_ip_pinholes: BTreeSet<(Ipv4Addr, u16)>,
     /// GUAs we asked the gateway for an 80->443 redirect pinhole on. Tracked so
     /// the redirect is withdrawn when 443 stops being exposed on that GUA, or 80
     /// becomes a real pinhole. There is no IPv4 analogue: over IPv4 the upstream
@@ -337,6 +345,7 @@ impl NetServiceData {
         let mut vhosts: BTreeMap<(Option<InternedString>, u16), ProxyTarget> = BTreeMap::new();
         let mut private_dns: BTreeMap<InternedString, BTreeSet<GatewayId>> = BTreeMap::new();
         let mut gua_pinholes: BTreeSet<(Ipv6Addr, u16)> = BTreeSet::new();
+        let mut ssl_ip_pinholes: BTreeSet<(Ipv4Addr, u16)> = BTreeSet::new();
         // Candidate v6 gateways per GUA, so the post-loop 80->443 redirect can
         // reach the same gateways the GUA's pinholes used.
         let mut gua_gateways: BTreeMap<Ipv6Addr, Vec<(IpAddr, Option<u32>)>> = BTreeMap::new();
@@ -463,6 +472,42 @@ impl NetServiceData {
                                 passthrough: false,
                             },
                         );
+                    }
+
+                    // A bare public IPv4 (WAN IP) enabled on this add_ssl port has
+                    // no SNI to demux, so — like a GUA pinhole — ask the upstream
+                    // gateway(s) to forward the ssl port to the box's own LAN IPv4
+                    // (the `*` vhost is the listener; there is no local DNAT). A
+                    // public domain requests its own SNI-keyed mapping separately;
+                    // on a StartTunnel gateway the two share the port with this
+                    // bare-IP forward acting as the SNI fallback.
+                    for a in enabled_addresses.iter().filter(|a| a.public && a.ssl) {
+                        let HostnameMetadata::Ipv4 { gateway } = &a.metadata else {
+                            continue;
+                        };
+                        let Some(info) = net_ifaces.get(gateway) else {
+                            continue;
+                        };
+                        let Some(ip_info) = &info.ip_info else {
+                            continue;
+                        };
+                        let gateways = candidate_gateways(info);
+                        if gateways.is_empty() {
+                            continue;
+                        }
+                        for subnet in &ip_info.subnets {
+                            let IpAddr::V4(local_ip) = subnet.addr() else {
+                                continue;
+                            };
+                            if ssl_ip_pinholes.insert((local_ip, assigned_ssl_port)) {
+                                ctrl.port_map.ensure(
+                                    IpAddr::V4(local_ip),
+                                    assigned_ssl_port,
+                                    assigned_ssl_port,
+                                    gateways.clone(),
+                                );
+                            }
+                        }
                     }
                 }
 
@@ -811,6 +856,18 @@ impl NetServiceData {
             ctrl.port_map.remove(IpAddr::V6(ip), port);
         }
         binds.gua_pinholes = gua_pinholes;
+
+        // Withdraw bare-IPv4 SSL-port pinholes that no longer apply (WAN IP
+        // disabled, or the binding went away).
+        let stale_ssl_ips: Vec<(Ipv4Addr, u16)> = binds
+            .ssl_ip_pinholes
+            .difference(&ssl_ip_pinholes)
+            .copied()
+            .collect();
+        for (ip, port) in stale_ssl_ips {
+            ctrl.port_map.remove(IpAddr::V4(ip), port);
+        }
+        binds.ssl_ip_pinholes = ssl_ip_pinholes;
 
         // Reconcile non-SSL v6 forwards: tear down any that changed or went
         // away, then install new/changed ones. Best-effort — a nft failure on

--- a/shared-libs/crates/start-core/src/net/utils.rs
+++ b/shared-libs/crates/start-core/src/net/utils.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::path::Path;
 use std::time::Duration;
@@ -7,6 +7,7 @@ use async_stream::try_stream;
 use color_eyre::eyre::eyre;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
+use imbl::OrdMap;
 use imbl_value::InternedString;
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use nix::net::if_::if_nametoindex;
@@ -14,7 +15,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::process::Command;
 
 use crate::GatewayId;
-use crate::db::model::public::{IpInfo, NetworkInterfaceType};
+use crate::db::model::public::{IpInfo, NetworkInterfaceInfo, NetworkInterfaceType};
 use crate::prelude::*;
 use crate::util::Invoke;
 
@@ -144,6 +145,24 @@ pub fn is_private_ip(addr: IpAddr) -> bool {
         IpAddr::V4(v4) => v4.is_private() || v4.is_loopback() || v4.is_link_local(),
         IpAddr::V6(v6) => ipv6_is_local(v6),
     }
+}
+
+/// The box's own IPv6 global-unicast addresses (GUAs) on `gateways` — the
+/// non-link-local, non-ULA v6 subnet addresses. Used to populate a vhost's
+/// per-IP `public_v6`, since one gateway may carry several GUAs.
+pub fn gua_ips(
+    ip_info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
+    gateways: &BTreeSet<GatewayId>,
+) -> BTreeSet<Ipv6Addr> {
+    gateways
+        .iter()
+        .filter_map(|gw| ip_info.get(gw).and_then(|i| i.ip_info.as_ref()))
+        .flat_map(|info| info.subnets.iter())
+        .filter_map(|s| match s.addr() {
+            IpAddr::V6(v6) if !ipv6_is_local(v6) => Some(v6),
+            _ => None,
+        })
+        .collect()
 }
 
 fn parse_iface_ip(output: &str) -> Result<Vec<&str>, Error> {

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::future::Future;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV6};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
@@ -14,8 +14,9 @@ use clap::Parser;
 use color_eyre::eyre::eyre;
 use futures::FutureExt;
 use futures::future::BoxFuture;
-use imbl::OrdMap;
+use imbl::{OrdMap, OrdSet};
 use imbl_value::{InOMap, InternedString};
+use ipnet::IpNet;
 use rpc_toolkit::{Context, HandlerArgs, HandlerExt, ParentHandler, from_fn, from_fn_async};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
@@ -40,7 +41,7 @@ use crate::net::acme::{
 use crate::net::gateway::{
     GatewayInfo, NetworkInterfaceController, NetworkInterfaceListenerAcceptMetadata,
 };
-use crate::net::port_map::PortMapController;
+use crate::net::port_map::{PortMapController, candidate_gateways};
 use crate::net::ssl::{CertBranding, CertStore, RootCaTlsHandler};
 use crate::net::tls::{ChainedHandler, TlsHandler, TlsHandlerAction, TlsListener, TlsMetadata};
 use crate::net::utils::{bind_mio_listener, ipv6_is_link_local, is_private_ip};
@@ -259,10 +260,14 @@ pub struct VHostController {
     servers: SyncMutex<BTreeMap<u16, VHostServer<VHostBindListener>>>,
     passthrough_handles: SyncMutex<BTreeMap<(InternedString, u16), PassthroughHandle>>,
     port_map: PortMapController,
-    /// Per-owner set of `(ext_ip, ext_port, hostname)` SNI routes this controller
-    /// has asked the port-mapper to maintain. Keyed by owner so one service's
-    /// reconcile only adds/removes its own hostnames on a shared port.
-    hostname_mappings: SyncMutex<BTreeMap<HostMapOwner, BTreeSet<(Ipv4Addr, u16, String)>>>,
+    /// Per-owner set of `(ext_ip, ext_port, hostname)` upstream port maps this
+    /// controller has asked the port-mapper to maintain for its vhosts —
+    /// everything: IPv4 SNI HOSTNAME routes (`Some(hostname)`), IPv4 bare-IP (`*`
+    /// vhost) pinholes and IPv6 GUA pinholes (`None`), and the v6 80->443 redirect.
+    /// Keyed by owner so one service's reconcile only adds/removes its own entries
+    /// on a shared port.
+    port_mappings:
+        SyncMutex<BTreeMap<HostMapOwner, BTreeSet<(IpAddr, u16, Option<InternedString>)>>>,
 }
 impl VHostController {
     pub fn new(
@@ -284,7 +289,7 @@ impl VHostController {
             servers: SyncMutex::new(BTreeMap::new()),
             passthrough_handles: SyncMutex::new(BTreeMap::new()),
             port_map,
-            hostname_mappings: SyncMutex::new(BTreeMap::new()),
+            port_mappings: SyncMutex::new(BTreeMap::new()),
         };
         for pt in passthroughs {
             if let Err(e) = controller.add_passthrough(
@@ -346,7 +351,10 @@ impl VHostController {
         private: BTreeSet<IpAddr>,
     ) -> Result<(), Error> {
         let target = ProxyTarget {
-            public: public.clone(),
+            // A TLS passthrough is domain (SNI) based, i.e. dual-stack public: it is
+            // public on its gateways' bare IPv4 and on each of their GUAs.
+            public_v4: public.clone(),
+            public_v6: crate::net::utils::gua_ips(&self.interfaces.watcher.ip_info(), &public),
             private: private.clone(),
             acme: None,
             addr: backend,
@@ -429,45 +437,146 @@ impl VHostController {
         })
     }
 
-    /// Reconcile best-effort PCP HOSTNAME port mappings for `owner`'s public
-    /// domain vhosts. `desired` maps `(box IP to map from, external port)` to
-    /// `(internal port, candidate gateways, FQDNs)`. Each hostname is mapped
-    /// independently — the gateway treats the hostname as part of the mapping's
-    /// identity and demultiplexes the shared external port by TLS SNI — so one
-    /// service adding or removing a hostname never disturbs another service's
-    /// hostnames on the same port. Like the rest of the port-map layer this is
-    /// best-effort: a gateway that can't honor it just leaves the user on a
-    /// manual forward.
-    pub fn sync_hostname_mappings(
+    /// Reconcile best-effort upstream port mappings for `owner`'s public vhosts.
+    /// `desired` maps `(box IP to map from, external port)` to `(internal port,
+    /// candidate gateways, hostnames)`. A `Some(hostname)` is mapped via PCP
+    /// HOSTNAME — the gateway treats the hostname as part of the mapping's identity
+    /// and demultiplexes the shared external port by TLS SNI, so one service adding
+    /// or removing a hostname never disturbs another's on the same port. A `None`
+    /// is a bare-IP (`*` vhost) forward: no SNI, so a plain pinhole to the box's own
+    /// IP where the OS reverse proxy listens. Like the rest of the port-map layer
+    /// this is best-effort: a gateway that can't honor it leaves a manual forward.
+    /// Reconcile every upstream IPv4 port map `owner`'s vhosts need, derived from
+    /// the vhost `targets` themselves — the controller owns the whole port-map
+    /// lifecycle, so callers hand over the same `ProxyTarget` set they use to bind
+    /// the listeners and compute nothing. For each target public on IPv4
+    /// (`public_v4`), each of that gateway's box IPv4s gets a mapping keyed by the
+    /// vhost's hostname: `Some(host)` is a PCP HOSTNAME mapping (SNI demux), `None`
+    /// is a bare-IP (`*` vhost) pinhole. IPv6 GUAs carry no NAT, so they get no
+    /// mapping here. Always call this every update — an owner whose target set went
+    /// empty withdraws its prior mappings via the per-owner diff.
+    pub fn reconcile_port_maps(
         &self,
         owner: HostMapOwner,
-        desired: BTreeMap<(Ipv4Addr, u16), (u16, Vec<(IpAddr, Option<u32>)>, Vec<String>)>,
+        targets: &BTreeMap<(Option<InternedString>, u16), ProxyTarget>,
     ) {
-        let want: BTreeSet<(Ipv4Addr, u16, String)> = desired
+        let ip_info = self.interfaces.watcher.ip_info();
+        let mut desired: BTreeMap<
+            (IpAddr, u16),
+            (u16, Vec<(IpAddr, Option<u32>)>, Vec<Option<InternedString>>),
+        > = BTreeMap::new();
+        for ((maybe_host, external), target) in targets {
+            // IPv4: forward the port to the box's LAN IPv4 — a PCP HOSTNAME mapping
+            // (SNI demux) for a domain, a plain pinhole for a bare `*` vhost.
+            for gw_id in &target.public_v4 {
+                let Some(info) = ip_info.get(gw_id) else {
+                    continue;
+                };
+                let Some(gw_ip_info) = &info.ip_info else {
+                    continue;
+                };
+                let gateways = candidate_gateways(info);
+                if gateways.is_empty() {
+                    continue;
+                }
+                for subnet in &gw_ip_info.subnets {
+                    let IpAddr::V4(local_ip) = subnet.addr() else {
+                        continue;
+                    };
+                    let entry = desired
+                        .entry((IpAddr::V4(local_ip), *external))
+                        .or_insert_with(|| (*external, gateways.clone(), Vec::new()));
+                    let name = maybe_host.clone();
+                    if !entry.2.contains(&name) {
+                        entry.2.push(name);
+                    }
+                }
+            }
+            // IPv6: the box's own GUA is the listener (no NAT), so open a firewall
+            // pinhole for GUA:port. No SNI demux over v6 (every host has its own
+            // GUA, nothing to share), so these are always hostname-less.
+            for gua in &target.public_v6 {
+                let Some(info) = ip_info.iter().map(|(_, i)| i).find(|info| {
+                    info.ip_info.as_ref().map_or(false, |i| {
+                        i.subnets.iter().any(|s| s.addr() == IpAddr::V6(*gua))
+                    })
+                }) else {
+                    continue;
+                };
+                let v6_gateways: Vec<(IpAddr, Option<u32>)> = candidate_gateways(info)
+                    .into_iter()
+                    .filter(|(g, _)| g.is_ipv6())
+                    .collect();
+                if v6_gateways.is_empty() {
+                    continue;
+                }
+                let entry = desired
+                    .entry((IpAddr::V6(*gua), *external))
+                    .or_insert_with(|| (*external, v6_gateways, Vec::new()));
+                if !entry.2.contains(&None) {
+                    entry.2.push(None);
+                }
+            }
+        }
+        // v6 HTTP->HTTPS redirect: for a GUA exposing 443, ask the gateway for an
+        // 80->443 redirect pinhole, unless 80 is already a real pinhole on that GUA.
+        // (No IPv4 equivalent — the upstream gateway serves the port-80 redirect.)
+        let redirects: Vec<(Ipv6Addr, Vec<(IpAddr, Option<u32>)>)> = desired
+            .iter()
+            .filter_map(|((ip, port), (_, gateways, _))| match ip {
+                IpAddr::V6(gua) if *port == 443 => Some((*gua, gateways.clone())),
+                _ => None,
+            })
+            .filter(|(gua, _)| !desired.contains_key(&(IpAddr::V6(*gua), 80)))
+            .collect();
+        for (gua, gateways) in redirects {
+            desired
+                .entry((IpAddr::V6(gua), 80))
+                .or_insert((443, gateways, vec![None]));
+        }
+        self.sync_port_maps(owner, desired);
+    }
+
+    fn sync_port_maps(
+        &self,
+        owner: HostMapOwner,
+        desired: BTreeMap<
+            (IpAddr, u16),
+            (u16, Vec<(IpAddr, Option<u32>)>, Vec<Option<InternedString>>),
+        >,
+    ) {
+        let want: BTreeSet<(IpAddr, u16, Option<InternedString>)> = desired
             .iter()
             .flat_map(|((ip, port), (_, _, hostnames))| {
                 hostnames.iter().map(move |h| (*ip, *port, h.clone()))
             })
             .collect();
         let had = self
-            .hostname_mappings
+            .port_mappings
             .peek(|owners| owners.get(&owner).cloned().unwrap_or_default());
         for (ip, port, hostname) in had.difference(&want) {
-            self.port_map
-                .remove_hostname(IpAddr::V4(*ip), *port, hostname.clone());
+            match hostname {
+                Some(h) => self.port_map.remove_hostname(*ip, *port, h.to_string()),
+                None => self.port_map.remove(*ip, *port),
+            }
         }
         for ((ip, port), (internal, gateways, hostnames)) in &desired {
             for hostname in hostnames {
-                self.port_map.ensure_hostname(
-                    IpAddr::V4(*ip),
-                    *port,
-                    *internal,
-                    gateways.clone(),
-                    hostname.clone(),
-                );
+                match hostname {
+                    Some(h) => self.port_map.ensure_hostname(
+                        *ip,
+                        *port,
+                        *internal,
+                        gateways.clone(),
+                        h.to_string(),
+                    ),
+                    None => self
+                        .port_map
+                        .ensure(*ip, *port, *internal, gateways.clone()),
+                }
             }
         }
-        self.hostname_mappings.mutate(|owners| {
+        self.port_mappings.mutate(|owners| {
             if want.is_empty() {
                 owners.remove(&owner);
             } else {
@@ -788,7 +897,16 @@ impl<A: Accept + 'static> Preprocessed<A> {
 
 #[derive(Clone)]
 pub struct ProxyTarget {
-    pub public: BTreeSet<GatewayId>,
+    /// Gateways on which this address is WAN-public over bare IPv4 (drives the
+    /// IPv4 accept filter and the derived IPv4 upstream forward). Split from
+    /// `public_v6` because a service can expose its GUA to the WAN while keeping
+    /// its bare IPv4 LAN-only (and vice versa), so accept must gate per family.
+    pub public_v4: BTreeSet<GatewayId>,
+    /// The box's own GUAs that are WAN-public (drives the IPv6 accept filter; the
+    /// GUA has no NAT, so no IPv4-style forward). Per-IP, not per-gateway, because
+    /// one gateway can carry several GUAs (SLAAC / multiple prefixes) that are
+    /// independently Local vs Public.
+    pub public_v6: BTreeSet<Ipv6Addr>,
     pub private: BTreeSet<IpAddr>,
     pub acme: Option<AcmeProvider>,
     pub addr: SocketAddr,
@@ -801,7 +919,8 @@ pub struct ProxyTarget {
 }
 impl PartialEq for ProxyTarget {
     fn eq(&self, other: &Self) -> bool {
-        self.public == other.public
+        self.public_v4 == other.public_v4
+            && self.public_v6 == other.public_v6
             && self.private == other.private
             && self.acme == other.acme
             && self.addr == other.addr
@@ -816,7 +935,8 @@ impl Eq for ProxyTarget {}
 impl fmt::Debug for ProxyTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ProxyTarget")
-            .field("public", &self.public)
+            .field("public_v4", &self.public_v4)
+            .field("public_v6", &self.public_v6)
             .field("private", &self.private)
             .field("acme", &self.acme)
             .field("addr", &self.addr)
@@ -825,6 +945,31 @@ impl fmt::Debug for ProxyTarget {
             .field("connect_ssl", &self.connect_ssl.as_ref().map(|_| ()))
             .field("passthrough", &self.passthrough)
             .finish()
+    }
+}
+
+impl ProxyTarget {
+    /// Whether to accept a connection that arrived on local address `dst` from
+    /// `src`, via gateway `gw_id` whose on-link subnets are `subnets`. WAN accept
+    /// is gated per family by `dst`'s family — a gateway public only on its GUA
+    /// accepts IPv6 WAN but rejects IPv4 WAN, and vice versa. LAN accept (via
+    /// `private`, matched by the exact local `dst`) is inherently family-scoped.
+    fn accepts(
+        &self,
+        gw_id: &GatewayId,
+        subnets: &OrdSet<IpNet>,
+        src: IpAddr,
+        dst: IpAddr,
+    ) -> bool {
+        // IPv4 WAN is keyed by the arrival gateway (NAT hides the WAN IP; the box
+        // sees its LAN IPv4); IPv6 WAN is keyed by the exact GUA the connection
+        // arrived on, since one gateway can carry several independently-public GUAs.
+        let wan = match dst {
+            IpAddr::V4(_) => self.public_v4.contains(gw_id),
+            IpAddr::V6(v6) => self.public_v6.contains(&v6),
+        };
+        wan || (self.private.contains(&dst)
+            && (subnets.iter().any(|s| s.contains(&src)) || is_private_ip(src)))
     }
 }
 
@@ -851,15 +996,19 @@ where
         let src = tcp.peer_addr.ip();
         let dst = tcp.local_addr.ip();
 
-        self.public.contains(&gw.id)
-            || (self.private.contains(&dst)
-                && (ip_info.subnets.iter().any(|s| s.contains(&src)) || is_private_ip(src)))
+        self.accepts(&gw.id, &ip_info.subnets, src, dst)
     }
     fn acme(&self) -> Option<&AcmeProvider> {
         self.acme.as_ref()
     }
     fn bind_requirements(&self) -> (BTreeSet<GatewayId>, BTreeSet<IpAddr>) {
-        (self.public.clone(), self.private.clone())
+        // Bind every IP of an IPv4-public gateway (the box's LAN IPv4 is the DNAT
+        // target; `filter` gates WAN acceptance per gateway) plus each public GUA
+        // and private IP explicitly. `filter` still gates acceptance per address,
+        // so binding a not-actually-public address is harmless.
+        let mut bind_ips = self.private.clone();
+        bind_ips.extend(self.public_v6.iter().map(|v6| IpAddr::V6(*v6)));
+        (self.public_v4.clone(), bind_ips)
     }
     fn is_passthrough(&self) -> bool {
         self.passthrough
@@ -1670,6 +1819,97 @@ async fn copy_bidirectional_hangs_without_keepalive_when_peer_idle() {
     );
 
     proxy.abort();
+}
+
+#[cfg(test)]
+mod accept_filter_tests {
+    use super::*;
+
+    fn gw(name: &str) -> GatewayId {
+        GatewayId::from(InternedString::intern(name))
+    }
+
+    fn target(public_v4: &[&str], public_v6: &[&str], private: &[&str]) -> ProxyTarget {
+        ProxyTarget {
+            public_v4: public_v4.iter().map(|s| gw(s)).collect(),
+            public_v6: public_v6.iter().map(|s| s.parse().unwrap()).collect(),
+            private: private.iter().map(|s| s.parse().unwrap()).collect(),
+            acme: None,
+            addr: "10.0.0.1:443".parse().unwrap(),
+            add_x_forwarded_headers: false,
+            auth: None,
+            connect_ssl: Err(AlpnInfo::Reflect),
+            passthrough: false,
+        }
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    // WAN accept is gated by the family of the address the connection arrived on:
+    // IPv4 by the gateway, IPv6 by the exact GUA — a gateway public only on its GUA
+    // must accept IPv6 WAN but reject IPv4 WAN, and a non-public GUA on an
+    // otherwise-public gateway is rejected.
+    #[test]
+    fn wan_accept_is_family_scoped() {
+        let g = gw("wg0");
+        let no_subnets = OrdSet::new();
+        let src = ip("198.51.100.9");
+        let v4 = ip("203.0.113.5");
+        let gua = ip("2001:db8::1");
+        let other_gua = ip("2001:db8::2");
+
+        // GUA-only public (only 2001:db8::1).
+        let t = target(&[], &["2001:db8::1"], &[]);
+        assert!(
+            t.accepts(&g, &no_subnets, src, gua),
+            "IPv6 WAN to the public GUA"
+        );
+        assert!(
+            !t.accepts(&g, &no_subnets, src, other_gua),
+            "a different GUA on the same gateway is not public"
+        );
+        assert!(!t.accepts(&g, &no_subnets, src, v4), "IPv4 WAN rejected");
+
+        // Bare-IPv4-only public.
+        let t = target(&["wg0"], &[], &[]);
+        assert!(t.accepts(&g, &no_subnets, src, v4), "IPv4 WAN accepted");
+        assert!(!t.accepts(&g, &no_subnets, src, gua), "IPv6 WAN rejected");
+
+        // Dual-stack public accepts both.
+        let t = target(&["wg0"], &["2001:db8::1"], &[]);
+        assert!(t.accepts(&g, &no_subnets, src, v4));
+        assert!(t.accepts(&g, &no_subnets, src, gua));
+
+        // A different gateway is never WAN-accepted on IPv4.
+        assert!(!t.accepts(&gw("other"), &no_subnets, src, v4));
+    }
+
+    // LAN accept via `private` is matched by the exact local `dst` (so it is
+    // already family-scoped) and unchanged by the fix: a private/on-link source to
+    // a `private` local address is accepted, a WAN source is not.
+    #[test]
+    fn lan_accept_via_private_unchanged() {
+        let g = gw("eth0");
+        let no_subnets = OrdSet::new();
+        let lan_dst = "192.168.1.2";
+        let t = target(&[], &[], &[lan_dst]);
+
+        // RFC1918 source to the private local address -> accept (no subnets needed).
+        assert!(t.accepts(&g, &no_subnets, ip("192.168.1.50"), ip(lan_dst)));
+        // A WAN (public, off-link) source to the same local address -> reject.
+        assert!(!t.accepts(&g, &no_subnets, ip("203.0.113.9"), ip(lan_dst)));
+        // A local address not in `private` -> reject.
+        assert!(!t.accepts(&g, &no_subnets, ip("192.168.1.50"), ip("192.168.1.9")));
+
+        // On-link (but not RFC1918) source is accepted when it falls in a subnet.
+        let subnets: OrdSet<IpNet> =
+            std::iter::once("203.0.113.0/24".parse::<IpNet>().unwrap()).collect();
+        let onlink = target(&[], &[], &["203.0.113.2"]);
+        assert!(onlink.accepts(&g, &subnets, ip("203.0.113.50"), ip("203.0.113.2")));
+        assert!(!onlink.accepts(&g, &no_subnets, ip("203.0.113.50"), ip("203.0.113.2")));
+    }
 }
 
 #[cfg(test)]

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -461,9 +461,18 @@ impl VHostController {
         targets: &BTreeMap<(Option<InternedString>, u16), ProxyTarget>,
     ) {
         let ip_info = self.interfaces.watcher.ip_info();
+        // `(box IP, ext port) -> (internal port, ordered PCP gateway candidates,
+        // hostnames)`. Gateways stay an ordered Vec (the port-mapper tries them in
+        // preference order and takes the first that binds); hostnames are a set —
+        // `None` is the bare-IP/GUA pinhole, `Some(h)` an SNI route, and neither
+        // repeats nor cares about order.
         let mut desired: BTreeMap<
             (IpAddr, u16),
-            (u16, Vec<(IpAddr, Option<u32>)>, Vec<Option<InternedString>>),
+            (
+                u16,
+                Vec<(IpAddr, Option<u32>)>,
+                BTreeSet<Option<InternedString>>,
+            ),
         > = BTreeMap::new();
         for ((maybe_host, external), target) in targets {
             // IPv4: forward the port to the box's LAN IPv4 — a PCP HOSTNAME mapping
@@ -483,13 +492,11 @@ impl VHostController {
                     let IpAddr::V4(local_ip) = subnet.addr() else {
                         continue;
                     };
-                    let entry = desired
+                    desired
                         .entry((IpAddr::V4(local_ip), *external))
-                        .or_insert_with(|| (*external, gateways.clone(), Vec::new()));
-                    let name = maybe_host.clone();
-                    if !entry.2.contains(&name) {
-                        entry.2.push(name);
-                    }
+                        .or_insert_with(|| (*external, gateways.clone(), BTreeSet::new()))
+                        .2
+                        .insert(maybe_host.clone());
                 }
             }
             // IPv6: the box's own GUA is the listener (no NAT), so open a firewall
@@ -510,12 +517,11 @@ impl VHostController {
                 if v6_gateways.is_empty() {
                     continue;
                 }
-                let entry = desired
+                desired
                     .entry((IpAddr::V6(*gua), *external))
-                    .or_insert_with(|| (*external, v6_gateways, Vec::new()));
-                if !entry.2.contains(&None) {
-                    entry.2.push(None);
-                }
+                    .or_insert_with(|| (*external, v6_gateways, BTreeSet::new()))
+                    .2
+                    .insert(None);
             }
         }
         // v6 HTTP->HTTPS redirect: for a GUA exposing 443, ask the gateway for an
@@ -532,7 +538,7 @@ impl VHostController {
         for (gua, gateways) in redirects {
             desired
                 .entry((IpAddr::V6(gua), 80))
-                .or_insert((443, gateways, vec![None]));
+                .or_insert((443, gateways, BTreeSet::from([None])));
         }
         self.sync_port_maps(owner, desired);
     }
@@ -542,7 +548,11 @@ impl VHostController {
         owner: HostMapOwner,
         desired: BTreeMap<
             (IpAddr, u16),
-            (u16, Vec<(IpAddr, Option<u32>)>, Vec<Option<InternedString>>),
+            (
+                u16,
+                Vec<(IpAddr, Option<u32>)>,
+                BTreeSet<Option<InternedString>>,
+            ),
         >,
     ) {
         let want: BTreeSet<(IpAddr, u16, Option<InternedString>)> = desired

--- a/shared-libs/crates/start-core/src/tunnel/api.rs
+++ b/shared-libs/crates/start-core/src/tunnel/api.rs
@@ -632,7 +632,7 @@ pub async fn remove_subnet(
     _: Empty,
     SubnetParams { subnet }: SubnetParams,
 ) -> Result<(), Error> {
-    let (server, (keep, dropped_sni)) = ctx
+    let (server, gc) = ctx
         .db
         .mutate(|db| {
             db.as_wg_mut().as_subnets_mut().remove(&subnet)?;
@@ -641,7 +641,8 @@ pub async fn remove_subnet(
         .await
         .result?;
     ctx.sync_network(&server).await?;
-    ctx.gc_forwards(&keep, &dropped_sni).await?;
+    ctx.gc_forwards(&gc.keep_sources, &gc.dropped_sni, &gc.dropped_fallbacks)
+        .await?;
 
     for iface in ctx.net_iface.peek(|i| {
         i.iter()
@@ -1091,7 +1092,7 @@ pub async fn remove_device(
     // their leases) before it's gone. `gc_forwards` below reclaims v4/SNI for any
     // departed client, but not v6 pinholes, so clear them here.
     crate::tunnel::forward::clear_for_peer(&ctx, ip, false).await?;
-    let (server, (keep, dropped_sni)) = ctx
+    let (server, gc) = ctx
         .db
         .mutate(|db| {
             db.as_wg_mut()
@@ -1106,7 +1107,8 @@ pub async fn remove_device(
         .await
         .result?;
     ctx.sync_network(&server).await?;
-    ctx.gc_forwards(&keep, &dropped_sni).await
+    ctx.gc_forwards(&gc.keep_sources, &gc.dropped_sni, &gc.dropped_fallbacks)
+        .await
 }
 
 #[derive(Deserialize, Serialize, Parser, TS)]
@@ -1398,7 +1400,7 @@ pub async fn remove_forward(
         .get(&source)
         .cloned();
     match entry {
-        Some(PortForward::Sni { routes }) => {
+        Some(PortForward::Sni { routes, fallback }) => {
             let to_remove: Vec<(String, SocketAddrV4)> = match &hostname {
                 Some(h) => routes
                     .get(h)
@@ -1408,6 +1410,12 @@ pub async fn remove_forward(
             };
             for (h, route_target) in to_remove {
                 ctx.remove_sni_forward(source, route_target, &[h]).await;
+            }
+            // Removing the whole forward (no hostname) also drops its fallback.
+            if hostname.is_none() {
+                if let Some(f) = fallback {
+                    ctx.remove_sni_fallback(source, f.target).await;
+                }
             }
             Ok(())
         }
@@ -1461,7 +1469,7 @@ pub async fn update_forward_label(
                         *l = label;
                         Ok(())
                     }
-                    PortForward::Sni { routes } => {
+                    PortForward::Sni { routes, .. } => {
                         let hostname = hostname.ok_or_else(|| {
                             Error::new(
                                 eyre!("--hostname is required to label an SNI route"),
@@ -1532,7 +1540,7 @@ pub async fn set_forward_enabled(
                         *e = enabled;
                         Ok(ForwardToggle::Dnat(*target))
                     }
-                    PortForward::Sni { routes } => {
+                    PortForward::Sni { routes, .. } => {
                         let hostname = hostname.clone().ok_or_else(|| {
                             Error::new(
                                 eyre!("--hostname is required to toggle an SNI route"),

--- a/shared-libs/crates/start-core/src/tunnel/context.rs
+++ b/shared-libs/crates/start-core/src/tunnel/context.rs
@@ -332,7 +332,7 @@ impl TunnelContext {
                             .await?,
                     );
                 }
-                PortForward::Sni { routes } => {
+                PortForward::Sni { routes, fallback } => {
                     for (hostname, route) in routes {
                         if !route.enabled {
                             continue;
@@ -347,6 +347,12 @@ impl TunnelContext {
                             tracing::warn!(
                                 "failed to restore SNI route {hostname} on {from}: code {code}"
                             );
+                        }
+                    }
+                    if let Some(f) = fallback.filter(|f| f.enabled) {
+                        if let Err(code) = sni.register_fallback(*from.ip(), from.port(), f.target)
+                        {
+                            tracing::warn!("failed to restore SNI fallback on {from}: code {code}");
                         }
                     }
                 }
@@ -398,6 +404,7 @@ impl TunnelContext {
         &self,
         keep: &BTreeSet<SocketAddrV4>,
         dropped_sni: &[(SocketAddrV4, String, SocketAddrV4)],
+        dropped_fallbacks: &[(SocketAddrV4, SocketAddrV4)],
     ) -> Result<(), Error> {
         for (source, hostname, target) in dropped_sni {
             self.sni.unregister(
@@ -407,13 +414,19 @@ impl TunnelContext {
                 *target,
             );
         }
+        for (source, target) in dropped_fallbacks {
+            self.sni
+                .unregister_fallback(*source.ip(), source.port(), *target);
+        }
         self.active_forwards
             .mutate(|pf| pf.retain(|k, _| keep.contains(k)));
         // Drop leases for forwards whose target is no longer a known client.
         use crate::tunnel::forward::lease::LeaseKey;
         self.leases.mutate(|l| {
             l.retain(|k, _| match k {
-                LeaseKey::Dnat(s) | LeaseKey::Sni { source: s, .. } => keep.contains(s),
+                LeaseKey::Dnat(s) | LeaseKey::Sni { source: s, .. } | LeaseKey::SniFallback(s) => {
+                    keep.contains(s)
+                }
                 LeaseKey::Pinhole(_) => true,
             })
         });
@@ -599,7 +612,7 @@ impl TunnelContext {
                         },
                     );
                 }
-                PortForward::Sni { routes } => {
+                PortForward::Sni { routes, fallback } => {
                     for (host, route) in routes {
                         let ip =
                             crate::tunnel::forward::igd::external_ipv4(self, *route.target.ip())
@@ -608,13 +621,33 @@ impl TunnelContext {
                         let key = SocketAddrV4::new(ip, src.port());
                         match want.entry(key).or_insert_with(|| PortForward::Sni {
                             routes: BTreeMap::new(),
+                            fallback: None,
                         }) {
-                            PortForward::Sni { routes } => {
+                            PortForward::Sni { routes, .. } => {
                                 routes.insert(host.clone(), route.clone());
                             }
                             PortForward::Dnat { .. } => {
                                 tracing::warn!(
                                     "dropping SNI route {host} on {key}: external IP now collides with a DNAT forward"
+                                );
+                            }
+                        }
+                    }
+                    if let Some(f) = fallback {
+                        let ip = crate::tunnel::forward::igd::external_ipv4(self, *f.target.ip())
+                            .await
+                            .unwrap_or(*src.ip());
+                        let key = SocketAddrV4::new(ip, src.port());
+                        match want.entry(key).or_insert_with(|| PortForward::Sni {
+                            routes: BTreeMap::new(),
+                            fallback: None,
+                        }) {
+                            PortForward::Sni { fallback: fb, .. } => {
+                                *fb = Some(f.clone());
+                            }
+                            PortForward::Dnat { .. } => {
+                                tracing::warn!(
+                                    "dropping SNI fallback on {key}: external IP now collides with a DNAT forward"
                                 );
                             }
                         }
@@ -626,7 +659,7 @@ impl TunnelContext {
         let sni_routes = |map: &BTreeMap<SocketAddrV4, PortForward>| {
             let mut out: BTreeMap<(SocketAddrV4, String), SocketAddrV4> = BTreeMap::new();
             for (src, entry) in map {
-                if let PortForward::Sni { routes } = entry {
+                if let PortForward::Sni { routes, .. } = entry {
                     for (host, route) in routes {
                         out.insert((*src, host.clone()), route.target);
                     }
@@ -652,6 +685,33 @@ impl TunnelContext {
                     None,
                 ) {
                     tracing::warn!("failed to register SNI route {host} on {src}: code {code}");
+                }
+            }
+        }
+
+        let sni_fallbacks = |map: &BTreeMap<SocketAddrV4, PortForward>| {
+            let mut out: BTreeMap<SocketAddrV4, SocketAddrV4> = BTreeMap::new();
+            for (src, entry) in map {
+                if let PortForward::Sni {
+                    fallback: Some(f), ..
+                } = entry
+                {
+                    out.insert(*src, f.target);
+                }
+            }
+            out
+        };
+        let old_fb = sni_fallbacks(&old);
+        let new_fb = sni_fallbacks(&want);
+        for (src, target) in &old_fb {
+            if new_fb.get(src) != Some(target) {
+                self.sni.unregister_fallback(*src.ip(), src.port(), *target);
+            }
+        }
+        for (src, target) in &new_fb {
+            if old_fb.get(src) != Some(target) {
+                if let Err(code) = self.sni.register_fallback(*src.ip(), src.port(), *target) {
+                    tracing::warn!("failed to register SNI fallback on {src}: code {code}");
                 }
             }
         }

--- a/shared-libs/crates/start-core/src/tunnel/db.rs
+++ b/shared-libs/crates/start-core/src/tunnel/db.rs
@@ -80,19 +80,12 @@ impl TunnelDatabase {
 
 impl Model<TunnelDatabase> {
     /// Prune forwards whose target is no longer a known client. Returns the
-    /// surviving sources and the dropped SNI routes, which the caller must
-    /// unregister from the in-memory demux dataplane.
-    pub fn gc_forwards(
-        &mut self,
-    ) -> Result<
-        (
-            BTreeSet<SocketAddrV4>,
-            Vec<(SocketAddrV4, String, SocketAddrV4)>,
-        ),
-        Error,
-    > {
+    /// surviving sources, the dropped SNI routes, and the dropped SNI fallbacks,
+    /// which the caller must unregister from the in-memory demux dataplane.
+    pub fn gc_forwards(&mut self) -> Result<GcForwards, Error> {
         let mut keep_sources = BTreeSet::new();
         let mut dropped_sni: Vec<(SocketAddrV4, String, SocketAddrV4)> = Vec::new();
+        let mut dropped_fallbacks: Vec<(SocketAddrV4, SocketAddrV4)> = Vec::new();
         let mut keep_targets = BTreeSet::new();
         for (_, cfg) in self.as_wg().as_subnets().as_entries()? {
             keep_targets.extend(cfg.as_clients().keys()?);
@@ -101,14 +94,20 @@ impl Model<TunnelDatabase> {
             Ok(pf.0.retain(|k, v| {
                 let keep = match v {
                     PortForward::Dnat { target, .. } => keep_targets.contains(target.ip()),
-                    PortForward::Sni { routes } => {
+                    PortForward::Sni { routes, fallback } => {
                         for (h, r) in routes.iter() {
                             if !keep_targets.contains(r.target.ip()) {
                                 dropped_sni.push((*k, h.clone(), r.target));
                             }
                         }
                         routes.retain(|_, r| keep_targets.contains(r.target.ip()));
-                        !routes.is_empty()
+                        if let Some(f) = fallback {
+                            if !keep_targets.contains(f.target.ip()) {
+                                dropped_fallbacks.push((*k, f.target));
+                                *fallback = None;
+                            }
+                        }
+                        !routes.is_empty() || fallback.is_some()
                     }
                 };
                 if keep {
@@ -117,8 +116,21 @@ impl Model<TunnelDatabase> {
                 keep
             }))
         })?;
-        Ok((keep_sources, dropped_sni))
+        Ok(GcForwards {
+            keep_sources,
+            dropped_sni,
+            dropped_fallbacks,
+        })
     }
+}
+
+/// The result of [`Model::<TunnelDatabase>::gc_forwards`]: surviving sources plus
+/// the dataplane demux entries (SNI routes and hostname-less fallbacks) whose
+/// target is no longer a known client and so must be unregistered.
+pub struct GcForwards {
+    pub keep_sources: BTreeSet<SocketAddrV4>,
+    pub dropped_sni: Vec<(SocketAddrV4, String, SocketAddrV4)>,
+    pub dropped_fallbacks: Vec<(SocketAddrV4, SocketAddrV4)>,
 }
 
 #[test]
@@ -179,6 +191,13 @@ pub enum PortForward {
     Sni {
         /// hostname (lowercase; may be `*.suffix`) -> route.
         routes: BTreeMap<String, SniRoute>,
+        /// Hostname-less catch-all for this shared external port. Traffic whose
+        /// SNI matches no `routes` entry — or that carries no SNI (bare-IP TLS,
+        /// non-TLS) — is spliced here instead of being dropped. `None` closes the
+        /// port to unmatched traffic. This lets a bare public IP and named
+        /// domains share one external port, the bare IP acting as the fallback.
+        #[serde(default)]
+        fallback: Option<SniRoute>,
     },
 }
 
@@ -627,14 +646,17 @@ fn sni_and_dnat_persistence_round_trip() {
     };
     let mut routes = BTreeMap::new();
     routes.insert("id.example.com".to_string(), route);
-    let sni = PortForward::Sni { routes };
+    let sni = PortForward::Sni {
+        routes,
+        fallback: None,
+    };
 
     let sni_json = serde_json::to_value(&sni).unwrap();
     eprintln!("SNI serialized: {sni_json}");
     assert_eq!(sni_json["kind"], serde_json::json!("sni"));
     let sni_back: PortForward = serde_json::from_value(sni_json).unwrap();
     match &sni_back {
-        PortForward::Sni { routes } => {
+        PortForward::Sni { routes, .. } => {
             let r = routes.get("id.example.com").expect("route present");
             assert_eq!(r.target, "10.59.0.2:443".parse().unwrap());
             assert_eq!(r.label, None);
@@ -703,11 +725,49 @@ fn sni_and_dnat_persistence_round_trip() {
     assert!(matches!(dnat_e, PortForward::Dnat { .. }));
     let sni_e = map.0.get(&"5.6.7.8:443".parse().unwrap()).unwrap();
     match sni_e {
-        PortForward::Sni { routes } => {
+        PortForward::Sni { routes, .. } => {
             let r = routes.get("id.example.com").unwrap();
             assert!(r.enabled);
         }
         other => panic!("expected Sni, got {other:?}"),
+    }
+}
+
+#[test]
+fn sni_fallback_serde_backward_compat() {
+    // Legacy SNI JSON (written before the `fallback` field existed) must
+    // deserialize with `fallback: None` — this is why no migration is needed.
+    let legacy = serde_json::json!({
+        "kind": "sni",
+        "routes": {
+            "id.example.com": {
+                "target": "10.59.0.2:443", "label": null, "enabled": true, "auto": true
+            }
+        }
+    });
+    let pf: PortForward = serde_json::from_value(legacy).unwrap();
+    match pf {
+        PortForward::Sni { fallback, .. } => assert!(fallback.is_none()),
+        other => panic!("expected Sni, got {other:?}"),
+    }
+
+    // A fallback round-trips through serde.
+    let with_fb = PortForward::Sni {
+        routes: BTreeMap::new(),
+        fallback: Some(SniRoute {
+            target: "10.59.0.3:443".parse().unwrap(),
+            label: Some("PCP".to_string()),
+            enabled: true,
+            auto: true,
+        }),
+    };
+    let back: PortForward =
+        serde_json::from_value(serde_json::to_value(&with_fb).unwrap()).unwrap();
+    match back {
+        PortForward::Sni {
+            fallback: Some(f), ..
+        } => assert_eq!(f.target, "10.59.0.3:443".parse().unwrap()),
+        other => panic!("expected Sni with fallback, got {other:?}"),
     }
 }
 
@@ -730,6 +790,7 @@ fn port_forward_overlap_detection() {
         src("1.2.3.4:443"),
         PortForward::Sni {
             routes: BTreeMap::new(),
+            fallback: None,
         },
     );
     let forwards = PortForwards(map);
@@ -774,6 +835,7 @@ fn port_forward_occupied_gates_http_redirect() {
         src("5.6.7.8:443"),
         PortForward::Sni {
             routes: BTreeMap::new(),
+            fallback: None,
         },
     );
     // A range on 9.9.9.9 spanning 78..=82, which swallows port 80.

--- a/shared-libs/crates/start-core/src/tunnel/forward/igd.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/igd.rs
@@ -31,6 +31,7 @@ use crate::net::port_map::server::igd::{
 use crate::prelude::*;
 use crate::tunnel::context::TunnelContext;
 use crate::tunnel::db::PortForward;
+use crate::tunnel::forward::lease::{self, LeaseKey};
 use crate::tunnel::wg::WIREGUARD_INTERFACE_NAME;
 
 /// Run the IGD server (SSDP responder + HTTP control server) for the life of
@@ -256,6 +257,7 @@ pub(super) async fn apply_peer_forward_range(
     target: SocketAddrV4,
     count: u16,
     protocol_label: &str,
+    lifetime: Option<u32>,
 ) -> Result<(), u16> {
     // Port 80 is reserved for the tunnel's HTTP→HTTPS redirect; never
     // automatically create a forward that would take it (PCP/UPnP alike).
@@ -271,9 +273,18 @@ pub(super) async fn apply_peer_forward_range(
         }) if t != target || c != count => {
             return Err(718); // ConflictInMappingEntry
         }
-        // The external port is held by an SNI-demuxed forward.
+        // The external port is SNI-demuxed. A single hostname-less MAP becomes the
+        // port's fallback (a bare public IP sharing the port with named domains);
+        // `persist_fallback_forward` stamps its own SniFallback lease. A range
+        // can't be a single-port fallback, so it still conflicts.
         Some(PortForward::Sni { .. }) => {
-            return Err(718); // ConflictInMappingEntry
+            if count != 1 {
+                return Err(718); // ConflictInMappingEntry
+            }
+            return ctx
+                .persist_fallback_forward(source, target, lifetime, true, None)
+                .await
+                .map_err(|_| 718u16);
         }
         Some(PortForward::Dnat { .. }) => {
             // Idempotent re-assert from the client's periodic refresh: ensure the
@@ -289,6 +300,9 @@ pub(super) async fn apply_peer_forward_range(
                 ctx.active_forwards.mutate(|m| {
                     m.insert(source, rc);
                 });
+            }
+            if let Some(lt) = lifetime {
+                lease::stamp(ctx, LeaseKey::Dnat(source), lt);
             }
             return Ok(());
         }
@@ -350,6 +364,9 @@ pub(super) async fn apply_peer_forward_range(
     ctx.active_forwards.mutate(|m| {
         m.insert(source, rc);
     });
+    if let Some(lt) = lifetime {
+        lease::stamp(ctx, LeaseKey::Dnat(source), lt);
+    }
     Ok(())
 }
 

--- a/shared-libs/crates/start-core/src/tunnel/forward/lease.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/lease.rs
@@ -34,6 +34,9 @@ pub enum LeaseKey {
         source: SocketAddrV4,
         hostname: String,
     },
+    /// The hostname-less fallback on an SNI-demuxed port, keyed by its single
+    /// external address (there is at most one fallback per port).
+    SniFallback(SocketAddrV4),
     Pinhole(SocketAddrV6),
 }
 
@@ -67,11 +70,14 @@ pub async fn seed_from_db(ctx: &TunnelContext) -> Result<(), Error> {
     for (source, entry) in peek.as_port_forwards().de()?.0 {
         match entry {
             PortForward::Dnat { auto: true, .. } => seed.push(LeaseKey::Dnat(source)),
-            PortForward::Sni { routes } => {
+            PortForward::Sni { routes, fallback } => {
                 for (hostname, route) in routes {
                     if route.auto {
                         seed.push(LeaseKey::Sni { source, hostname });
                     }
+                }
+                if fallback.is_some_and(|f| f.auto) {
+                    seed.push(LeaseKey::SniFallback(source));
                 }
             }
             PortForward::Dnat { .. } => {}
@@ -134,6 +140,7 @@ async fn reap_expired(ctx: &TunnelContext) -> Option<Instant> {
         match &key {
             LeaseKey::Dnat(source) => reap_dnat(ctx, *source).await,
             LeaseKey::Sni { source, hostname } => reap_sni(ctx, *source, hostname).await,
+            LeaseKey::SniFallback(source) => reap_sni_fallback(ctx, *source).await,
             LeaseKey::Pinhole(k) => reap_pinhole(ctx, *k).await,
         }
         // Drop the lease unless a renewal extended it while we reaped.
@@ -184,7 +191,7 @@ async fn reap_sni(ctx: &TunnelContext, source: SocketAddrV4, hostname: &str) {
         .de()
         .ok()
         .and_then(|pf| match pf.0.get(&source) {
-            Some(PortForward::Sni { routes }) => {
+            Some(PortForward::Sni { routes, .. }) => {
                 routes.get(hostname).filter(|r| r.auto).map(|r| r.target)
             }
             _ => None,
@@ -195,6 +202,27 @@ async fn reap_sni(ctx: &TunnelContext, source: SocketAddrV4, hostname: &str) {
     ctx.remove_sni_forward(source, target, &[hostname.to_string()])
         .await;
     tracing::info!("PCP lease lapsed: removed auto SNI route {hostname} on {source}");
+}
+
+async fn reap_sni_fallback(ctx: &TunnelContext, source: SocketAddrV4) {
+    let target = ctx
+        .db
+        .peek()
+        .await
+        .as_port_forwards()
+        .de()
+        .ok()
+        .and_then(|pf| match pf.0.get(&source) {
+            Some(PortForward::Sni { fallback, .. }) => {
+                fallback.as_ref().filter(|f| f.auto).map(|f| f.target)
+            }
+            _ => None,
+        });
+    let Some(target) = target else {
+        return;
+    };
+    ctx.remove_sni_fallback(source, target).await;
+    tracing::info!("PCP lease lapsed: removed auto SNI fallback on {source}");
 }
 
 async fn reap_pinhole(ctx: &TunnelContext, key: SocketAddrV6) {

--- a/shared-libs/crates/start-core/src/tunnel/forward/mod.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/mod.rs
@@ -30,12 +30,16 @@ pub async fn clear_for_peer(
 ) -> Result<(), Error> {
     // v4 DNAT + SNI live in port_forwards, matched by their target (the device).
     let forwards = ctx.db.peek().await.as_port_forwards().de()?;
-    let (dnat_sources, sni_routes) = select_peer_forwards(&forwards.0, peer, auto_only);
+    let (dnat_sources, sni_routes, sni_fallbacks) =
+        select_peer_forwards(&forwards.0, peer, auto_only);
     for source in dnat_sources {
         ctx.remove_forward_by_source(source, peer).await;
     }
     for (source, target, host) in sni_routes {
         ctx.remove_sni_forward(source, target, &[host]).await;
+    }
+    for (source, target) in sni_fallbacks {
+        ctx.remove_sni_fallback(source, target).await;
     }
 
     // v6 pinholes are keyed by the device's own GUA, derivable from each subnet's
@@ -72,15 +76,21 @@ pub async fn clear_for_peer(
     Ok(())
 }
 
-/// The DNAT sources and SNI routes (`source`, `target`, `hostname`) held by
-/// `peer` — everything, or just the automatic entries when `auto_only`.
+/// The DNAT sources, SNI routes (`source`, `target`, `hostname`), and SNI
+/// fallbacks (`source`, `target`) held by `peer` — everything, or just the
+/// automatic entries when `auto_only`.
 fn select_peer_forwards(
     forwards: &std::collections::BTreeMap<SocketAddrV4, PortForward>,
     peer: Ipv4Addr,
     auto_only: bool,
-) -> (Vec<SocketAddrV4>, Vec<(SocketAddrV4, SocketAddrV4, String)>) {
+) -> (
+    Vec<SocketAddrV4>,
+    Vec<(SocketAddrV4, SocketAddrV4, String)>,
+    Vec<(SocketAddrV4, SocketAddrV4)>,
+) {
     let mut dnat_sources = Vec::new();
     let mut sni_routes = Vec::new();
+    let mut sni_fallbacks = Vec::new();
     for (source, entry) in forwards {
         match entry {
             PortForward::Dnat { target, auto, .. }
@@ -88,17 +98,22 @@ fn select_peer_forwards(
             {
                 dnat_sources.push(*source);
             }
-            PortForward::Sni { routes } => {
+            PortForward::Sni { routes, fallback } => {
                 for (host, route) in routes {
                     if route.target.ip() == &peer && (!auto_only || route.auto) {
                         sni_routes.push((*source, route.target, host.clone()));
+                    }
+                }
+                if let Some(f) = fallback {
+                    if f.target.ip() == &peer && (!auto_only || f.auto) {
+                        sni_fallbacks.push((*source, f.target));
                     }
                 }
             }
             _ => {}
         }
     }
-    (dnat_sources, sni_routes)
+    (dnat_sources, sni_routes, sni_fallbacks)
 }
 
 #[cfg(test)]
@@ -153,19 +168,40 @@ mod tests {
                 auto: false,
             },
         );
-        fwds.insert("5.6.7.8:443".parse().unwrap(), PortForward::Sni { routes });
+        fwds.insert(
+            "5.6.7.8:443".parse().unwrap(),
+            PortForward::Sni {
+                routes,
+                fallback: Some(SniRoute {
+                    target: "10.59.0.2:443".parse().unwrap(),
+                    label: None,
+                    enabled: true,
+                    auto: true,
+                }),
+            },
+        );
 
-        let (auto_dnat, auto_sni) = select_peer_forwards(&fwds, peer, true);
+        let (auto_dnat, auto_sni, auto_fb) = select_peer_forwards(&fwds, peer, true);
         assert_eq!(auto_dnat, vec!["1.2.3.4:443".parse().unwrap()], "auto only");
         assert_eq!(auto_sni.len(), 1);
         assert_eq!(auto_sni[0].2, "auto.example.com");
+        // The auto fallback to this peer is swept too.
+        assert_eq!(
+            auto_fb,
+            vec![(
+                "5.6.7.8:443".parse().unwrap(),
+                "10.59.0.2:443".parse().unwrap()
+            )]
+        );
 
-        let (all_dnat, all_sni) = select_peer_forwards(&fwds, peer, false);
+        let (all_dnat, all_sni, all_fb) = select_peer_forwards(&fwds, peer, false);
         assert_eq!(all_dnat.len(), 2, "manual + auto for peer");
         assert_eq!(all_sni.len(), 2);
+        assert_eq!(all_fb.len(), 1);
 
         // A different device's forward is never swept.
-        let (other_dnat, _) = select_peer_forwards(&fwds, other, false);
+        let (other_dnat, _, other_fb) = select_peer_forwards(&fwds, other, false);
         assert_eq!(other_dnat, vec!["1.2.3.4:9000".parse().unwrap()]);
+        assert!(other_fb.is_empty());
     }
 }

--- a/shared-libs/crates/start-core/src/tunnel/forward/pcp.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/pcp.rs
@@ -148,15 +148,10 @@ impl GatewayBackend for TunnelContext {
         _peer: Ipv4Addr,
         lifetime: Option<u32>,
     ) -> Result<(), u16> {
-        let res = apply_peer_forward_range(self, source, target, count, "PCP").await;
-        // Stamp the lease on the renewal (idempotent re-assert) path too, so a
-        // still-renewing client is never reaped.
-        if res.is_ok() {
-            if let Some(lt) = lifetime {
-                lease::stamp(self, LeaseKey::Dnat(source), lt);
-            }
-        }
-        res
+        // `apply_peer_forward_range` stamps the lease itself (Dnat on the DNAT
+        // path, SniFallback when the port is SNI-demuxed and this becomes its
+        // fallback), so a still-renewing client is never reaped whichever it is.
+        apply_peer_forward_range(self, source, target, count, "PCP", lifetime).await
     }
 
     async fn remove_forward(&self, peer: Ipv4Addr, internal_port: u16) {
@@ -278,9 +273,9 @@ impl GatewayBackend for TunnelContext {
                 db.as_port_forwards_mut().mutate(|pf| {
                     use crate::tunnel::db::PortForward;
                     let mut now_empty = false;
-                    if let Some(PortForward::Sni { routes }) = pf.0.get_mut(&source) {
+                    if let Some(PortForward::Sni { routes, fallback }) = pf.0.get_mut(&source) {
                         routes.retain(|h, r| !(r.target == target && hostnames.contains(h)));
-                        now_empty = routes.is_empty();
+                        now_empty = routes.is_empty() && fallback.is_none();
                     }
                     if now_empty {
                         pf.0.remove(&source);
@@ -328,11 +323,41 @@ impl TunnelContext {
                             ErrorKind::InvalidRequest,
                         ));
                     }
+                    // A lone same-owner hostname-less DNAT on this exact port is
+                    // promoted to this shared SNI port's fallback, so a bare public
+                    // IP and named domains can coexist. A range or another client's
+                    // DNAT is rejected (see `plan_dnat_conversion`).
+                    let mut converted = None;
+                    if plan_dnat_conversion(pf.0.get(&source), source, target)? {
+                        if let Some(PortForward::Dnat {
+                            target: dt,
+                            label,
+                            enabled,
+                            auto,
+                            ..
+                        }) = pf.0.remove(&source)
+                        {
+                            converted = Some(dt);
+                            pf.0.insert(
+                                source,
+                                PortForward::Sni {
+                                    routes: std::collections::BTreeMap::new(),
+                                    fallback: Some(SniRoute {
+                                        target: dt,
+                                        label,
+                                        enabled,
+                                        auto,
+                                    }),
+                                },
+                            );
+                        }
+                    }
                     let entry = pf.0.entry(source).or_insert_with(|| PortForward::Sni {
                         routes: std::collections::BTreeMap::new(),
+                        fallback: None,
                     });
                     match entry {
-                        PortForward::Sni { routes } => {
+                        PortForward::Sni { routes, .. } => {
                             for h in &hostnames_owned {
                                 if routes.get(h).is_some_and(|r| r.target != target) {
                                     return Err(Error::new(
@@ -356,9 +381,9 @@ impl TunnelContext {
                                     },
                                 );
                             }
-                            Ok(())
+                            Ok(converted)
                         }
-                        // external port already used by a DNAT forward
+                        // Unreachable: a lone DNAT was converted to Sni just above.
                         PortForward::Dnat { .. } => Err(Error::new(
                             eyre!("{source} is already a DNAT forward"),
                             ErrorKind::InvalidRequest,
@@ -368,8 +393,31 @@ impl TunnelContext {
             })
             .await
             .result;
-        if persisted.is_err() {
-            return Err(crate::net::port_map::pcp::hostname::RESULT_HOSTNAME_TAKEN);
+        let converted = match persisted {
+            Ok(c) => c,
+            Err(_) => return Err(crate::net::port_map::pcp::hostname::RESULT_HOSTNAME_TAKEN),
+        };
+        // If a lone DNAT was promoted to this port's fallback, bind the fallback in
+        // the demux, tear down the now-superseded kernel DNAT (the SNI listener
+        // takes over the port), and carry its lease to the fallback so a still-
+        // renewing bare-IP client isn't reaped before its next MAP.
+        if let Some(dnat_target) = converted {
+            if let Err(code) =
+                self.sni()
+                    .register_fallback(*source.ip(), source.port(), dnat_target)
+            {
+                tracing::warn!("failed to register fallback converting DNAT on {source}: {code}");
+            }
+            if let Some(rc) = self.active_forwards.mutate(|m| m.remove(&source)) {
+                drop(rc);
+                self.forward.gc().await.log_err();
+            }
+            let carried = self.leases.mutate(|l| l.remove(&LeaseKey::Dnat(source)));
+            if let Some(exp) = carried {
+                self.leases.mutate(|l| {
+                    l.insert(LeaseKey::SniFallback(source), exp);
+                });
+            }
         }
         // Mirror into the dataplane; on the unexpected register failure undo the
         // DB routes we just added.
@@ -394,6 +442,129 @@ impl TunnelContext {
             }
         }
         Ok(())
+    }
+
+    /// Persist + register the hostname-less fallback on `source -> target`. The
+    /// port must already be SNI-demuxed (a lone hostname-less forward stays a
+    /// kernel DNAT); on a StartTunnel this is how a bare public IP shares a port
+    /// with named domains. `auto`/`label` mirror [`persist_sni_forward`]; the
+    /// same target reclaims, a different one is rejected (one fallback per port).
+    pub async fn persist_fallback_forward(
+        &self,
+        source: SocketAddrV4,
+        target: SocketAddrV4,
+        lifetime: Option<u32>,
+        auto: bool,
+        label: Option<String>,
+    ) -> Result<(), u8> {
+        let default_label = if auto { Some("PCP".to_string()) } else { label };
+        let persisted = self
+            .db
+            .mutate(|db| {
+                db.as_port_forwards_mut().mutate(|pf| {
+                    use crate::tunnel::db::{PortForward, SniRoute};
+                    match pf.0.get_mut(&source) {
+                        Some(PortForward::Sni { fallback, .. }) => {
+                            if fallback.as_ref().is_some_and(|f| f.target != target) {
+                                return Err(Error::new(
+                                    eyre!("fallback on {source} is held by another client"),
+                                    ErrorKind::InvalidRequest,
+                                ));
+                            }
+                            let (label, enabled, auto) =
+                                sni_route_fields(fallback.as_ref(), auto, &default_label);
+                            *fallback = Some(SniRoute {
+                                target,
+                                label,
+                                enabled,
+                                auto,
+                            });
+                            Ok(())
+                        }
+                        _ => Err(Error::new(
+                            eyre!("{source} is not an SNI-demuxed port"),
+                            ErrorKind::InvalidRequest,
+                        )),
+                    }
+                })
+            })
+            .await
+            .result;
+        if persisted.is_err() {
+            return Err(crate::net::port_map::pcp::hostname::RESULT_HOSTNAME_TAKEN);
+        }
+        if self
+            .sni()
+            .register_fallback(*source.ip(), source.port(), target)
+            .is_err()
+        {
+            self.remove_sni_fallback(source, target).await;
+            return Err(crate::net::port_map::pcp::hostname::RESULT_HOSTNAME_TAKEN);
+        }
+        if let Some(lt) = lifetime {
+            lease::stamp(self, LeaseKey::SniFallback(source), lt);
+        }
+        Ok(())
+    }
+
+    /// Remove the hostname-less fallback on `source`, only if held by `target`.
+    /// Drops the shared port entirely if no SNI routes remain either.
+    pub async fn remove_sni_fallback(&self, source: SocketAddrV4, target: SocketAddrV4) {
+        self.sni()
+            .unregister_fallback(*source.ip(), source.port(), target);
+        lease::forget(self, &LeaseKey::SniFallback(source));
+        self.db
+            .mutate(|db| {
+                db.as_port_forwards_mut().mutate(|pf| {
+                    use crate::tunnel::db::PortForward;
+                    let mut now_empty = false;
+                    if let Some(PortForward::Sni { routes, fallback }) = pf.0.get_mut(&source) {
+                        if fallback.as_ref().is_some_and(|f| f.target == target) {
+                            *fallback = None;
+                        }
+                        now_empty = routes.is_empty() && fallback.is_none();
+                    }
+                    if now_empty {
+                        pf.0.remove(&source);
+                    }
+                    Ok(())
+                })
+            })
+            .await
+            .result
+            .log_err();
+    }
+}
+
+/// Whether a hostname MAP arriving on `source` may promote an existing
+/// hostname-less DNAT there into this SNI port's fallback. `Ok(true)` converts (a
+/// lone, same-owner DNAT); `Ok(false)` means nothing to convert (empty or already
+/// SNI). `Err` rejects an incompatible claim: a DNAT range (can't host SNI) or a
+/// *different* client's DNAT — a whole-port claim another peer must not carve up.
+/// Each peer's forward target is forced to its own tunnel IP, so the target IP
+/// identifies the owner.
+fn plan_dnat_conversion(
+    existing: Option<&PortForward>,
+    source: SocketAddrV4,
+    new_target: SocketAddrV4,
+) -> Result<bool, Error> {
+    match existing {
+        Some(PortForward::Dnat { count, target, .. }) => {
+            if *count != 1 {
+                return Err(Error::new(
+                    eyre!("{source} is already a DNAT range forward"),
+                    ErrorKind::InvalidRequest,
+                ));
+            }
+            if target.ip() != new_target.ip() {
+                return Err(Error::new(
+                    eyre!("{source} is already a DNAT forward for another client"),
+                    ErrorKind::InvalidRequest,
+                ));
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
     }
 }
 
@@ -453,8 +624,8 @@ async fn remove_peer_forward(ctx: &TunnelContext, peer: Ipv4Addr, internal_port:
 mod tests {
     use std::net::SocketAddrV4;
 
-    use super::sni_route_fields;
-    use crate::tunnel::db::SniRoute;
+    use super::{plan_dnat_conversion, sni_route_fields};
+    use crate::tunnel::db::{PortForward, SniRoute};
 
     fn route(label: Option<&str>, enabled: bool, auto: bool) -> SniRoute {
         SniRoute {
@@ -463,6 +634,40 @@ mod tests {
             enabled,
             auto,
         }
+    }
+
+    fn dnat(target: &str, count: u16) -> PortForward {
+        PortForward::Dnat {
+            target: target.parse().unwrap(),
+            label: None,
+            enabled: true,
+            count,
+            auto: true,
+        }
+    }
+
+    // A hostname MAP may promote *its own* client's lone DNAT to the port's
+    // fallback, but must not carve up another client's whole-port DNAT, a DNAT
+    // range, and does nothing on an empty or already-SNI port.
+    #[test]
+    fn dnat_conversion_is_owner_scoped() {
+        let src: SocketAddrV4 = "1.2.3.4:443".parse().unwrap();
+        let mine: SocketAddrV4 = "10.59.0.2:443".parse().unwrap();
+        let theirs: SocketAddrV4 = "10.59.0.3:443".parse().unwrap();
+
+        // Same owner's lone DNAT -> convert.
+        assert!(plan_dnat_conversion(Some(&dnat("10.59.0.2:443", 1)), src, mine).unwrap());
+        // A different client's DNAT is an exclusive whole-port claim -> reject.
+        assert!(plan_dnat_conversion(Some(&dnat("10.59.0.3:443", 1)), src, mine).is_err());
+        // Even the owner can't fold a DNAT *range* into a single SNI port.
+        assert!(plan_dnat_conversion(Some(&dnat("10.59.0.2:443", 4)), src, mine).is_err());
+        // Nothing to convert on an empty port or one already SNI.
+        assert!(!plan_dnat_conversion(None, src, mine).unwrap());
+        let sni = PortForward::Sni {
+            routes: std::collections::BTreeMap::new(),
+            fallback: None,
+        };
+        assert!(!plan_dnat_conversion(Some(&sni), src, theirs).unwrap());
     }
 
     // A manually-added hostname on a fresh source is stored as manual, with the

--- a/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
@@ -189,6 +189,42 @@ impl SniDemux {
         self.reap_if_empty(key);
     }
 
+    /// Set the hostname-less fallback for `(ext_ip, ext_port) -> target` and
+    /// ensure the listener runs. Traffic matching no hostname route (or sending
+    /// no SNI) is spliced here. `Err(RESULT_HOSTNAME_TAKEN)` if a different
+    /// target already holds the fallback; the same target reclaims (idempotent).
+    pub fn register_fallback(
+        self: &Arc<Self>,
+        ext_ip: Ipv4Addr,
+        ext_port: u16,
+        target: SocketAddrV4,
+    ) -> Result<(), u8> {
+        let key = (ext_ip, ext_port);
+        self.ports.mutate(|ports| {
+            let entry = ports.entry(key).or_default();
+            if entry.fallback.is_some_and(|t| t != target) {
+                return Err(RESULT_HOSTNAME_TAKEN);
+            }
+            entry.fallback = Some(target);
+            Ok(())
+        })?;
+        self.ensure_listener(key);
+        Ok(())
+    }
+
+    /// Clear the fallback on `(ext_ip, ext_port)`, only if held by `target`.
+    pub fn unregister_fallback(&self, ext_ip: Ipv4Addr, ext_port: u16, target: SocketAddrV4) {
+        let key = (ext_ip, ext_port);
+        self.ports.mutate(|ports| {
+            if let Some(entry) = ports.get_mut(&key) {
+                if entry.fallback == Some(target) {
+                    entry.fallback = None;
+                }
+            }
+        });
+        self.reap_if_empty(key);
+    }
+
     fn prune(&self) {
         let now = Instant::now();
         let empty: Vec<PortKey> = self.ports.mutate(|ports| {
@@ -393,6 +429,50 @@ mod tests {
     #[test]
     fn non_tls_is_none() {
         assert_eq!(extract_sni(b"GET / HTTP/1.1\r\n"), None);
+    }
+
+    #[tokio::test]
+    async fn fallback_register_ownership_and_coexistence() {
+        let demux = SniDemux::new();
+        let ip: Ipv4Addr = Ipv4Addr::LOCALHOST;
+        let port = 44300u16;
+        let fb = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 9), 443);
+        let host_target = SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 443);
+
+        // A fallback can be set; a different target can't steal it, same reclaims.
+        demux.register_fallback(ip, port, fb).unwrap();
+        assert!(
+            demux
+                .register_fallback(ip, port, SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 8), 443))
+                .is_err()
+        );
+        assert!(demux.register_fallback(ip, port, fb).is_ok());
+
+        // A named route coexists with the fallback: exact SNI hits the route,
+        // no/unmatched SNI hits the fallback.
+        demux
+            .register(ip, port, &["a.example.com".to_string()], host_target, None)
+            .unwrap();
+        demux.ports.peek(|p| {
+            let pb = p.get(&(ip, port)).unwrap();
+            assert_eq!(pb.select(Some("a.example.com")), Some(host_target));
+            assert_eq!(pb.select(Some("nope.example.com")), Some(fb));
+            assert_eq!(pb.select(None), Some(fb));
+        });
+
+        // Unregister with the wrong target is a no-op; the right target clears it,
+        // leaving the named route intact.
+        demux.unregister_fallback(ip, port, SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 8), 443));
+        demux.ports.peek(|p| {
+            assert_eq!(p.get(&(ip, port)).unwrap().fallback, Some(fb));
+        });
+        demux.unregister_fallback(ip, port, fb);
+        demux.ports.peek(|p| {
+            let pb = p.get(&(ip, port)).unwrap();
+            assert_eq!(pb.fallback, None);
+            assert_eq!(pb.select(None), None);
+            assert_eq!(pb.select(Some("a.example.com")), Some(host_target));
+        });
     }
 
     #[test]

--- a/shared-libs/ts-modules/start-core/lib/osBindings/tunnel/PortForward.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/tunnel/PortForward.ts
@@ -26,4 +26,12 @@ export type PortForward =
        * hostname (lowercase; may be `*.suffix`) -> route.
        */
       routes: { [key: string]: SniRoute }
+      /**
+       * Hostname-less catch-all for this shared external port. Traffic whose
+       * SNI matches no `routes` entry — or that carries no SNI (bare-IP TLS,
+       * non-TLS) — is spliced here instead of being dropped. `None` closes the
+       * port to unmatched traffic. This lets a bare public IP and named
+       * domains share one external port, the bare IP acting as the fallback.
+       */
+      fallback: SniRoute | null
     }


### PR DESCRIPTION
## The bug

Enabling a **public IPv4** address on an **SSL** service interface did not trigger automatic port forwarding — the port stayed closed until forwarded by hand. Adding a public **domain** on the same interface worked fine; only the bare IP:port failed, and only for bindings with `addSsl`. (Reported by @dr-bonez.)

## Root cause (StartOS)

In `net_controller.rs::NetServiceData::update`, the IPv4 auto-map path (`forwards` → `InterfaceForwardEntry::update` → `port_map.ensure`) that opens the router pinhole is built **only** in the non-SSL forwards block. For an `add_ssl` port that block is skipped. The bare public IPv4 got a `*` reverse-proxy listener but no pinhole:

- public **domains** → `hostname_maps` → `sync_hostname_mappings` → `ensure_hostname` ✅
- public **IPv6 GUAs** → `gua_pinholes` → `port_map.ensure` ✅
- bare public **IPv4** on an SSL port → **nothing** ❌

It even affected the StartOS admin UI itself (bound `add_ssl` + `secure: None`): its HTTP port auto-forwarded on a public IPv4 but its HTTPS port did not.

## Fix (StartOS)

For each enabled bare public IPv4 at the SSL port, request the pinhole directly — mirroring the IPv6 `gua_pinholes` mechanism: ask the gateway to forward the SSL port to the box's own **LAN IPv4** (the host TLS `*` vhost is the listener, so it's a pure pinhole, no local DNAT). Tracked in a new `HostBinds.ssl_ip_pinholes` set and withdrawn on the same reconcile as the GUA pinholes. Gated strictly to a public IPv4 (not a GUA-only gateway, not a domain).

## Fix (StartTunnel) — required so the OS fix doesn't regress domains

@dr-bonez flagged that a StartTunnel port was strictly **either** a DNAT **or** an SNI route set — so with the OS change, a service with both a public domain *and* a bare public IPv4 on the same SSL port would have its two PCP mappings collide (whichever landed first won; the other errored), regressing the working domain case.

So a hostname-less forward now acts as the **SNI fallback** (the `PortBindings.fallback` slot that existed but was never wired):

- `PortForward::Sni` gains `fallback: Option<SniRoute>` (`#[serde(default)]` → **no DB migration**).
- A hostname-less MAP on an SNI port sets the fallback; a hostname MAP on a lone **same-owner** DNAT promotes it to the fallback (kernel rule torn down, demux listener registered, lease carried to a new `SniFallback` key).
- Traffic whose TLS SNI matches a named route reaches that device; a bare-IP client or unmatched/absent SNI reaches the fallback device.

The DNAT→SNI promotion is **owner-scoped** (`plan_dnat_conversion`): a DNAT is an exclusive whole-port claim, so only the DNAT's own client (target forced to its tunnel IP) may fold it into the fallback — another client's hostname is rejected, as before. *(This guard was added in response to a self-run adversarial review that flagged the unguarded conversion as a cross-peer boundary issue on shared-WAN-IP subnets.)*

Wired through the data-plane demux, PCP/UPnP backend (lease stamping centralized into `apply_peer_forward_range`), lease seed/reap, startup + WAN-IP reconcile, peer teardown (`clear_for_peer`/`gc_forwards`), and the manual API. The tunnel UI lists the fallback as a hostname-less row.

## Versioning / changelog

- **start-os** `0.4.0-beta.10` is unreleased → CHANGELOG entry added in place, no bump.
- **start-tunnel** `v1.1.1` is released → new `## [1.1.2]` + `Cargo.toml`/`Cargo.lock` bump.
- Regenerated `osBindings/tunnel/PortForward.ts` (only the `fallback` field added).

## Testing

- `cargo test -p start-core` — tunnel (36, incl. new `dnat_conversion_is_owner_scoped`, `fallback_register_ownership_and_coexistence`, `sni_fallback_serde_backward_compat`) and net (180) suites pass.
- Prettier + pinned-nightly (`nightly-2026-05-28`) rustfmt clean.
- **Not** exercised here: end-to-end WAN reachability needs a real PCP/NAT-PMP/UPnP gateway (a libvirt NAT gateway won't grant a pinhole), and the `start-tunnel` binary itself needs its web frontend built (`include_dir!`) which isn't built in this environment — CI covers the full web/tunnel build. Manual confirmation on real hardware (or a StartTunnel VM) that the pinhole is emitted/withdrawn is the one remaining step.