### PR TITLE
fix(tunnel): reclaim port 80 for the HTTP→HTTPS redirect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "start-tunnel"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "include_dir",
  "start-core",

--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to StartTunnel are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1]
+
+### Fixed
+
+- **Port 80 is the HTTP→HTTPS redirect on every public IPv4.** Upgrading
+  re-enables the redirect on every public IPv4 (clearing any per-address
+  opt-outs) and removes any published forward that occupies port 80, so a plain
+  `http://` request always bounces to `https://`. Republish port 80 to a device
+  afterward if you need it there — turn the redirect off for that address first.
+
 ## [1.2.0]
 
 ### Changed

--- a/projects/start-tunnel/Cargo.toml
+++ b/projects/start-tunnel/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-tunnel"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "1.2.0"                                               # VERSION_BUMP
+version = "1.2.1"                                               # VERSION_BUMP
 
 [[bin]]
 name = "tunnelbox"

--- a/shared-libs/crates/start-core/src/tunnel/migrations/m_04_reclaim_port_80_redirect.rs
+++ b/shared-libs/crates/start-core/src/tunnel/migrations/m_04_reclaim_port_80_redirect.rs
@@ -1,0 +1,105 @@
+use std::net::SocketAddrV4;
+
+use imbl_value::{InternedString, json};
+
+use super::TunnelMigration;
+use crate::prelude::*;
+
+/// Reclaim port 80 for the HTTP→HTTPS redirect on every public IPv4: clear the
+/// per-IP redirect opt-outs and drop every forward that occupies port 80, so
+/// port 80 is the redirect rather than a published port. A missing
+/// `httpRedirects` already means "on everywhere", so it is left alone.
+pub struct ReclaimPort80Redirect;
+impl TunnelMigration for ReclaimPort80Redirect {
+    fn action(&self, db: &mut Value) -> Result<(), Error> {
+        let Some(root) = db.as_object_mut() else {
+            return Ok(());
+        };
+        if let Some(redirects) = root
+            .get_mut("httpRedirects")
+            .and_then(|v| v.as_object_mut())
+        {
+            redirects.insert(InternedString::intern("disabled"), json!([]));
+        }
+        if let Some(forwards) = root.get_mut("portForwards").and_then(|v| v.as_object_mut()) {
+            forwards.retain(|src, forward| !occupies_port_80(src, forward));
+        }
+        Ok(())
+    }
+}
+
+/// Whether a forward's external port span covers port 80. A DNAT spans `count`
+/// contiguous ports from its key port (default 1); an SNI forward spans 1. This
+/// mirrors `PortForwards::occupied`, so the migration frees port 80 wherever the
+/// runtime would otherwise see it taken. Unparseable keys are treated as not
+/// occupying it (left untouched).
+fn occupies_port_80(src: &str, forward: &Value) -> bool {
+    let Ok(addr) = src.parse::<SocketAddrV4>() else {
+        return false;
+    };
+    let span = forward
+        .get("count")
+        .and_then(|c| c.as_u64())
+        .and_then(|c| u16::try_from(c).ok())
+        .unwrap_or(1)
+        .max(1);
+    let hi = addr.port().saturating_add(span - 1);
+    addr.port() <= 80 && 80 <= hi
+}
+
+#[cfg(test)]
+mod test {
+    use imbl_value::json;
+
+    use super::{ReclaimPort80Redirect, TunnelMigration};
+
+    #[test]
+    fn clears_opt_outs_and_drops_port_80_forwards() {
+        let mut db = json!({
+            "httpRedirects": { "disabled": ["1.2.3.4", "5.6.7.8"] },
+            "portForwards": {
+                "1.2.3.4:80": { "kind": "dnat", "target": "10.59.0.2:80", "label": null, "enabled": true, "count": 1, "auto": false },
+                "1.2.3.4:443": { "kind": "dnat", "target": "10.59.0.2:443", "label": null, "enabled": true, "count": 1, "auto": false },
+                "5.6.7.8:80": { "kind": "sni", "routes": {}, "fallback": null },
+                "9.9.9.9:78": { "kind": "dnat", "target": "10.59.0.2:78", "label": null, "enabled": true, "count": 5, "auto": false },
+                "6.6.6.6:78": { "kind": "dnat", "target": "10.59.0.2:78", "label": null, "enabled": true, "count": 2, "auto": false },
+                "7.7.7.7:81": { "kind": "dnat", "target": "10.59.0.2:81", "label": null, "enabled": true, "count": 3, "auto": false },
+                "80.0.0.1:443": { "kind": "dnat", "target": "10.59.0.2:443", "label": null, "enabled": true, "count": 1, "auto": false }
+            }
+        });
+
+        ReclaimPort80Redirect.action(&mut db).unwrap();
+
+        assert_eq!(db["httpRedirects"]["disabled"], json!([]));
+
+        let forwards = db["portForwards"].as_object().unwrap();
+        // Dropped: a single :80 dnat, an :80 sni, and a range that spans 80.
+        assert!(!forwards.contains_key("1.2.3.4:80"));
+        assert!(!forwards.contains_key("5.6.7.8:80"));
+        assert!(!forwards.contains_key("9.9.9.9:78"));
+        // Kept: other ports, and ranges near but not covering 80.
+        assert!(forwards.contains_key("1.2.3.4:443"));
+        assert!(forwards.contains_key("6.6.6.6:78")); // 78..=79
+        assert!(forwards.contains_key("7.7.7.7:81")); // 81..=83
+        assert!(forwards.contains_key("80.0.0.1:443")); // IP has "80", port 443
+    }
+
+    #[test]
+    fn no_op_when_http_redirects_absent() {
+        let mut db = json!({
+            "portForwards": {
+                "1.2.3.4:80": { "kind": "dnat", "target": "10.59.0.2:80", "label": null, "enabled": true, "count": 1, "auto": false }
+            }
+        });
+
+        ReclaimPort80Redirect.action(&mut db).unwrap();
+
+        assert!(db.as_object().unwrap().get("httpRedirects").is_none());
+        assert!(
+            !db["portForwards"]
+                .as_object()
+                .unwrap()
+                .contains_key("1.2.3.4:80")
+        );
+    }
+}

