### PR TITLE
chore(net): gate NetworkInterfaceController sync log behind the dev feature

### DIFF
--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -2584,7 +2584,7 @@ impl NetworkInterfaceController {
         db: &TypedPatchDb<Database>,
         info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
     ) -> Result<(), Error> {
-        tracing::debug!("syncronizing {info:?} to db");
+        crate::dev_log!(debug, "syncronizing {info:?} to db");
 
         let wifi_iface = find_wifi_iface()
             .await


### PR DESCRIPTION
Switches the network-interface sync's routine debug log to `dev`-only.

`NetworkInterfaceController::sync` logs `syncronizing {info:?} to db` on **every** sync — each ip_info change and each `defaultOutbound` change — dumping the whole gateway map. That's noise in production and only useful while developing, so it now goes through the `dev_log!` macro (emits only under the `dev` cargo feature), matching the sibling best-effort net logs gated in #3499.

```diff
-        tracing::debug!("syncronizing {info:?} to db");
+        crate::dev_log!(debug, "syncronizing {info:?} to db");
```

The `error-syncing-ip-info` errors in the same `_sync` task are genuine faults and stay un-gated, consistent with #3499's convention (best-effort/expected noise → dev; real errors → always visible).

No functional change; only log verbosity in non-dev builds. `cargo check -p start-core` passes.