### PR TITLE
fix(ci): stop an empty deploy input from publishing an iso build

### DIFF
--- a/.github/workflows/startos-iso.yaml
+++ b/.github/workflows/startos-iso.yaml
@@ -4,9 +4,13 @@ on:
   workflow_call:
   workflow_dispatch:
     inputs:
+      # `default:` is not decoration — the UI preselects the first option, but an API
+      # dispatch (`gh workflow run`) that omits an input delivers it as the empty
+      # string, and only a declared default fills it in.
       environment:
         type: choice
         description: Environment
+        default: NONE
         options:
           - NONE
           - dev
@@ -15,12 +19,14 @@ on:
       runner:
         type: choice
         description: Runner
+        default: standard
         options:
           - standard
           - fast
       platform:
         type: choice
         description: Platform
+        default: ALL
         options:
           - ALL
           - x86_64
@@ -35,6 +41,7 @@ on:
       deploy:
         type: choice
         description: Deploy
+        default: NONE
         options:
           - NONE
           - alpha
@@ -434,9 +441,13 @@ jobs:
     needs: [image]
     # Explicit status check so the skipped PR-only `changes` job can't poison
     # the implicit success() through the needs chain (actions/runner#2205).
+    # Allowlist the channels rather than excluding NONE: a `!= 'NONE'` gate also admits
+    # an empty deploy input, which uploaded a branch build to the public bucket and then
+    # died on the empty REGISTRY below. Keep in sync with the REGISTRY map.
     if: >-
       !cancelled() && needs.image.result == 'success'
-      && github.event_name == 'workflow_dispatch' && github.event.inputs.deploy != 'NONE'
+      && github.event_name == 'workflow_dispatch'
+      && contains(fromJson('["alpha", "beta"]'), github.event.inputs.deploy)
     runs-on: ubuntu-latest
     env:
       REGISTRY: >-


### PR DESCRIPTION
Dispatching this workflow from the CLI without naming every input published a branch build to the public images bucket. This closes that path.

## What happened

`gh workflow run startos-iso.yaml --ref <branch> -f platform=x86_64` (run [29804211348](https://github.com/Start9Labs/start-technologies/actions/runs/29804211348), on a PR branch) ran the **Deploy** job. It uploaded `startos-0.4.0-beta.10-0026aa2~dev_x86_64.{squashfs,iso}` to `s3://startos-images/v0.4.0-beta.10/` with a public ACL, then failed on `Register OS version`.

Two things combined:

- **An API dispatch applies no default to an omitted input** — it arrives as the empty string. The UI preselects the first option, so `deploy` only ever looked like it defaulted to `NONE`. None of the four inputs declared a `default:`.
- **The Deploy gate was `deploy != 'NONE'`**, which an empty string passes.

`REGISTRY` is a `fromJson` map keyed on that same input, so it resolved to `""` and `start-cli --registry=""` exited 38 — after the S3 upload had already run. The registry was left untouched and `Index assets in registry` was skipped, so the objects are unreferenced, but they are public and were not cleaned up by the failure.

## The change

- `default:` on all four dispatch inputs (`environment: NONE`, `runner: standard`, `platform: ALL`, `deploy: NONE`), so an omitted input matches what the UI would have sent.
- Deploy gates on an explicit channel allowlist, `contains(fromJson('["alpha", "beta"]'), inputs.deploy)`, instead of excluding `NONE`. Only a value the `REGISTRY` map can resolve reaches the publish step.

Either half alone would have prevented this; the allowlist also covers any future input value that isn't a real channel.

## Notes

- `start-wrt.yaml` gates its deploy on `== 'release'`, so it was never exposed. The other dispatchable workflows (`start-cli`, `start-registry`, `start-tunnel`) also declare no input defaults, but nothing irreversible hangs off them — their only input gates are `runner == 'fast'`. Left alone to keep this scoped; happy to add the defaults there too.
- The two orphaned objects from that run still need deleting from the bucket by hand.
