### PR TITLE
docs(start-os): expand the Clock Sync Failure FAQ entry

### DIFF
--- a/projects/start-os/docs/src/faq.md
+++ b/projects/start-os/docs/src/faq.md
@@ -72,7 +72,30 @@ To resolve this, fully quit and restart your browser. A hard refresh or private 
 
 ## Clock Sync Failure
 
-This means your server was unable to sync its clock with the Internet using the Network Time Protocol (NTP). This is usually due to a firewall issue with your network/router. Make sure you are not blocking NTP. If the issue persists, please contact support.
+This warning means your server has not completed a successful time sync over the Internet (NTP) since it booted. The clock itself is usually still correct — it is set from the onboard hardware clock at boot — so services generally continue to run normally. Ongoing sync still matters (certificate validation, logs, and some services are time-sensitive), so the warning should not be ignored indefinitely.
+
+The usual cause is the network path, not the server: a router or firewall blocking outbound NTP (UDP port 123), an ISP filtering it, or the public `pool.ntp.org` servers assigned to your region being unreliable.
+
+To diagnose, [connect via SSH](ssh.md) and run:
+
+```
+timedatectl timesync-status
+sudo journalctl -u systemd-timesyncd -b
+```
+
+The journal names each time server StartOS is trying and how the attempts fail (for example `Timed out waiting for reply`).
+
+If the default servers are unreachable from your network, point StartOS at servers that do work from it (for example Google's and Cloudflare's):
+
+```
+sudo mkdir -p /etc/systemd/timesyncd.conf.d
+printf '[Time]\nNTP=time.google.com time.cloudflare.com\n' | sudo tee /etc/systemd/timesyncd.conf.d/10-custom.conf
+sudo systemctl restart systemd-timesyncd
+```
+
+Within a minute or so, `timedatectl timesync-status` should report a successful sync. If the warning in the UI does not clear shortly after that, restart your server once. The override file survives reboots; after a StartOS update, check that it is still present and re-create it if needed.
+
+If time sync still fails, please [contact support](https://start9.com/contact).
 
 ## Issue with a particular service
 


### PR DESCRIPTION
Rewrites the FAQ's **Clock Sync Failure** entry — the page the UI warning links to directly — from three sentences ("NTP failed, probably a firewall, contact support") into a short diagnose-then-fix flow:

- what the warning actually means (no successful NTP exchange since boot; the clock itself is usually still correct, services keep running);
- how to confirm over SSH (`timedatectl timesync-status`, the systemd-timesyncd journal — verbose on StartOS, so it names exactly which servers fail and how);
- the common causes (blocked/filtered UDP 123, an unreliable regional `pool.ntp.org` zone);
- a durable override via `/etc/systemd/timesyncd.conf.d/` pointing at servers reachable from the user's network, with how to verify success;
- support as the escalation rather than the first step.

Motivated by a 0.4.0-beta.9 field report (regional pool zone serving dead servers; the box's clock was fine the whole time). Related: #3520 (clock-sync check error-handling fix), #3521 (feature request for a first-class NTP-servers setting — once that lands, this section should point at it instead of the manual override).

Notes:

- The `## Clock Sync Failure` heading is unchanged, preserving the `#clock-sync-failure` fragment the UI links to.
- "Restart your server once" if the warning outlives a successful sync is deliberate: on current betas the background poller that clears the warning can be dead (the #3520 bug), so the advice holds both before and after that fix ships.
- Verification: prettier 3.8.3 clean; built with local mdBook 0.4.40 (repo pins 0.5.2 — not available here; the missing `tabs` preprocessor warns but this page uses no tabs) and the rendered page checked; the one new intra-book link (`ssh.md`) exists; SSH instructions match ssh.md (user `start9`, `sudo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
