### PR TITLE
fix(login): stop showing spurious "Value is invalid" on the login form

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/login/login.page.ts
+++ b/projects/start-os/web/ui/src/app/routes/login/login.page.ts
@@ -38,7 +38,7 @@ import { ConfigService } from 'src/app/services/config.service'
             />
             <tui-icon tuiPassword />
           </tui-textfield>
-          <tui-error [error]="error() || authError() | i18n" />
+          <tui-error [error]="(error() || authError() | i18n) || null" />
           <button tuiButton size="m" [loading]="loading()">
             {{ 'Login' | i18n }}
           </button>


### PR DESCRIPTION
## What

The StartOS login form displays **"Value is invalid"** under the password field on every fresh page load, even though login works normally.

## Why

The `<tui-error>` on the login page is bound to:

```html
<tui-error [error]="error() || authError() | i18n" />
```

On a fresh page both `error()` and `authError()` are `null`, so the expression is `null`. The `i18n` pipe maps `null` → `''` (empty string) — its normal behavior for interpolation. But Taiga's `<tui-error>` treats **any string input, even `''`, as "an error is present"**:

- `content = tuiIsString('') ? new TuiValidationError('') : …` → a *truthy* object, so `@if (content())` renders
- it then shows `error.message || default()`; `error.message` is `''` (falsy) → falls back to `TUI_DEFAULT_ERROR_MESSAGE`, whose English default is literally `"Value is invalid"`

Login itself works because the password field is a standalone `ngModel` with no validators — nothing actually failed. The message is purely Taiga's default-message fallback being triggered by an empty string.

This is a regression from #3526: the binding used to be `[error]="error() || null"` (a real `null` → no message, no pipe). #3526 added the `| i18n` pipe to translate the real error messages but dropped the `|| null` guard, so the `null` became `''` and tripped the default.

## Fix

Guard the piped value so an empty translation collapses back to `null`:

```html
<tui-error [error]="(error() || authError() | i18n) || null" />
```

Real error keys translate to non-empty strings (still shown); the no-error case yields `''` → `null` → nothing rendered. The `(… | pipe) || fallback` shape is already used elsewhere in the UI.

## Notes

- No changelog entry: both the regression (#3526) and this fix are unreleased in the `0.4.0-beta.10` line, so no released StartOS ever showed the message.
- No docs change: no user-facing doc references the login error text.

## Testing

- `npm run check:ui` — clean (after rebuilding the stale local `@start9labs/start-core` dist)
- `ng run ui:build:development` — AoT template compile succeeds, validating the new expression