### PR TITLE
fix(migration): write start-os/admin into tor's onion-migration handoff

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -99,8 +99,9 @@ file tracks notable changes since the move to the monorepo.
   hostname, and the UI passes `start-os` wherever a package id is expected.
   Installing a package with the id `start-os` is rejected. The migration
   re-points the tor package's persisted hidden-service identity for the admin
-  UI (`STARTOS`/`startos-ui` → `start-os`/`admin`), preserving the server's
-  existing `.onion` address across the identity change.
+  UI (`STARTOS`/`startos-ui` → `start-os`/`admin`) — including the onion-address
+  import handoff written into tor's volume before tor is installed — preserving
+  the server's existing `.onion` address across the identity change.
 - **SDK:** `PluginHostnameInfo.packageId` is required in the type — url plugins
   (e.g. tor) should export the StartOS UI's urls as `start-os`/`admin` instead of
   `packageId: null`. For backwards compatibility during the beta.10 transition,

--- a/shared-libs/crates/start-core/src/version/v0_3_6_alpha_0.rs
+++ b/shared-libs/crates/start-core/src/version/v0_3_6_alpha_0.rs
@@ -760,7 +760,8 @@ async fn previous_ssh_keys(pg: &sqlx::Pool<sqlx::Postgres>) -> Result<SshKeys, E
 }
 
 /// Returns deduplicated map of `(package_id, host_id) -> expanded_key`.
-/// Server key uses `("STARTOS", "STARTOS")`.
+/// Server key uses `("start-os", "admin")` — the StartOS UI's service-model
+/// identity (see `PackageId::start_os` / `HostId::admin`).
 /// When the same (package, interface) exists in both the `network_keys` and
 /// `tor` tables, the `tor` table entry wins because it contains the actual
 /// expanded key that was used by tor.
