### PR TITLE
fix(start-os): sideload preview width + bare ports in the domain modal

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/domain-validation.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/addresses/gateway/domain-validation.component.ts
@@ -14,7 +14,7 @@ import { CheckIconComponent } from 'src/app/routes/portal/components/check-icon.
 import { TableComponent } from 'src/app/routes/portal/components/table.component'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
 import { formatPortRange } from 'src/app/utils/format-port-range'
-import { dnsAllPass, getGua, getLanIpv4, portAllPass } from 'src/app/utils/gua'
+import { dnsAllPass, getGua, portAllPass } from 'src/app/utils/gua'
 import { parse } from 'tldts'
 import {
   PortCheckField,
@@ -255,7 +255,6 @@ export class DomainValidationComponent {
     parse(this.context.data.fqdn).domain || this.context.data.fqdn
 
   private readonly wanIp = this.context.data.gateway.ipInfo.wanIp
-  private readonly lanIpv4 = getLanIpv4(this.context.data.gateway.ipInfo)
   // The gateway's IPv6 GUA (the AAAA target), if it has one. When present the
   // domain is DualStack and the modal verifies both families.
   readonly gua = getGua(this.context.data.gateway.ipInfo)
@@ -268,20 +267,16 @@ export class DomainValidationComponent {
     this.context.data.count,
   )
 
-  // Full socket addresses make the boxes self-distinguishing: the IPv4 forward
-  // (external WAN -> internal LAN) vs the IPv6 firewall (the server's own GUA).
-  readonly externalAddr = this.socketAddr(this.wanIp)
-  readonly internalAddr = this.socketAddr(this.lanIpv4)
   readonly ipv6Addr = this.gua ? `[${this.gua}]:${this.portDisplay}` : ''
 
   readonly portFields: readonly PortCheckField[] = this.isRange
     ? [
-        { label: 'External Range', value: this.externalAddr },
-        { label: 'Internal Range', value: this.internalAddr },
+        { label: 'External Range', value: this.portDisplay },
+        { label: 'Internal Range', value: this.portDisplay },
       ]
     : [
-        { label: 'External', value: this.externalAddr },
-        { label: 'Internal', value: this.internalAddr },
+        { label: 'External Port', value: this.portDisplay },
+        { label: 'Internal Port', value: this.portDisplay },
       ]
   readonly firewallFields: readonly PortCheckField[] = [
     { label: 'Address', value: this.ipv6Addr },
@@ -369,10 +364,6 @@ export class DomainValidationComponent {
     } finally {
       this.portV6Loading.set(false)
     }
-  }
-
-  private socketAddr(ip: string | null): string {
-    return ip ? `${ip}:${this.portDisplay}` : this.portDisplay
   }
 }
 

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/sideload/package.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/sideload/package.component.ts
@@ -40,7 +40,7 @@ import { MarketplacePkgSideload } from './sideload.utils'
     :host {
       display: grid;
       gap: 1rem;
-      inline-size: min(100%, 30rem);
+      inline-size: min(100%, 42rem);
       margin: auto;
     }
 

--- a/projects/start-os/web/ui/src/app/utils/gua.ts
+++ b/projects/start-os/web/ui/src/app/utils/gua.ts
@@ -16,20 +16,6 @@ export function getGua(ipInfo: T.IpInfo): string | null {
 }
 
 /**
- * The server's own LAN IPv4 (the internal side of an IPv4 port-forward rule), or
- * null when it has none. `subnets` holds the server's own addresses on each link.
- */
-export function getLanIpv4(ipInfo: T.IpInfo): string | null {
-  for (const cidr of ipInfo.subnets) {
-    try {
-      const net = utils.IpNet.parse(cidr)
-      if (net.isIpv4()) return net.address
-    } catch {}
-  }
-  return null
-}
-
-/**
  * Whether the domain's DNS resolves correctly for every family the gateway
  * offers: the `A` record must match the WAN IPv4 (if any) and the `AAAA` must
  * match the GUA (if any).

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/de.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/de.ts
@@ -789,8 +789,6 @@ export default {
   893: 'Ihre persönliche StartOS-Web-Benutzeroberfläche.',
   894: 'diese DNS-Einträge erstellen',
   895: 'IPv6-Firewall',
-  896: 'Extern',
-  897: 'Intern',
   898: 'Adresse',
   899: 'IPv6 hat keine Portweiterleitung — Ihr Server ist direkt unter seiner globalen Adresse erreichbar. Die Firewall Ihres Gateways muss eingehende Verbindungen dorthin zulassen, oder aktivieren Sie die automatische Firewall-Konfiguration (PCP) auf dem Gateway.',
   900: 'Prüfen Sie Ihren verfügbaren Speicherplatz',

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/en.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/en.ts
@@ -799,8 +799,6 @@ export const ENGLISH: Record<string, number> = {
   'Your personal StartOS web user interface.': 893,
   'create these DNS records': 894,
   'IPv6 Firewall': 895,
-  'External': 896, // as in, external socket address
-  'Internal': 897, // as in, internal socket address
   'Address': 898, // as in, a socket address (ip:port)
   'IPv6 has no port forwarding — your server is reachable directly at its global address. Your gateway firewall must allow inbound connections to it, or enable automatic firewall configuration (PCP) on the gateway.': 899,
   'Cannot Preserve Data': 909,

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/es.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/es.ts
@@ -789,8 +789,6 @@ export default {
   893: 'Tu interfaz web personal de StartOS.',
   894: 'cree estos registros DNS',
   895: 'Firewall IPv6',
-  896: 'Externo',
-  897: 'Interno',
   898: 'Dirección',
   899: 'IPv6 no usa reenvío de puertos: tu servidor es accesible directamente en su dirección global. El firewall de tu gateway debe permitir las conexiones entrantes hacia él, o habilita la configuración automática del firewall (PCP) en el gateway.',
   900: 'Comprueba el espacio disponible',

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/fr.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/fr.ts
@@ -789,8 +789,6 @@ export default {
   893: 'Votre interface web personnelle StartOS.',
   894: 'créez ces enregistrements DNS',
   895: 'Pare-feu IPv6',
-  896: 'Externe',
-  897: 'Interne',
   898: 'Adresse',
   899: "IPv6 n'utilise pas de redirection de port — votre serveur est accessible directement à son adresse globale. Le pare-feu de votre passerelle doit autoriser les connexions entrantes vers celui-ci, ou activez la configuration automatique du pare-feu (PCP) sur la passerelle.",
   900: 'Vérifiez votre espace disponible',

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/pl.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/pl.ts
@@ -789,8 +789,6 @@ export default {
   893: 'Twój osobisty interfejs webowy StartOS.',
   894: 'utwórz te rekordy DNS',
   895: 'Zapora IPv6',
-  896: 'Zewnętrzny',
-  897: 'Wewnętrzny',
   898: 'Adres',
   899: 'IPv6 nie używa przekierowania portów — Twój serwer jest dostępny bezpośrednio pod swoim adresem globalnym. Zapora bramy musi zezwalać na połączenia przychodzące do niego lub włącz automatyczną konfigurację zapory (PCP) na bramie.',
   900: 'Sprawdź dostępne miejsce',


### PR DESCRIPTION
Two small StartOS web UI fixes, both refining unreleased beta.10 work (no changelog entries needed — released beta.9 behavior is unaffected or restored).

## Summary

- **Sideload:** the marketplace refactor capped the sideload package preview at the drawer width (30rem), which reads as squeezed and stranded in the middle of a full page. Widen it to `min(100%, 42rem)`, matching the cap the page already uses for its upload drop zone.
- **Address Requirements (domain modal):** the port forwarding table showed full socket addresses (`wanIp:port` external, `lanIp:port` internal). Show just the external and internal ports, with the same labels as the standalone public-IP port forward modal. The IPv6 firewall table is unchanged — its whole point is the address. Removes the now-dead `socketAddr()`/`externalAddr`/`internalAddr` members, the `getLanIpv4` helper, and the orphaned `External`/`Internal` i18n keys from all five dictionaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)