### PR TITLE
fix(ui): stop long release notes from widening the updates table

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/portal/routes/updates/item.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/updates/item.component.ts
@@ -210,6 +210,7 @@ import UpdatesComponent from './updates.component'
         padding: 0 3rem;
         text-align: left;
         white-space: normal;
+        overflow-wrap: anywhere;
       }
     }
 

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -899,7 +899,7 @@ For the full changelog, see https://github.com/bitcoin/bitcoin/blob/v27.0.0/doc/
           packageRepo: 'https://github.com/start9labs/lnd-startos',
           upstreamRepo: 'https://github.com/lightningnetwork/lnd',
           marketingUrl: 'https://lightning.engineering/',
-          releaseNotes: 'Upstream release and minor fixes.',
+          releaseNotes: `Updated LND to 0.18.0. Adds simple taproot channels, reworks the sweeper into a batched fee-bumping design, and fixes a peer-connection leak that could exhaust file descriptors on long-running nodes. Upstream notes: https://github.com/lightningnetwork/lnd/releases/tag/v0.18.0-beta`,
           osVersion: '0.4.0',
           sdkVersion: '0.4.0-beta.49',
           gitHash: 'fakehash',
@@ -949,7 +949,14 @@ For the full changelog, see https://github.com/bitcoin/bitcoin/blob/v27.0.0/doc/
           packageRepo: 'https://github.com/Start9Labs/btc-rpc-proxy-wrappers',
           upstreamRepo: 'https://github.com/Kixunil/btc-rpc-proxy',
           marketingUrl: '',
-          releaseNotes: 'Major release with breaking changes.',
+          releaseNotes: `# Bitcoin Proxy 0.4.0
+
+**Breaking:** the \`users\` config section is now \`accounts\`, and each \`allowed-calls\` entry must be a fully-qualified RPC method name. Existing configs migrate automatically on first start.
+
+- Requests are pipelined over a single upstream connection, roughly halving median latency for wallets that batch \`getblock\` calls.
+- Fixed a panic when upstream Bitcoin Core returned \`503\` during initial block download.
+
+Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.md#040-breaking-changes-to-the-users-configuration-section`,
           osVersion: '0.4.0',
           sdkVersion: '0.4.0-beta.49',
           gitHash: 'fakehash',


### PR DESCRIPTION
Release notes in the Updates tab render past the right edge of the screen — the text wraps at a width wider than the viewport, so every line is cut off.

## Cause

It isn't the paragraph that's clipped — the whole table is wider than the viewport, and the notes are wrapping at *table* width.

`updates/item.component.ts` renders the expanded row into a `td[colspan=5]` with `white-space: normal` but no word-breaking rule. Release notes routinely end in a bare URL (`https://github.com/filebrowser/filebrowser/releases/tag/v2.63.18`), which is one unbreakable token. In an auto-layout table that token's min-content width becomes the table's width, and `.g-card { overflow: auto }` on the ancestor turns the excess into a horizontal scroll region — so every row, collapsed ones included, runs past the right edge.

The collapsed row already guards against this (`tr:first-child { word-break: break-word }`). The expanded row never got the same treatment.

## Fix

One declaration on the expanded cell:

```scss
&[colspan]:only-child {
  ...
  overflow-wrap: anywhere;
}
```

`anywhere` rather than `break-word` is the load-bearing part — only `anywhere` reduces the min-content contribution, which is what the table sizes against. `overflow-wrap` inherits, so it reaches the markdown-rendered `<p>`/`<a>` inside.

Verified the mechanism in headless Chromium against a minimal repro of the same structure (grid rows, `width: stretch`, auto table layout) in a 360px container: table width **447px → 360px**.

## Mocks

All three installed mock packages have a newer registry version, so all three render in Updates. `bitcoind` already had a long markdown note; `lnd` and `btc-rpc-proxy` had one-liners that couldn't reproduce this. They now carry long notes in two different shapes — `lnd` prose ending in a bare upstream URL (the exact real-world case), `btc-rpc-proxy` structured markdown closing on a long anchored changelog link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
