### PR TITLE
fix(install): pace the install serialize path and harden s9pk resume

### DIFF
--- a/shared-libs/crates/start-core/src/registry/asset.rs
+++ b/shared-libs/crates/start-core/src/registry/asset.rs
@@ -353,19 +353,23 @@ mod tests {
     struct TestServer {
         url: Url,
         complete_hits: Arc<AtomicUsize>,
+        changes_full_hits: Arc<AtomicUsize>,
     }
 
     async fn spawn_test_server() -> Result<TestServer, Error> {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;
         let complete_hits = Arc::new(AtomicUsize::new(0));
+        let changes_full_hits = Arc::new(AtomicUsize::new(0));
         let server_complete_hits = complete_hits.clone();
+        let server_changes_full_hits = changes_full_hits.clone();
         tokio::spawn(async move {
             loop {
                 let Ok((mut stream, _)) = listener.accept().await else {
                     break;
                 };
                 let complete_hits = server_complete_hits.clone();
+                let changes_full_hits = server_changes_full_hits.clone();
                 tokio::spawn(async move {
                     let mut buf = [0; 1024];
                     let Ok(n) = stream.read(&mut buf).await else {
@@ -403,6 +407,30 @@ mod tests {
                                 .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
                                 .await;
                         }
+                        "/changes" if request_lower.contains("range: bytes=5-") => {
+                            // The file was replaced mid-download: the resume total
+                            // (13) no longer matches the first response's (11).
+                            let _ = stream
+                                .write_all(
+                                    b"HTTP/1.1 206 Partial Content\r\nContent-Length: 8\r\nContent-Range: bytes 5-12/13\r\n\r\nED WORLD",
+                                )
+                                .await;
+                        }
+                        "/changes" => {
+                            if changes_full_hits.fetch_add(1, Ordering::SeqCst) == 0 {
+                                let _ = stream
+                                    .write_all(
+                                        b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello",
+                                    )
+                                    .await;
+                            } else {
+                                let _ = stream
+                                    .write_all(
+                                        b"HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nCHANGED WORLD",
+                                    )
+                                    .await;
+                            }
+                        }
                         "/always-truncated" => {
                             let _ = stream
                                 .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello")
@@ -436,6 +464,7 @@ mod tests {
         Ok(TestServer {
             url: Url::parse(&format!("http://{addr}")).with_kind(ErrorKind::ParseUrl)?,
             complete_hits,
+            changes_full_hits,
         })
     }
 
@@ -502,6 +531,24 @@ mod tests {
 
         assert_eq!(buffered_contents(asset).await?, b"hello world");
         assert_eq!(server.complete_hits.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn buffered_download_fails_when_mirror_file_changes() -> Result<(), Error> {
+        let server = spawn_test_server().await?;
+        let asset = RegistryAsset {
+            published_at: Utc::now(),
+            urls: vec![server.url.join("changes")?, server.url.join("complete")?],
+            commitment: (),
+            signatures: HashMap::new(),
+        };
+
+        // Splicing the two generations would corrupt the archive, so the
+        // download fails rather than recover.
+        assert!(buffered_contents(asset).await.is_err());
+        assert_eq!(server.complete_hits.load(Ordering::SeqCst), 0);
+        assert_eq!(server.changes_full_hits.load(Ordering::SeqCst), 1);
         Ok(())
     }
 

--- a/shared-libs/crates/start-core/src/service/service_map.rs
+++ b/shared-libs/crates/start-core/src/service/service_map.rs
@@ -8,6 +8,7 @@ use exver::VersionRange;
 use futures::future::{BoxFuture, Fuse};
 use futures::{Future, FutureExt, StreamExt, TryFutureExt, stream};
 use imbl::OrdMap;
+use tokio::io::AsyncSeekExt;
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock, oneshot};
 use tracing::instrument;
 use url::Url;
@@ -302,9 +303,21 @@ impl ServiceMap {
                             .log_err();
                         unpack_progress.set_total(size);
                     }
-                    let mut progress_writer = ProgressTrackerWriter::new(out, unpack_progress);
+                    let mut progress_writer = ProgressTrackerWriter::new(
+                        crate::util::writeback::PacedWriter::new(out),
+                        unpack_progress,
+                    );
                     s9pk.serialize(&mut progress_writer, true).await?;
-                    let (file, mut unpack_progress) = progress_writer.into_inner();
+                    let (paced_writer, mut unpack_progress) = progress_writer.into_inner();
+                    let mut file = paced_writer.into_inner();
+                    // `size` is the pre-filter source size; free the reserved tail that
+                    // arch-filtering didn't use.
+                    let written = file.stream_position().await?;
+                    if let Some(size) = size {
+                        crate::util::writeback::release_beyond(file.as_raw_fd(), written, size)
+                            .await
+                            .log_err();
+                    }
                     file.sync_all().await?;
 
                     crate::util::io::rename(&download_path, &installed_path).await?;

--- a/shared-libs/crates/start-core/src/upload.rs
+++ b/shared-libs/crates/start-core/src/upload.rs
@@ -187,7 +187,8 @@ impl UploadingFile {
             error: None,
             complete: false,
         });
-        let file = create_file(path).await?;
+        let file = create_file(&path).await?;
+        writeback::set_no_cow(&path).await;
         let multi_cursor = MultiCursorFile::open(&file).await?;
         let pacer = WritebackPacer::new(file.as_raw_fd());
         let uploading = Self {
@@ -224,7 +225,8 @@ impl UploadingFile {
             error: None,
             complete: false,
         });
-        let file = create_file(path).await?;
+        let file = create_file(&path).await?;
+        writeback::set_no_cow(&path).await;
         let multi_cursor = MultiCursorFile::open(&file).await?;
         let pacer = WritebackPacer::new(file.as_raw_fd());
         let uploading = Self {
@@ -400,7 +402,7 @@ impl AsyncSeek for UploadingFileReader {
                             (this.progress.borrow().expected_size.ok_or_else(|| {
                                 std::io::Error::new(
                                     std::io::ErrorKind::Other,
-                                    eyre!("upload maked complete without expected size"),
+                                    eyre!("upload marked complete without expected size"),
                                 )
                             })? as i64
                                 + n) as u64
@@ -449,8 +451,7 @@ impl UploadHandle {
     ) {
         let expected = self.progress.borrow().expected_size;
         if let Some(total) = expected {
-            // Reserve before setting the total so the phase spins during the reserve
-            // (which can stall on fragmented btrfs) rather than showing a frozen 0%.
+            // See set_expected_size: reserve before set_total so the phase spins.
             writeback::preallocate(self.file.as_raw_fd(), total)
                 .await
                 .log_err();
@@ -511,6 +512,23 @@ impl DownloadHandle {
             p.tracker.set_total(total);
         });
     }
+    async fn restart(&mut self) -> Result<(), Error> {
+        self.file
+            .set_len(0)
+            .await
+            .map_err(|e| Error::new(e, ErrorKind::Filesystem))?;
+        self.file
+            .seek(SeekFrom::Start(0))
+            .await
+            .map_err(|e| Error::new(e, ErrorKind::Filesystem))?;
+        self.pacer.reset();
+        self.progress.send_modify(|p| {
+            p.written = 0;
+            p.expected_size = None;
+            p.tracker.set_done(0);
+        });
+        Ok(())
+    }
     pub async fn download_from<F, Fut>(&mut self, mut next_response: F)
     where
         F: FnMut(DownloadAttemptContext) -> Fut,
@@ -540,32 +558,36 @@ impl DownloadHandle {
                 }
             };
 
-            if response.status() == StatusCode::PARTIAL_CONTENT {
-                // Resume in place: the write head and pacer offsets already sit
-                // past bytes_written, so no truncate, seek, or pacer reset.
-                if let Some(total) = parse_content_range_total(response.headers()) {
-                    self.set_expected_size(total).await;
+            let new_size = if response.status() == StatusCode::PARTIAL_CONTENT {
+                // Re-sync the write head: a failed write may have committed
+                // bytes past `bytes_written` before erroring.
+                if let Err(e) = self.file.seek(SeekFrom::Start(bytes_written)).await {
+                    break Err(Error::new(e, ErrorKind::Filesystem));
                 }
+                parse_content_range_total(response.headers())
             } else {
-                if let Err(e) = self.file.set_len(0).await {
-                    break Err(Error::new(e, ErrorKind::Filesystem));
-                }
-                if let Err(e) = self.file.seek(SeekFrom::Start(0)).await {
-                    break Err(Error::new(e, ErrorKind::Filesystem));
-                }
-                self.pacer.reset();
-                self.progress.send_modify(|p| {
-                    p.written = 0;
-                    p.tracker.set_done(0);
-                });
-                if let Some(content_length) = response
+                let content_length = response
                     .headers()
                     .get(CONTENT_LENGTH)
                     .and_then(|a| a.to_str().log_err())
-                    .and_then(|a| a.parse::<u64>().log_err())
-                {
-                    self.set_expected_size(content_length).await;
+                    .and_then(|a| a.parse::<u64>().log_err());
+                if let Err(e) = self.restart().await {
+                    break Err(e);
                 }
+                content_length
+            };
+            // A size change between attempts means the mirror's file changed
+            // mid-download. Already-consumed bytes (here and in concurrent
+            // readers) may be from another generation, so fail rather than
+            // splice them together.
+            if matches!((expected_size, new_size), (Some(prev), Some(new)) if prev != new) {
+                break Err(Error::new(
+                    eyre!("file changed on mirror mid-download"),
+                    ErrorKind::Network,
+                ));
+            }
+            if let Some(size) = new_size {
+                self.set_expected_size(size).await;
             }
 
             let stream_result: Result<(), Error> = async {

--- a/shared-libs/crates/start-core/src/util/io.rs
+++ b/shared-libs/crates/start-core/src/util/io.rs
@@ -901,7 +901,6 @@ impl TmpDir {
             ));
         }
         tokio::fs::create_dir_all(&path).await?;
-        crate::util::writeback::set_no_cow(&path).await;
         Ok(Self { path })
     }
 

--- a/shared-libs/crates/start-core/src/util/writeback.rs
+++ b/shared-libs/crates/start-core/src/util/writeback.rs
@@ -1,21 +1,25 @@
 //! Bounded-memory streaming writes for large s9pk transfers.
 //!
-//! Replaces O_DIRECT on the download/sideload path. Writes stay buffered — so
-//! the file remains seekable for mirror-resume and the concurrent archive
-//! reader keeps hitting the page cache — but writeback is paced with
-//! `sync_file_range` so dirty pages never accumulate into a multi-gigabyte
-//! final `fdatasync` that locks up the box. Paired with [`preallocate`] and
-//! [`set_no_cow`] to keep the file contiguous on CoW btrfs.
+//! Replaces O_DIRECT on the download/sideload/install path. Writes stay
+//! buffered — so the file remains seekable for mirror-resume and the
+//! concurrent archive reader keeps hitting the page cache — but writeback is
+//! paced with `sync_file_range` so dirty pages never accumulate into a
+//! multi-gigabyte final `fdatasync` that locks up the box. Paired with
+//! [`preallocate`] and [`set_no_cow`] to keep the file contiguous on CoW
+//! btrfs.
 //!
 //! Linux-only mechanics; on other targets (start-cli on macOS) pacing,
 //! preallocation, and the nodatacow hint are no-ops and the kernel's own
 //! writeback throttling bounds dirty memory.
 
-use std::os::fd::RawFd;
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::Path;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 #[cfg(target_os = "linux")]
 use tokio::process::Command;
+use tokio::task::JoinHandle;
 
 #[cfg(target_os = "linux")]
 use crate::prelude::*;
@@ -25,73 +29,96 @@ use crate::util::Invoke;
 /// Issue asynchronous writeback once this many bytes have piled up unkicked.
 #[cfg(target_os = "linux")]
 const KICK_EVERY: u64 = 16 << 20;
-/// Cap on bytes left un-durable behind the write head (bounds the final fsync).
+/// Cap on bytes left un-flushed behind the write head (bounds the final fsync).
 #[cfg(target_os = "linux")]
 const DIRTY_WINDOW: u64 = 64 << 20;
 
 /// Paces page-cache writeback for a buffered file being streamed to.
 ///
-/// Call [`pace`](Self::pace) after each write with the running byte total.
-// Fields drive the linux `sync_file_range` path; elsewhere `pace` is a no-op.
+/// Drive it either with [`pace`](Self::pace) after each write, or from an
+/// `AsyncWrite` impl via [`poll_pace`](Self::poll_pace).
+// Fields drive the linux `sync_file_range` path; elsewhere pacing is a no-op.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub struct WritebackPacer {
     fd: RawFd,
     kicked: u64,
-    durable: u64,
+    written_back: u64,
+    pending: Option<JoinHandle<std::io::Result<u64>>>,
 }
 impl WritebackPacer {
     pub fn new(fd: RawFd) -> Self {
         Self {
             fd,
             kicked: 0,
-            durable: 0,
+            written_back: 0,
+            pending: None,
         }
     }
 
     /// Reset offsets after the file is truncated back to empty (mirror restart).
+    /// Detaching an in-flight flush is harmless: its range no longer has pages.
     pub fn reset(&mut self) {
         self.kicked = 0;
-        self.durable = 0;
+        self.written_back = 0;
+        self.pending = None;
+    }
+
+    pub async fn pace(&mut self, written: u64) -> std::io::Result<()> {
+        std::future::poll_fn(|cx| self.poll_pace(cx, written)).await
     }
 
     #[cfg(target_os = "linux")]
-    pub async fn pace(&mut self, written: u64) -> std::io::Result<()> {
+    pub fn poll_pace(&mut self, cx: &mut Context<'_>, written: u64) -> Poll<std::io::Result<()>> {
+        if let Some(pending) = &mut self.pending {
+            match Pin::new(pending).poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Ok(Ok(waited_to))) => {
+                    self.pending = None;
+                    self.written_back = self.written_back.max(waited_to);
+                }
+                Poll::Ready(Ok(Err(e))) => {
+                    self.pending = None;
+                    return Poll::Ready(Err(e));
+                }
+                Poll::Ready(Err(e)) => {
+                    self.pending = None;
+                    return Poll::Ready(Err(std::io::Error::other(e)));
+                }
+            }
+        }
         if written.saturating_sub(self.kicked) < KICK_EVERY {
-            return Ok(());
+            return Poll::Ready(Ok(()));
         }
         let fd = self.fd;
         let kick_from = self.kicked;
-        let wait_from = self.durable;
-        let want_durable = written.saturating_sub(DIRTY_WINDOW);
-        tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        let wait_from = self.written_back;
+        let wait_to = written.saturating_sub(DIRTY_WINDOW);
+        self.kicked = written;
+        self.pending = Some(tokio::task::spawn_blocking(move || {
             sync_range(
                 fd,
                 kick_from,
                 written - kick_from,
                 libc::SYNC_FILE_RANGE_WRITE,
             )?;
-            if want_durable > wait_from {
+            if wait_to > wait_from {
                 sync_range(
                     fd,
                     wait_from,
-                    want_durable - wait_from,
+                    wait_to - wait_from,
                     libc::SYNC_FILE_RANGE_WAIT_BEFORE
                         | libc::SYNC_FILE_RANGE_WRITE
                         | libc::SYNC_FILE_RANGE_WAIT_AFTER,
                 )?;
             }
-            Ok(())
-        })
-        .await
-        .map_err(std::io::Error::other)??;
-        self.kicked = written;
-        self.durable = want_durable.max(self.durable);
-        Ok(())
+            Ok(wait_to)
+        }));
+        Poll::Ready(Ok(()))
     }
 
     #[cfg(not(target_os = "linux"))]
-    pub async fn pace(&mut self, _written: u64) -> std::io::Result<()> {
-        Ok(())
+    pub fn poll_pace(&mut self, _cx: &mut Context<'_>, _written: u64) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -105,6 +132,76 @@ fn sync_range(fd: RawFd, offset: u64, nbytes: u64, flags: libc::c_uint) -> std::
         Err(std::io::Error::last_os_error())
     } else {
         Ok(())
+    }
+}
+
+/// Wraps a writer and paces writeback as bytes pass through.
+#[pin_project::pin_project]
+pub struct PacedWriter<W> {
+    #[pin]
+    inner: W,
+    pacer: WritebackPacer,
+    written: u64,
+}
+impl<W: AsRawFd> PacedWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self {
+            pacer: WritebackPacer::new(inner.as_raw_fd()),
+            inner,
+            written: 0,
+        }
+    }
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+impl<W: tokio::io::AsyncWrite> tokio::io::AsyncWrite for PacedWriter<W> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.project();
+        std::task::ready!(this.pacer.poll_pace(cx, *this.written))?;
+        match this.inner.poll_write(cx, buf) {
+            Poll::Ready(Ok(n)) => {
+                *this.written += n as u64;
+                Poll::Ready(Ok(n))
+            }
+            a => a,
+        }
+    }
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.project().inner.poll_flush(cx)
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        let this = self.project();
+        std::task::ready!(this.pacer.poll_pace(cx, *this.written))?;
+        match this.inner.poll_write_vectored(cx, bufs) {
+            Poll::Ready(Ok(n)) => {
+                *this.written += n as u64;
+                Poll::Ready(Ok(n))
+            }
+            a => a,
+        }
+    }
+}
+impl<W: tokio::io::AsyncSeek> tokio::io::AsyncSeek for PacedWriter<W> {
+    fn start_seek(self: Pin<&mut Self>, position: std::io::SeekFrom) -> std::io::Result<()> {
+        self.project().inner.start_seek(position)
+    }
+    fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<u64>> {
+        self.project().inner.poll_complete(cx)
     }
 }
 
@@ -138,10 +235,49 @@ pub async fn preallocate(_fd: RawFd, _len: u64) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Free the tail of a [`preallocate`] reservation past what was actually
+/// written. Beyond-EOF reservations are otherwise kept for the life of the
+/// file. Best-effort, like `preallocate`.
+#[cfg(target_os = "linux")]
+pub async fn release_beyond(fd: RawFd, written: u64, reserved: u64) -> std::io::Result<()> {
+    if written >= reserved {
+        return Ok(());
+    }
+    let (Ok(offset), Ok(len)) = (
+        libc::off_t::try_from(written),
+        libc::off_t::try_from(reserved - written),
+    ) else {
+        return Ok(());
+    };
+    tokio::task::spawn_blocking(move || {
+        // SAFETY: fd is a valid open file descriptor owned by the caller.
+        let ret = unsafe {
+            libc::fallocate(
+                fd,
+                libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE,
+                offset,
+                len,
+            )
+        };
+        if ret == -1 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
+#[cfg(not(target_os = "linux"))]
+pub async fn release_beyond(_fd: RawFd, _written: u64, _reserved: u64) -> std::io::Result<()> {
+    Ok(())
+}
+
 /// Mark a path `nodatacow` (`chattr +C`) so writes don't fragment via CoW on
-/// btrfs. Set it on an empty file/dir (files created inside a `+C` dir inherit
-/// it) — the flag has no effect once extents exist. Best-effort: off btrfs the
-/// flag is unsupported, an expected miss logged at debug rather than as an error.
+/// btrfs. Only takes effect on an empty file, so call it right after creation,
+/// before any write or `fallocate`. Best-effort: off btrfs the flag is
+/// unsupported, an expected miss logged at debug rather than as an error.
 #[cfg(target_os = "linux")]
 pub async fn set_no_cow(path: impl AsRef<Path>) {
     let path = path.as_ref();


### PR DESCRIPTION
Follow-up cleanup/refactor of #3517 (requested post-merge). Reviewing that change surfaced a few things worth tightening — one missing half of the fix, one disk leak, and three resume-correctness edge cases.

## What

- **Pace the install/restore serialize path too.** #3517 paced the download/sideload writes but the install path still streamed the full archive to disk unpaced and ended with one multi-GB `sync_all` — the same freeze pattern on the write half of the transfer. `WritebackPacer` gains a poll-based driver and a `PacedWriter` AsyncWrite wrapper now paces the serialize output, so the bounded-dirty / cheap-final-fsync guarantee covers the whole transfer.
- **Free the unused preallocation tail.** `preallocate` reserved `s9pk.size()`, the *pre-filter* source size; for multi-arch packages serialize writes roughly half, and `FALLOC_FL_KEEP_SIZE` extents beyond EOF are not reclaimed on close — the file is renamed into `installed/` and kept for the life of the installation. `release_beyond` (`FALLOC_FL_PUNCH_HOLE | KEEP_SIZE`) frees the tail after serialize.
- **Scope `chattr +C` to the transfer files.** It was applied in `TmpDir::new()`, hitting ~11 unrelated call sites (overlayfs upperdirs, os_install unsquash targets, rpc tmp dirs) with nodatacow/nodatasum for no benefit. Now set only on `upload.tmp`/`download.tmp` and the install download file, right after creation (still before `fallocate`, so the reservation lands nodatacow).
- **Seek to `bytes_written` on 206 resume.** The resume path assumed the write head sat at `progress.written`, but a short write committed before a transient write error leaves it `k` bytes ahead — the resumed body landed shifted and, because the byte count still added up, was *accepted as complete* (only caught later as a merkle mismatch).
- **Fail on mid-download file changes.** If `Content-Length`/`Content-Range` totals disagree between attempts, the mirror's file changed under us. Restarting is not safe: concurrent read-while-write readers have already consumed bytes from the old generation and cannot recover, so the download now fails loudly (`file changed on mirror mid-download`) instead of splicing two generations. Same-content mirror fallback is unaffected.
- **Clear stale `expected_size` on full restarts** — a retry response without `Content-Length` previously inherited the previous attempt's total, producing spurious size-mismatch errors.

## Testing

- `cargo check -p start-core` clean; pinned-nightly `make start-core-format-check` clean.
- All 6 `registry::asset::tests::buffered_download_*` pass, including the new `buffered_download_fails_when_mirror_file_changes` regression test (raw-TCP stub serves a 206 whose total contradicts the first 200; asserts the download errors instead of splicing) and the pre-existing resume/fallback/read-while-write tests.
- Linux-only mechanics remain cfg-gated with non-Linux no-ops, so the darwin/musl matrix should be unaffected.

No changelog change: this refines the s9pk-transfer entry that shipped (unreleased) with #3517 under `0.4.0-beta.10`; its wording already covers these mechanics.