### PR TITLE
fix(web): keep password-manager icons off password-field controls

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/login/login.page.ts
+++ b/projects/start-os/web/ui/src/app/routes/login/login.page.ts
@@ -68,7 +68,7 @@ import { ConfigService } from 'src/app/services/config.service'
 
     [tuiCardLarge] {
       overflow: visible;
-      width: max(33%, 22rem);
+      width: min(30rem, 100%);
       background: var(--start9-base-1);
     }
 

--- a/projects/start-wrt/web/src/styles.scss
+++ b/projects/start-wrt/web/src/styles.scss
@@ -361,3 +361,19 @@ tui-data-list [tuiOption]:disabled {
     }
   }
 }
+
+// Password managers (Bitwarden & co.) anchor their injected autofill icon to
+// the input's border-box, which spans the full textfield — landing the icon on
+// top of the field's trailing control (reveal eye, in-field button) and
+// swallowing its clicks. Trading the end padding for margin keeps the text box
+// identical while ending the input's box before that control, so injected icons
+// sit beside it instead of on top. Matching tuiPassword and not only the type
+// keeps this stable while the password is revealed, when the directive swaps
+// the input's type to text.
+tui-textfield:has(tui-icon[tuiPassword], input[type='password'])
+  input[tuiInput] {
+  padding-inline-end: 0;
+  margin-inline-end: calc(
+    var(--t-end) + var(--t-side) + var(--t-padding) + var(--t-space)
+  );
+}

--- a/shared-libs/ts-modules/shared/styles/shared.scss
+++ b/shared-libs/ts-modules/shared/styles/shared.scss
@@ -57,6 +57,22 @@ a {
   text-decoration: none;
 }
 
+// Password managers (Bitwarden & co.) anchor their injected autofill icon to
+// the input's border-box, which spans the full textfield — landing the icon on
+// top of the field's trailing control (reveal eye, in-field button) and
+// swallowing its clicks. Trading the end padding for margin keeps the text box
+// identical while ending the input's box before that control, so injected icons
+// sit beside it instead of on top. Matching tuiPassword and not only the type
+// keeps this stable while the password is revealed, when the directive swaps
+// the input's type to text.
+tui-textfield:has(tui-icon[tuiPassword], input[type='password'])
+  input[tuiInput] {
+  padding-inline-end: 0;
+  margin-inline-end: calc(
+    var(--t-end) + var(--t-side) + var(--t-padding) + var(--t-space)
+  );
+}
+
 // Global utility classes the shared @start9labs/marketplace lib relies on.
 // They live here (loaded by every host) rather than in a single app's
 // stylesheet so the lib's components render identically across the OS UI and


### PR DESCRIPTION
Password managers that inject an inline autofill icon (Bitwarden's inline menu et al.) anchor it to the focused input's border-box. Taiga absolutely-positions a textfield's native input across the whole field, so the injected icon renders exactly on top of the field's trailing control and swallows its clicks — the password-reveal eye on the StartOS login and setup password fields, and the in-field Login button on the StartTunnel and StartWRT logins. With Bitwarden active, clicking the eye on the StartOS login page was a no-op; it only worked on a fresh load, before anything triggered the inline menu.

Replayed against Bitwarden's own positioning math (`overlay.background.ts` `getInlineMenuButtonPosition`), its button lands at x 749–779 over an eye spanning x 752–776 on the login page.

The fix swaps the input's end padding for an equal margin on password fields. The text box is pixel-identical — screenshot-diffed before/after with zero differing pixels — but the input's border-box now ends before the trailing control, so injected icons land beside it (x 713–743) instead of on top. Clicks in the vacated strip still focus the input via `.t-content`'s own `pointerdown` handler, and the eye/button remain fully clickable.

### Scoping

The rule is deliberately narrow — `:has(tui-icon[tuiPassword], input[type='password'])`, not "any textfield with trailing content". Taiga's cleaner button defaults to on and renders inside `.t-content`, so the looser form matched nearly every input in the fleet and silently rewrote the box model on inputs that have no autofill problem (including masked fields, whose `.t-filler` sibling has to stay aligned with the input's text box).

Matching the `tuiPassword` directive and not only the type is load-bearing: `TuiPassword.toggle()` swaps the input's `type` to `text` on reveal, so a type-only selector would drop the override mid-reveal — jumping the layout and putting the icon back over the eye exactly when the password is visible. Verified: no layout jump across the toggle.

### Verification

- StartOS login — Bitwarden anchor CLEAR of the eye, both hidden and revealed, no layout jump.
- StartTunnel login — the `[type=password]`-only branch (trailing button, no eye): anchor clear, long text stops cleanly before the button, no clipping.
- Unrelated fields untouched — a plain textfield keeps Taiga's `56px` end padding, rule not applied.
- Chromium, Firefox and WebKit; dev serve, prod bundle, and a live box. `check:ui` clean; `build:wrt` clean.

Applied once in `shared.scss` (StartOS UI, setup wizard, StartTunnel) and mirrored in StartWRT's standalone stylesheet. The StartOS login card also widens `max(33%, 22rem)` → a fixed `min(30rem, 100%)`, since the old formula sat on its 22rem floor at ordinary desktop widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)