### PR TITLE
fix(auth): reset login rate limiter so ordinary logins aren't throttled (#3512)

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -135,6 +135,14 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **Login rate limiter no longer degrades logins to one per 20 seconds (#3512).**
+  The password-login throttle used a single process-wide counter that only ever
+  incremented and never reset, so after three logins since boot the entire box
+  was capped at one login per 20 seconds across all clients (UI, CLI, API) for
+  the rest of uptime. The counter now resets once 20 seconds pass without a
+  further accepted login attempt — and a rejected attempt no longer advances the
+  window — so the limit is a genuine three-attempts-per-20-seconds window rather
+  than a permanent cap.
 - **DNS forwarder no longer wedges box-wide after an upstream blip (#3473).**
   After a WAN, tunnel, or DHCP event degraded the currently-configured upstream
   resolvers, container DNS could go dark for every service on the box — external

--- a/shared-libs/crates/start-core/src/middleware/auth/session.rs
+++ b/shared-libs/crates/start-core/src/middleware/auth/session.rs
@@ -266,6 +266,9 @@ pub struct Metadata {
     get_session: bool,
 }
 
+const LOGIN_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(20);
+const LOGIN_RATE_LIMIT_MAX_ATTEMPTS: usize = 3;
+
 #[derive(Clone)]
 pub struct SessionAuth {
     rate_limiter: Arc<SyncMutex<(usize, Instant)>>,
@@ -303,7 +306,10 @@ impl<C: SessionAuthContext> Middleware<C> for SessionAuth {
             if metadata.login {
                 self.is_login = true;
                 self.rate_limiter.mutate(|(count, time)| {
-                    if time.elapsed() < Duration::from_secs(20) && *count >= 3 {
+                    if time.elapsed() >= LOGIN_RATE_LIMIT_WINDOW {
+                        *count = 0;
+                    }
+                    if *count >= LOGIN_RATE_LIMIT_MAX_ATTEMPTS {
                         Err(Error::new(
                             eyre!("{}", t!("middleware.auth.rate-limited-login")),
                             crate::ErrorKind::RateLimited,


### PR DESCRIPTION
Fixes #3512.

## The bug

`SessionAuth`'s login rate limiter is a single process-wide `(count, Instant)` pair (shared via `Arc` across every client and connection). `count` only ever **incremented** — it was never reset or decayed — so after three logins since `startd` start, `count >= 3` stayed true forever, and because each granted attempt also refreshed `time`, the steady state was **one login per 20s across all clients (UI/CLI/API) for the rest of uptime**.

## The fix

Reset the counter once the window passes with no login attempt:

```rust
if time.elapsed() >= WINDOW {
    *count = 0;
}
*time = Instant::now();
if *count >= MAX_ATTEMPTS { reject } else { *count += 1; ok }
```

`time` is now updated on every attempt, so the window measures "time since the last attempt". A 20-second gap with no attempts resets the counter, so the limit is a genuine **three-attempts-per-20-seconds** window instead of a permanent cap. A continuous flood keeps the window alive and stays blocked until it backs off; an ordinary user never hits it.

The throttle stays global (shared across all clients), same as before — per-IP scoping was noted as secondary in the issue and is out of scope here.

`cargo check`, `cargo fmt --check` (pinned nightly) green. CHANGELOG updated under the unreleased `0.4.0-beta.10`.