### PR TITLE
fix(web): include setup-wizard polyfills in its TypeScript program

### DIFF
--- a/projects/start-os/web/setup-wizard/tsconfig.json
+++ b/projects/start-os/web/setup-wizard/tsconfig.json
@@ -12,7 +12,7 @@
       ]
     }
   },
-  "files": ["src/main.ts"],
+  "files": ["src/main.ts", "src/polyfills.ts"],
   "include": ["src/**/*.d.ts"],
   "angularCompilerOptions": {
     "extendedDiagnostics": {


### PR DESCRIPTION
`polyfills.ts` was added to the setup-wizard `angular.json` polyfills array without being added to the project tsconfig's `files`, so it was bundled but never type-checked — neither by the build nor by `npm run check:setup`. Add it to `files`, matching the `ui` project's tsconfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)