### PR TITLE
docs(tunnel): expand IPv6 guidance and add an IPv4 page

### DIFF
--- a/projects/start-os/docs/src/gateways.md
+++ b/projects/start-os/docs/src/gateways.md
@@ -15,6 +15,9 @@ Every gateway routes outbound traffic from your server to the Internet. Some gat
 - **Outbound only** — routes outbound traffic but does not accept inbound connections. Commercial VPN providers (Mullvad, ProtonVPN, etc.) are outbound-only gateways. These are used as [outbound VPNs](outbound-vpn.md).
 
 > [!NOTE]
+> A StartTunnel gateway can also carry IPv6. If the tunnel subnet your server belongs to has an [IPv6 prefix delegated](/start-tunnel/ipv6.html), your server receives its own global IPv6 address (GUA) through the gateway — usable for [DualStack public domains](clearnet.md) and controlled from each interface's address list (see [Interfaces](interfaces.md)).
+
+> [!NOTE]
 > If you are running StartOS on a VPS with a public IP address, there is no router gateway. Your server's network interface is directly exposed to the Internet.
 
 > [!WARNING]

--- a/projects/start-tunnel/docs/src/SUMMARY.md
+++ b/projects/start-tunnel/docs/src/SUMMARY.md
@@ -17,6 +17,7 @@
 - [Published Ports](published-ports.md)
 - [HTTP Redirects](http-redirects.md)
 - [IPv6](ipv6.md)
+- [IPv4](ipv4.md)
 - [DNS Records](dns-records.md)
 - [Updating](updating.md)
 - [Uninstalling](uninstalling.md)

