### PR TITLE
fix(registry): stub manifest alerts for pre-beta.10 clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7888,7 +7888,7 @@ dependencies = [
 
 [[package]]
 name = "start-registry"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "start-core",
 ]

--- a/projects/start-registry/CHANGELOG.md
+++ b/projects/start-registry/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `start-registry` (the Start Registry server) are documented here. This project is versioned **independently** (starting at `1.0.0`); its version lives in `Cargo.toml`. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.1]
+
+- **Registry responses stay compatible with pre-beta.10 clients.** `package.get` re-adds a
+  stubbed (empty-object) manifest `alerts` field for clients older than StartOS `0.4.0-beta.10`,
+  which require it present (`alerts` was removed from the manifest in beta.10). Removed the
+  long-dead `0.4.0-alpha.17`/`alpha.18` client-compatibility shims.
+
 ## [1.0.0]
 
 - **Signer/admin authentication moved to the new request-signature scheme.** Every authenticated

--- a/projects/start-registry/Cargo.toml
+++ b/projects/start-registry/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-registry"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "1.0.0"                                               # VERSION_BUMP
+version = "1.0.1"                                               # VERSION_BUMP
 
 [[bin]]
 name = "registrybox"

--- a/shared-libs/crates/start-core/src/registry/device_info.rs
+++ b/shared-libs/crates/start-core/src/registry/device_info.rs
@@ -73,14 +73,7 @@ impl DeviceInfo {
                 language: query
                     .get("os.language")
                     .map(|v| v.deref())
-                    .map(InternedString::intern)
-                    .or_else(|| {
-                        if version < "0.4.0-alpha.18".parse().ok()? {
-                            Some(rust_i18n::locale().deref().into())
-                        } else {
-                            None
-                        }
-                    }),
+                    .map(InternedString::intern),
                 version,
             },
             hardware: has_hw_info
@@ -138,20 +131,14 @@ impl DeviceInfo {
         &self,
         versions: &mut Model<BTreeMap<VersionString, PackageVersionInfo>>,
     ) -> Result<(), Error> {
-        let alpha_17: Version = "0.4.0-alpha.17".parse()?;
+        let beta_10: Version = "0.4.0-beta.10".parse()?;
 
-        // Filter package versions using for_device
         versions.retain(|_, info| info.for_device(self))?;
 
-        // Alpha.17 compatibility: add legacy fields
-        if self.os.version <= alpha_17 {
+        // beta.10 dropped the manifest `alerts` field; older clients require it present.
+        if self.os.version < beta_10 {
             for (_, info) in versions.as_entries_mut()? {
-                let v = info.as_value_mut();
-                if let Some(mut tup) = v["s9pks"].get(0).cloned() {
-                    v["s9pk"] = tup[1].take();
-                    v["hardwareRequirements"] = tup[0].take();
-                    v["s9pk"]["url"] = v["s9pk"]["urls"][0].clone();
-                }
+                info.as_value_mut()["alerts"] = imbl_value::json!({});
             }
         }
 
@@ -171,31 +158,10 @@ impl DeviceInfo {
     }
 
     fn filter_os_version(&self, res: &mut Model<OsVersionInfoMap>) -> Result<(), Error> {
-        let alpha_17: Version = "0.4.0-alpha.17".parse()?;
-
-        // Filter OS versions based on source_version compatibility
         res.retain(|_, info| {
             let source_version = info.as_source_version().de()?;
             Ok(self.os.version.satisfies(&source_version))
-        })?;
-
-        // Alpha.17 compatibility: add url field from urls array
-        if self.os.version <= alpha_17 {
-            for (_, info) in res.as_entries_mut()? {
-                let v = info.as_value_mut();
-                for asset_ty in ["iso", "squashfs", "img"] {
-                    for (_, asset) in v[asset_ty]
-                        .as_object_mut()
-                        .into_iter()
-                        .flat_map(|o| o.iter_mut())
-                    {
-                        asset["url"] = asset["urls"][0].clone();
-                    }
-                }
-            }
-        }
-
-        Ok(())
+        })
     }
 }
 


### PR DESCRIPTION
## What

The registry's `DeviceInfoMiddleware` still rewrites `package.get` / `os.version.get` responses based on the requesting client's `os.version`. This swaps the two long-dead `0.4.0-alpha.17`/`alpha.18` compatibility shims for a single **pre-`0.4.0-beta.10`** shim that stubs the manifest `alerts` field.

`alerts` was removed from the manifest in beta.10 (`feat!: remove package alerts`, 78dc643), but the pre-beta.10 `PackageVersionInfo` binding declares `alerts` as a required field, so older clients fail to parse `package.get` from a current registry when it's absent. The shim re-adds an empty-object stub, which is enough for those clients to accept the response:

```json
"alerts": {}
```

## Changes

- `shared-libs/crates/start-core/src/registry/device_info.rs`
  - `filter_package_versions`: drop the alpha.17 legacy `s9pk`/`hardwareRequirements` back-fill; add the `< 0.4.0-beta.10` `alerts` stub (`{}`).
  - `filter_os_version`: drop the alpha.17 `url`-from-`urls` back-fill (now just the compat filter).
  - `from_header_value`: drop the `< 0.4.0-alpha.18` `os.language` fallback.
- `projects/start-registry`: `## [1.0.1]` changelog entry + `Cargo.toml`/`Cargo.lock` bump (1.0.0 is already tagged `start-registry/v1.0.0`).

## Verification

- `cargo check -p start-core` — clean
- `cargo check -p start-registry` — clean (`registrybox`)
- `cargo test -p start-core check_matching_info --features=test` — passes
- `cargo fmt -p start-core -- --check` — clean

Note: the `< beta.10` gate also covers all 0.3.x / earlier clients, so any pre-beta.10 client gets the stub.