@@ -779,12 +780,12 @@ async fn previous_tor_keys(
         .with_kind(ErrorKind::Database)?;
     if let Ok(tor_key) = row.try_get::<Vec<u8>, _>("tor_key") {
         if let Ok(key) = <[u8; 64]>::try_from(tor_key) {
-            keys.insert(("STARTOS".to_owned(), "STARTOS".to_owned()), key);
+            keys.insert(("start-os".to_owned(), "admin".to_owned()), key);
         }
     } else if let Ok(net_key) = row.try_get::<Vec<u8>, _>("network_key") {
         if let Ok(seed) = <[u8; 32]>::try_from(net_key) {
             keys.insert(
-                ("STARTOS".to_owned(), "STARTOS".to_owned()),
+                ("start-os".to_owned(), "admin".to_owned()),
                 crate::util::crypto::ed25519_expand_key(&seed),
             );
         }

--- a/shared-libs/crates/start-core/src/version/v0_4_0_alpha_20.rs
+++ b/shared-libs/crates/start-core/src/version/v0_4_0_alpha_20.rs
@@ -44,8 +44,12 @@ impl VersionT for Version {
             .and_then(|p| p.get("torMigration"))
             .and_then(|t| t.as_array())
         {
+            let mut addresses = tor_migration.clone();
+            for entry in addresses.iter_mut() {
+                normalize_legacy_service_identity(entry);
+            }
             json!({
-                "addresses": tor_migration.clone(),
+                "addresses": addresses,
             })
         } else {
             // Fallback for fresh installs or installs that didn't go through
@@ -81,8 +85,8 @@ impl VersionT for Version {
                             })?;
                         addresses.push_back(json!({
                             "hostname": hostname,
-                            "packageId": "STARTOS",
-                            "hostId": "startos-ui",
+                            "packageId": "start-os",
+                            "hostId": "admin",
                             "key": key,
                         }));
                     }
@@ -297,6 +301,17 @@ impl VersionT for Version {
     }
 }
 
+/// The server UI's onion entries were keyed by the legacy `STARTOS` sentinel
+/// (with host id `STARTOS` or `startos-ui`) before the StartOS UI became an
+/// ordinary service interface (`start-os`/`admin`). Dev builds that already ran
+/// v0_3_6_alpha_0 have the legacy form persisted in `private.torMigration`.
+fn normalize_legacy_service_identity(entry: &mut Value) {
+    if entry.get("packageId").and_then(|p| p.as_str()) == Some("STARTOS") {
+        entry["packageId"] = json!("start-os");
+        entry["hostId"] = json!("admin");
+    }
+}
+
 fn collect_ports_from_host(host: Option<&Value>, ports: &mut Value) {
     let Some(bindings) = host
         .and_then(|h| h.get("bindings"))
@@ -438,5 +453,35 @@ fn migrate_host(host: Option<&mut Value>) {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn normalizes_legacy_startos_sentinel() {
+        let mut legacy = json!({
+            "hostname": "abcdef",
+            "packageId": "STARTOS",
+            "hostId": "STARTOS",
+            "key": "a2V5",
+        });
+        normalize_legacy_service_identity(&mut legacy);
+        assert_eq!(legacy["packageId"].as_str(), Some("start-os"));
+        assert_eq!(legacy["hostId"].as_str(), Some("admin"));
+        assert_eq!(legacy["hostname"].as_str(), Some("abcdef"));
+        assert_eq!(legacy["key"].as_str(), Some("a2V5"));
+
+        let mut package_entry = json!({
+            "hostname": "abcdef",
+            "packageId": "bitcoind",
+            "hostId": "main",
+            "key": "a2V5",
+        });
+        normalize_legacy_service_identity(&mut package_entry);
+        assert_eq!(package_entry["packageId"].as_str(), Some("bitcoind"));
+        assert_eq!(package_entry["hostId"].as_str(), Some("main"));
     }
 }


### PR DESCRIPTION
## Problem

Updating a server from 0.3.5.1 to 0.4.0 fails to install the bundled tor package; the migration log shows:

```
Unknown Error: Error: Invalid params: Deserialization Error: Invalid ID: STARTOS@get-host-info
```

(The trailing `@get-host-info` is decoration added by the container-runtime's effect client — the actual RPC error is `Invalid ID: STARTOS` on a `get-host-info` call.)

## Root cause

The OS migration hands the tor package its onion-import file (`volumes/tor/data/startos/onion-migration.json`) with the server UI's entries keyed by the legacy `STARTOS` sentinel:

- `v0_3_6_alpha_0`'s `previous_tor_keys` keys the account-table server UI key as `("STARTOS", "STARTOS")`, which lands in `private.torMigration`.
- `v0_4_0_alpha_20`'s fallback path emits `packageId: "STARTOS", hostId: "startos-ui"`.

`v0_4_0_alpha_20`'s `post_up` writes that file and sideloads the bundled tor s9pk, whose init imports each entry via `sdk.host.get(effects, { hostId, packageId })`. `STARTOS` is not a valid `Id` in the 0.4.0 service model, so the `get-host-info` effect rejects the params and tor's init — and with it the whole tor install — fails. `v0_4_0_beta_10`'s `migrate_tor_service_identity` does rewrite `STARTOS` → `start-os`/`admin` in that file, but it runs in beta.10's `post_up`, strictly *after* alpha.20's `post_up` where the install already failed.

## Fix

Write the real service identity at the source instead of healing it later:

- `v0_3_6_alpha_0`: collect the server UI tor key as `("start-os", "admin")`.
- `v0_4_0_alpha_20`: same for the fallback path, and normalize any legacy `STARTOS` entries when consuming a `private.torMigration` persisted by a pre-fix dev build.
- `v0_4_0_beta_10`'s file/torrc/hidden-service-dir healing is unchanged — it still covers boxes that already migrated past alpha.20 with the legacy form on disk.

Unit test added for the normalizer; full `start-core` suite passes (`cargo test -p start-core --features=test`).