--- a/projects/start-tunnel/docs/src/devices.md
+++ b/projects/start-tunnel/docs/src/devices.md
@@ -24,6 +24,9 @@ Every device on a StartTunnel subnet gets its own WireGuard configuration. Devic
    - **Phone or tablet**: Scan the QR code shown in StartTunnel using the [WireGuard app](https://www.wireguard.com/install/).
    - **Laptop or desktop**: Download the config and import it into the [WireGuard app](https://www.wireguard.com/install/).
 
+> [!NOTE]
+> The config's `Endpoint` — the address the device connects to — is the device's [outbound IP](#outbound-ip) if one is assigned (otherwise its subnet's); with neither assigned, StartTunnel uses the address you are accessing it over. The server answers on all of its addresses, so configs generated earlier keep working if you change these later.
+
 ## Server capabilities
 
 A Server has two independently-toggleable capabilities, shown as switches in the Servers table:
@@ -39,7 +42,11 @@ Use a device's actions menu to **Change to Server** or **Change to Client**. Cha
 
 ## Outbound IP
 
-By default a device's outbound traffic leaves from its subnet's [outbound IP](/start-tunnel/subnets.html#outbound-ip). On a VPS with more than one public IPv4 address, you can override this per device with the **WAN IP** field in the device's Add/Edit dialog — choose **Subnet default** to inherit the subnet's setting (the address it resolves to is shown in parentheses), or a specific address to pin this device's egress. On a single-IP VPS there is only one choice, so leave it on **Subnet default**.
+By default a device's outbound traffic leaves from its subnet's [outbound IP](/start-tunnel/subnets.html#outbound-ip). On a VPS with more than one public IPv4 address, you can override this per device with the **WAN IP** field in the device's Add/Edit dialog — choose **Subnet default** to inherit the subnet's setting (the address it resolves to is shown in parentheses), or a specific address to pin this device's egress. On a single-IP VPS there is only one choice, so leave it on **Subnet default**. To add another public IPv4 address to your VPS, see [IPv4](/start-tunnel/ipv4.html).
+
+## IPv6
+
+If a device's subnet carries an [IPv6 prefix](/start-tunnel/ipv6.html), the device gets its own stable, globally-routable IPv6 address, shown in the **IPv6** column of the Servers and Clients tables. The address is computed from the prefix and the device's tunnel IP, so it never changes. It is the address to use when opening a pinhole from the CLI or adding a manual **AAAA** record on the [DNS Records](/start-tunnel/dns-records.html) page.
 
 ## Removing a Device
 

--- a/projects/start-tunnel/docs/src/faq.md
+++ b/projects/start-tunnel/docs/src/faq.md
@@ -49,13 +49,13 @@ StartTunnel is designed to run on a dedicated VPS. To remove it, simply destroy 
 Any provider that offers Debian 13 with root access and a **dedicated public IPv4 address**. Common choices include Hetzner, DigitalOcean, Linode, Vultr, and OVH. Budget VPS providers (~$5/mo) work fine — StartTunnel has minimal resource requirements.
 
 > [!WARNING]
-> StartTunnel's published ports (clearnet hosting) require a dedicated public IPv4 address. Shared IPv4 addresses (CGNAT, shared NAT, load-balanced IPs) will not work. Some budget providers and IPv6-only tiers do not include a dedicated IPv4 — confirm with your provider before purchasing.
+> StartTunnel's IPv4 published ports (clearnet hosting) require a dedicated public IPv4 address. Shared IPv4 addresses (CGNAT, shared NAT, load-balanced IPs) will not work. Some budget providers and IPv6-only tiers do not include a dedicated IPv4 — confirm with your provider before purchasing.
 
 Some providers (AWS, Google Cloud, Azure, Oracle Cloud, IONOS) have cloud-panel firewalls that block WireGuard (UDP 51820) by default. See [Installing — Cloud firewalls](installing.md#cloud-firewalls) for setup instructions.
 
 ## Does StartTunnel work on an IPv6-only VPS?
 
-Partially. The WireGuard tunnel itself works over IPv6, so devices with IPv6 connectivity can join your private VPN and reach each other through the VPS. However, **published ports for clearnet hosting are IPv4-only** and cannot be used on an IPv6-only VPS. Additionally, any device joining the VPN must have IPv6 connectivity on its current network — most modern carriers and home ISPs are dual-stack, but some are still IPv4-only. For clearnet hosting, choose a VPS with a dedicated public IPv4 address.
+It isn't designed to. StartTunnel assumes a dedicated public IPv4 address; its IPv6 support gives the devices on a subnet their own global IPv6 addresses on top of that, rather than running the tunnel without IPv4. The VPN itself can come up over IPv6, so a device can still join and reach others through the VPS — but only from a network that has IPv6 (most carriers and home ISPs are dual-stack, though some are still IPv4-only). Clearnet hosting expects a public IPv4 too: IPv4 published ports require one, and while a device can also be published over IPv6 (see [IPv6](ipv6.md)), only visitors that themselves have IPv6 can reach it. For clearnet hosting that anyone can reach, choose a VPS with a dedicated public IPv4 address.
 
 ## Does StartTunnel provide DDoS protection?
 

--- a/projects/start-tunnel/docs/src/installing.md
+++ b/projects/start-tunnel/docs/src/installing.md
@@ -32,6 +32,9 @@ Rent a cheap VPS with a dedicated public IP. Minimum CPU/RAM/disk is fine. For b
 > [!WARNING]
 > Publishing ports requires a **dedicated public IPv4 address** assigned to your VPS. Shared IPv4 addresses (CGNAT, shared NAT, or load-balanced IPs) will not work. IPv6-only VPSes will not work for clearnet hosting either — see [Can I use an IPv6-only VPS?](faq.md#does-starttunnel-work-on-an-ipv6-only-vps) in the FAQ. Confirm with your VPS provider that the IPv4 address is dedicated to your VM before purchasing.
 
+> [!TIP]
+> Thinking about IPv6? It's optional, and you configure it per subnet after installing (see [IPv6](ipv6.md)) — but the easiest time to arrange it is server creation: enable IPv6 if your provider offers it as an option, and note the size of the block they route to your VPS. Adding it to an existing server often takes extra host-side configuration.
+
 ### Cloud firewalls
 
 Some VPS providers have a **cloud-panel firewall** that sits outside the operating system. This firewall can silently block WireGuard traffic (UDP 51820) before it ever reaches your VPS, even if the OS firewall is correctly configured. If your provider is listed below, you must open UDP 51820 in the cloud panel **before** devices can connect.

--- a/projects/start-tunnel/docs/src/ipv4.md
+++ b/projects/start-tunnel/docs/src/ipv4.md
@@ -1,0 +1,53 @@
+# IPv4
+
+StartTunnel uses your VPS's public IPv4 addresses for clearnet hosting and
+outbound traffic. The one dedicated address required at install time is all
+most users need — this page covers adding **more**. Each additional address is
+a full, independent public identity with its own port space.
+
+## Why add an address
+
+- **A separate egress identity.** Point a subnet — or a single device — at its
+  own address, so its outbound traffic is distinguishable from everything else
+  on the tunnel.
+- **A second port space.** Over IPv4, an external port can carry only one plain
+  forward per address (SNI hostnames on one TLS port being the exception). A
+  second address lets two devices each claim, say, port `443` outright.
+
+## Getting an address onto your VPS
+
+Ordering an extra IPv4 attaches it to your server, but does not necessarily
+configure it: the network configuration a provider applies at a server's first
+boot covers what existed then, and secondary addresses are typically not handed
+out by DHCP afterwards. Until the address is actually configured on the host's
+interface, StartTunnel cannot see it. Your provider's docs are the authority
+for both steps — ordering the address, and configuring it on an existing
+Debian server. `ip addr` on the VPS shows what the host holds; the new address
+must appear there.
+
+## Using it in StartTunnel
+
+StartTunnel picks up the host's public IPv4 addresses automatically — no
+restart needed. Once the host holds the new address, it shows up:
+
+- as a choice in the **WAN IP** selectors, to be assigned as a subnet's
+  [outbound IP](subnets.md#outbound-ip) or a single device's
+  [override](devices.md#outbound-ip);
+- in **Settings → HTTP Redirect (80 → 443)**, with a port-80 HTTP→HTTPS
+  redirect of its own, on by default — see
+  [HTTP Redirects](http-redirects.md).
+
+Assigning the address moves that subnet's or device's egress onto it, and a
+device's [published ports](published-ports.md) follow: their external IP is
+always the device's effective WAN. Configs generated afterwards use it as
+their `Endpoint`; existing device configs keep working, because the server
+answers on all of its addresses.
+
+## Verifying
+
+- `ip addr` on the VPS lists the new address — the provider-side and host-side
+  setup is done.
+- The address appears in the **WAN IP** selector of the subnet and device
+  dialogs — StartTunnel has detected it.
+- After assigning it, an IP-echo site visited from a device on that subnet
+  reports the new address — egress is moved.

--- a/projects/start-tunnel/docs/src/ipv6.md
+++ b/projects/start-tunnel/docs/src/ipv6.md
@@ -7,11 +7,17 @@ default; IPv4 published ports work without it.
 
 ## What your VPS provides
 
-IPv6 addressing depends on the block your provider routes to your VPS. Most
-budget providers give a single **/64** (Hetzner, Vultr, BuyVM); some give less
-(DigitalOcean routes a /124 — 16 addresses); a few give a **/56** or larger on
-request (Linode) or on dedicated servers. Check your provider's dashboard or
-docs for the exact prefix. A **/64 per subnet** is the natural fit.
+IPv6 addressing depends on the block your provider routes to your VPS, and
+providers vary widely. Most route a single **/64** to each server; some route
+only a small slice of one (a /124 holds 16 addresses); larger blocks (a /56 or
+more) are often available, but only on request. Delivery varies too: usually
+the block is **on-link** (your server holds an address inside it on its WAN
+interface), less commonly it is **routed** to your server as a separate block.
+And IPv6 is not always on to begin with — many providers gate it behind an
+option at server creation or a toggle in their panel. Your provider's
+docs/guides — or their support team — are the authority: confirm whether IPv6
+must be enabled, the exact block you get, and how it is delivered. A
+**/64 per subnet** is the natural fit.
 
 ## Requirements
 
@@ -32,6 +38,15 @@ Delegating a prefix only works if the server can actually route it:
   but logs a warning: make sure your provider actually routes the block to this
   host, or the subnet's devices will have no working IPv6.
 
+> [!NOTE]
+> "Enabled with the provider" is not the same as "configured on the host". A
+> provider's IPv6 option typically takes effect through the provisioning that
+> runs at a server's first boot — flip it on an existing server and the panel
+> may say enabled while the host still has no IPv6 address or route, because
+> that provisioning already ran. If `ip -6 route show default` prints nothing
+> after enabling IPv6, configure the address and gateway per your provider's
+> docs, or rebuild the server with IPv6 enabled from the start.
+
 ## Configuring a subnet's prefix
 
 Assign the routed prefix your provider gave you to a subnet:
@@ -47,6 +62,29 @@ To turn IPv6 back off for a subnet, run the command with no `--prefix` argument
 Once set, StartTunnel re-renders the WireGuard configs of that subnet's devices
 to include an IPv6 address. Reconnect (or re-download the config) on each device
 to pick it up.
+
+## Verifying it works
+
+Devices keep their old configuration until refreshed, so after setting a
+prefix, re-import the config (or reconnect) on each device first. Then visit an
+IPv6 connectivity test site from the device: it should report the device's
+tunnel IPv6 — the same address the Devices table shows for it, since there is
+no NAT. If it does, IPv6 works end to end.
+
+When it doesn't:
+
+- **`set-ipv6` refused with "no IPv6 connectivity"** — the server itself has no
+  IPv6 default route. Fix the VPS's own IPv6 first (see Requirements above).
+- **`set-ipv6` warned that the prefix is not on-link** — StartTunnel could not
+  confirm the block reaches this server. If devices then get an address but no
+  connectivity, your provider likely is not routing the block to this host —
+  take it up with them.
+- **A device has no IPv6 address, or a test site shows its native address** —
+  the device is still running a config generated before the prefix was set.
+  Re-import it and reconnect.
+- **Outbound IPv6 works, but the device can't be reached from outside** — by
+  design: unsolicited inbound needs a published port (a pinhole on the device's
+  address). See [Published Ports](./published-ports.md).
 
 > [!NOTE]
 > Devices can make **outbound** IPv6 connections and receive their replies. To
@@ -74,7 +112,8 @@ a smaller block works too but keeps only its low host bits of the IPv4. Every
 host must get a distinct address, so if a block is too small — or two devices'
 low IP bits would collide — StartTunnel rejects adding the device or setting the
 prefix rather than hand out a duplicate. Keep the number of devices (and their
-low IP bits) within what the block can hold.
+low IP bits) within what the block can hold. (The Add Device dialog helps: the
+IP it suggests already avoids colliding addresses.)
 
 ## Routing
 

--- a/projects/start-tunnel/docs/src/subnets.md
+++ b/projects/start-tunnel/docs/src/subnets.md
@@ -28,7 +28,7 @@ If your VPS has more than one public IPv4 address, you can choose which one a su
 - **System default** — let StartTunnel choose (masquerade through the server's primary address). When the address it resolves to is known, it's shown in parentheses, e.g. `System default (203.0.113.10)`.
 - A specific address — pin egress to one of the VPS's detected public IPv4 addresses.
 
-A single-IP VPS has only one choice, so you can leave this on **System default**. Individual devices can override their subnet's choice — see [Devices › Outbound IP](/start-tunnel/devices.html#outbound-ip).
+A single-IP VPS has only one choice, so you can leave this on **System default**. Individual devices can override their subnet's choice — see [Devices › Outbound IP](/start-tunnel/devices.html#outbound-ip). To add another public IPv4 address to your VPS, see [IPv4](/start-tunnel/ipv4.html).
 
 ## IPv6
 


### PR DESCRIPTION
## What & why

The per-subnet IPv6 feature shipped in 1.1.0 with docs covering its own
surface, but not the parts that live outside the repo or across the book: the
provider-side realities of getting IPv6 onto a VPS, how to verify it end to
end, and the sibling "I added an IPv4 later" journey. This fills those gaps and
corrects two pages that still described clearnet hosting as IPv4-only — false
since IPv6 pinhole publishing landed in 1.1.0.

Every behavior claim was verified against the StartTunnel source
(`shared-libs/crates/start-core/src/tunnel/`) or the running UI — not from
memory or other docs. The whole book was built locally (mdBook 0.5.2 +
mdbook-tabs 0.3.4) and each changed page viewed rendered.

## Changes

**StartTunnel book**
- **FAQ** — rewrite "Does StartTunnel work on an IPv6-only VPS?", which claimed
  clearnet hosting was IPv4-only. Reframed around design intent: StartTunnel
  assumes a public IPv4, and IPv6 gives devices their own global addresses on
  top of that.
- **IPv6** — generalize the "what your VPS provides" guidance (behavior
  classes, no per-provider walkthroughs), add an "enabling IPv6 with a provider
  ≠ configuring it on the host" note, and add a "Verifying it works" section
  that maps each failure to its cause.
- **Devices** — document the IPv6 column (each device's stable, computed GUA —
  the address used for pinholes and AAAA records) and how a config's `Endpoint`
  is chosen.
- **Installing** — add a tip to arrange IPv6 at server-creation time, when it's
  easiest.
- **IPv4** (new page) — adding another public IPv4 to the VPS and putting it to
  use (egress identity, published ports, the per-IP redirect), including that a
  provider attaching an address ≠ the host being configured with it.
- Cross-links from Subnets and Devices; new SUMMARY entry.

**StartOS book**
- **Gateways** — note that a StartTunnel gateway whose subnet has a delegated
  IPv6 prefix gives the server its own global IPv6 address (usable for
  DualStack domains), linking the tunnel IPv6 page and Interfaces.

## Notes
- Docs-only — no behavior change, so no CHANGELOG entry (the repo's changelog
  rule binds behavior changes).
- Rebased on current master, which includes the 1.2.0 signature-auth work. That
  change doesn't touch `show_config`, so the `Endpoint`-selection behavior the
  Devices note describes is unchanged.
