### PR TITLE
docs(tunnel): document minimal/Lite-image installer prerequisites

### DIFF
--- a/projects/start-tunnel/README.md
+++ b/projects/start-tunnel/README.md
@@ -61,6 +61,10 @@ End users install a release build with the hosted script:
 curl -fsSL https://start9.com/start-tunnel/install.sh | sudo bash
 ```
 
+On minimal or "Lite" Debian images, first install the base utilities the
+installer needs: `apt-get install -y curl iputils-ping` (see
+[Minimal or "Lite" images](docs/src/installing.md#minimal-or-lite-images)).
+
 See [docs/src/installing.md](docs/src/installing.md) for the full walkthrough
 (VPS requirements, login, creating your first subnet and device).
 

--- a/projects/start-tunnel/docs/src/faq.md
+++ b/projects/start-tunnel/docs/src/faq.md
@@ -53,6 +53,17 @@ Any provider that offers Debian 13 with root access and a **dedicated public IPv
 
 Some providers (AWS, Google Cloud, Azure, Oracle Cloud, IONOS) have cloud-panel firewalls that block WireGuard (UDP 51820) by default. See [Installing — Cloud firewalls](installing.md#cloud-firewalls) for setup instructions.
 
+## The installer says "No internet connectivity detected", but my network works
+
+Some minimal or "Lite" VPS images ship without `ping` (and sometimes `curl`), which the installer uses to check connectivity. Without `ping`, that check misfires and the installer aborts with a misleading connectivity error. Install the base utilities over SSH, then re-run the installer:
+
+```bash
+apt-get update && apt-get install -y curl iputils-ping
+curl -sSL https://start9.com/start-tunnel/install.sh | sh
+```
+
+See [Installing — Minimal or "Lite" images](installing.md#minimal-or-lite-images).
+
 ## Does StartTunnel work on an IPv6-only VPS?
 
 It isn't designed to. StartTunnel assumes a dedicated public IPv4 address; its IPv6 support gives the devices on a subnet their own global IPv6 addresses on top of that, rather than running the tunnel without IPv4. The VPN itself can come up over IPv6, so a device can still join and reach others through the VPS — but only from a network that has IPv6 (most carriers and home ISPs are dual-stack, though some are still IPv4-only). Clearnet hosting expects a public IPv4 too: IPv4 published ports require one, and while a device can also be published over IPv6 (see [IPv6](ipv6.md)), only visitors that themselves have IPv6 can reach it. For clearnet hosting that anyone can reach, choose a VPS with a dedicated public IPv4 address.

--- a/projects/start-tunnel/docs/src/installing.md
+++ b/projects/start-tunnel/docs/src/installing.md
@@ -35,6 +35,19 @@ Rent a cheap VPS with a dedicated public IP. Minimum CPU/RAM/disk is fine. For b
 > [!TIP]
 > Thinking about IPv6? It's optional, and you configure it per subnet after installing (see [IPv6](ipv6.md)) — but the easiest time to arrange it is server creation: enable IPv6 if your provider offers it as an option, and note the size of the block they route to your VPS. Adding it to an existing server often takes extra host-side configuration.
 
+### Minimal or "Lite" images
+
+Some providers ship minimal or "Lite" Debian 13 images that omit base utilities the installer needs — notably `curl` (used to download the installer) and `ping` (used to check connectivity). On these, the [installer command](#run-the-installer) fails with `curl: command not found`, or the installer aborts partway with a misleading `No internet connectivity detected` error even though the network is fine.
+
+After connecting over SSH, install the base packages first, then run the installer:
+
+```bash
+apt-get update && apt-get install -y curl iputils-ping
+curl -sSL https://start9.com/start-tunnel/install.sh | sh
+```
+
+This has been reported on mynymbox.io's Debian 13 "Lite" image, but can affect any minimal image.
+
 ### Cloud firewalls
 
 Some VPS providers have a **cloud-panel firewall** that sits outside the operating system. This firewall can silently block WireGuard traffic (UDP 51820) before it ever reaches your VPS, even if the OS firewall is correctly configured. If your provider is listed below, you must open UDP 51820 in the cloud panel **before** devices can connect.
@@ -138,6 +151,9 @@ Run:
 ```bash
 curl -sSL https://start9.com/start-tunnel/install.sh | sh
 ```
+
+> [!NOTE]
+> If this fails with `curl: command not found` or a misleading `No internet connectivity detected` error, your VPS image is missing base utilities — see [Minimal or "Lite" images](#minimal-or-lite-images).
 
 > [!NOTE]
 > If DNS resolution is not working on your VPS, the installer will configure public DNS resolvers (Google, Cloudflare, Quad9) and back up your existing `/etc/resolv.conf`.


### PR DESCRIPTION
## What

Documents a support finding: some VPS providers (reported on **mynymbox.io**'s Debian 13 "Lite" image) ship stripped-down images missing base utilities the StartTunnel installer needs. Setup fails with no clear guidance until the user installs the missing packages by hand.

## Why it fails

Confirmed by reading the live installer (`https://start9.com/start-tunnel/install.sh`):

- **`curl`** — the documented one-liner is `curl -sSL … | sh`, so a curl-less image can't even fetch the installer (`curl: command not found`). The script *does* self-install curl in `check_dependencies()`, but that only helps if you already got the script onto the box another way.
- **`ping`** — the installer's `check_dns()` shells out to `ping deb.debian.org`, then `ping 1.1.1.1`/`8.8.8.8`. With no `ping` binary, all three fail and it aborts with the **misleading** `No internet connectivity detected. Please check network connection` — even though the network is fine. There is no install-ping fallback (unlike curl).

## The fix (community-verified)

Install the base utilities over SSH before running the installer:

```bash
apt-get update && apt-get install -y curl iputils-ping
```

(The finding used `inetutils-ping`; both provide `/usr/bin/ping`. This PR recommends Debian's default `iputils-ping`.)

## Changes

- **`docs/src/installing.md`** — new "Minimal or \"Lite\" images" subsection under *Get a VPS*, plus a pointer `[!NOTE]` right at *Run the installer* (where the failure actually surfaces).
- **`docs/src/faq.md`** — a FAQ entry keyed on the literal `No internet connectivity detected` error string (the phrase a stuck user searches), grouped with the other VPS-provider questions.
- **`README.md`** — one-line pointer under the install block (the one entry point not covered by the book).

## Notes

- Docs-only; per repo convention (and prior docs PR #3535) no `CHANGELOG.md`/`Cargo.toml` version bump.
- `mdbook build` (v0.5.2, matching CI) passes; verified the generated anchor `id`s match every intra-book link (`#minimal-or-lite-images`, `#run-the-installer`, `faq → installing`).
- Deliberately does not editorialize about the provider's support/refund quality — just the technical prerequisite and fix.