### PR TITLE
fix(marketplace): keep version picker after selecting a version

### DIFF
--- a/shared-libs/ts-modules/marketplace/src/components/preview.component.ts
+++ b/shared-libs/ts-modules/marketplace/src/components/preview.component.ts
@@ -204,23 +204,25 @@ export class MarketplacePreviewComponent {
     ),
   )
 
-  readonly versions$ = combineLatest([
-    this.pkg$.pipe(filter(Boolean)),
-    this.flavor$,
-  ]).pipe(
-    map(([pkg, flavor]) => {
-      const range = this.targetRange()
-      const others = Object.keys(pkg.otherVersions).filter(
-        v => this.exver.getFlavor(v) === flavor,
-      )
-      return [pkg.version, ...others]
-        .filter(v =>
-          v === pkg.version
-            ? !range || this.satisfiesWithAliases(pkg, range)
-            : !range || this.exver.satisfies(v, range),
-        )
-        .sort((a, b) => -1 * (this.exver.compareExver(a, b) || 0))
-    }),
+  readonly versions$ = this.flavor$.pipe(
+    switchMap(flavor =>
+      this.marketplaceService.getPackage$(this.pkgId(), null, flavor).pipe(
+        filter(Boolean),
+        map(pkg => {
+          const range = this.targetRange()
+          const others = Object.keys(pkg.otherVersions).filter(
+            v => this.exver.getFlavor(v) === flavor,
+          )
+          return [pkg.version, ...others]
+            .filter(v =>
+              v === pkg.version
+                ? !range || this.satisfiesWithAliases(pkg, range)
+                : !range || this.exver.satisfies(v, range),
+            )
+            .sort((a, b) => -1 * (this.exver.compareExver(a, b) || 0))
+        }),
+      ),
+    ),
   )
 
   onStatic() {


### PR DESCRIPTION
## Summary

Selecting a non-default version of a service in the marketplace permanently removed the version picker, stranding you on that version with no way to switch back.

The picker's version list (`versions$` in `preview.component.ts`) was derived from the **currently-displayed** package. Viewing the default version loads it unpinned from the registry cache, whose `otherVersions` holds the full sibling set → list length > 1 → the `[marketplaceVersions]` button renders (gated in `about.component.ts` on `length > 1`). But selecting version X fetches it **pinned** (`targetVersion: =X`); the registry filters versions by `target_version.satisfies(tv)` and reports `otherVersions` as "matching versions *other than* the best", which for a pinned target is empty. The list collapsed to `[X]`, and the `@else` static text replaced the button.

The fix sources the version list from the **unpinned** default listing — `getPackage$(pkgId, null, flavor)`, served straight from the registry cache — which always enumerates every version. `versions$` now depends only on `flavor$`, so selecting a version no longer shrinks it; `pkg$` still follows the selection for the displayed details and the picker's highlighted current version.

This lives in the shared `@start9labs/marketplace` lib, so it covers the StartOS UI, brochure-marketplace, and the registry-served UI.

Note: only reproduces against a real registry — the mock fixtures return a populated `otherVersions` for pinned targets.

## Verification

- `npm run check:marketplace`, `check:ui`, `check:brochure` pass; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)