--- a/shared-libs/crates/start-core/src/tunnel/migrations/mod.rs
+++ b/shared-libs/crates/start-core/src/tunnel/migrations/mod.rs
@@ -7,6 +7,7 @@ mod m_00_port_forward_entry;
 mod m_01_port_forward_kind;
 mod m_02_wg_client_kind;
 mod m_03_port_forward_auto;
+mod m_04_reclaim_port_80_redirect;
 
 #[cfg(test)]
 pub use m_01_port_forward_kind::PortForwardKind;
@@ -24,6 +25,7 @@ pub const MIGRATIONS: &[&dyn TunnelMigration] = &[
     &m_01_port_forward_kind::PortForwardKind,
     &m_02_wg_client_kind::WgClientKind,
     &m_03_port_forward_auto::PortForwardAuto,
+    &m_04_reclaim_port_80_redirect::ReclaimPort80Redirect,
 ];
 
 #[instrument(skip_all)]


### PR DESCRIPTION
Adds a one-time StartTunnel db migration (`m_04` `ReclaimPort80Redirect`) that, on upgrade:

1. **Enables the port-80 redirect on every public IPv4** — clears `httpRedirects.disabled` (the per-IP opt-out set). A pre-1.2.0 db that predates `httpRedirects` already means "on everywhere", so it's left untouched — no stray `httpRedirects: null` is inserted (that would break deserialization; the migration reads via `get_mut`, not the auto-vivifying `db[..]` index).
2. **Removes every port-forward occupying port 80** — so nothing blocks the redirect from binding, and port 80 is the redirect rather than a published port.

### Design note (port-80 forward removal)

The request was "remove all port 80 forwards". I read that as the **effect** — free port 80 so the redirect actually binds on every IP — rather than the literal "forward whose key is `:80`". The migration therefore drops any forward whose external port **span** covers 80, matching `PortForwards::occupied()` / `add_port_forward`'s `covers_80` — the same span logic the runtime already uses in all three sibling sites. That means a manual DNAT range keyed below 80 that swallows it (e.g. `IP:78` `count:5` → 78–82) is removed too; a literal `port()==80` check would leave it, and `redirect::desired()` would still yield on that IP, defeating the goal. Ranges near but not covering 80 (e.g. `:81 count 3`, `:78 count 2`) are kept.

If you'd rather this be strictly the literal `:80`-key reading (leaving straddling ranges in place), it's a one-line change — say the word.

### Versioning / docs
- `start-tunnel` 1.2.0 → 1.2.1 (patch — this completes the intent of the 1.2.0 redirect feature), new `## [1.2.1]` CHANGELOG heading, `Cargo.lock` updated in the same commit.
- No user-docs change: steady-state redirect behavior (docs/src/http-redirects.md) is unchanged; this is a one-time upgrade cleanup, covered by the changelog.

### Testing
- `cargo test -p start-core --lib tunnel::` — all green, incl. two new migration tests (drops single `:80` dnat, `:80` sni, and a span-covering range; keeps other ports and near-but-not-covering ranges; no-op when `httpRedirects` absent).
- `cargo check -p start-core`, `cargo fmt -p start-core --check` clean.