### PR TITLE
fix(backup): hold per-package progress open through image write; weight rsync phase

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -200,6 +200,12 @@ file tracks notable changes since the move to the monorepo.
   package finishing early, with a visible pause before the next one began. Older
   packages built against start-sdk ≤ 2.0.6 still self-report completion and see
   the early "complete" until rebuilt against start-sdk ≥ 2.0.7.
+- **The overall backup progress bar advances with each package's progress.**
+  Every package now contributes equal weight (100) to the overall bar, with the
+  OS-data step a small tail (10), so the top-level percentage climbs as each
+  package's data copies rather than jumping only when a package finishes.
+  Intra-package movement comes from the package's own reported progress, which
+  packages built against start-sdk ≥ 2.0.7 report continuously.
 - **Mixed-case domains now match the browser.** Domain names are lowercased
   when added or removed (UI and CLI alike), so a domain entered with capital
   letters can no longer end up unreachable against the browser's lowercased

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -190,6 +190,16 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **Each package's backup progress stays open until its image finishes
+  writing.** A package's backup phase now completes only once the whole package
+  backup — including streaming its `.s9pk` image to the backup target — is done,
+  so the progress list keeps that package at 100% and still working until it
+  truly finishes, then advances to the next one. Previously the phase was marked
+  complete the moment the service's data procedure returned, while the image
+  (often the larger part) was still writing to the target — which read as the
+  package finishing early, with a visible pause before the next one began. Older
+  packages built against start-sdk ≤ 2.0.6 still self-report completion and see
+  the early "complete" until rebuilt against start-sdk ≥ 2.0.7.
 - **Mixed-case domains now match the browser.** Domain names are lowercased
   when added or removed (UI and CLI alike), so a domain entered with capital
   letters can no longer end up unreachable against the browser's lowercased

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 2.0.7 — StartOS 0.4.0-beta.10 (2026-07-23)
+
+### Changed
+
+- **Backup and restore progress now weights the rsync transfer far above the
+  pre/post hooks, so the bar tracks the copy.** Every progress phase — the
+  optional pre/post hooks and each rsync sync — previously carried equal weight,
+  so on a typical single-volume package the instant pre-backup hook alone
+  accounted for a third of the bar while the rsync (the part that actually takes
+  time) was squeezed into a band too narrow for its fractional progress to move
+  the rounded total: it sat at 33% for the whole transfer and then jumped. Each
+  rsync sync phase now defaults to weight `80` (`DEFAULT_SYNC_WEIGHT`) and each
+  pre/post hook phase to `10` (`DEFAULT_HOOK_WEIGHT`), and a pre/post phase is
+  added only when that hook is actually set — so a hook-less backup is just its
+  rsync phase(s) and tracks the copy directly. All weights are overridable:
+  `setPreBackup` / `setPostBackup` / `setPreRestore` / `setPostRestore` take an
+  optional second `weight` argument, and a sync's weight is set via the new
+  `BackupSync.weight` field (or the `weight` key on `addVolume`'s options).
+- **`createBackup` no longer marks its own progress tracker complete.** The
+  StartOS backup harness owns per-package completion and holds the phase open
+  until the package's `.s9pk` image has finished writing to the backup target,
+  so a package reports 100% and "still working" during the image write rather
+  than a premature "done". Restore is driven by the init harness and was already
+  finalized externally, so it is unchanged in this respect.
+
 ## 2.0.6 — StartOS 0.4.0-beta.10 (2026-07-17)
 
 ### Fixed

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -18,6 +18,8 @@
   `setPreBackup` / `setPostBackup` / `setPreRestore` / `setPostRestore` take an
   optional second `weight` argument, and a sync's weight is set via the new
   `BackupSync.weight` field (or the `weight` key on `addVolume`'s options).
+  Pre/post hooks now receive a `PhaseHandle` for their own phase rather than a
+  full sub-tracker.
 - **`createBackup` no longer marks its own progress tracker complete.** The
   StartOS backup harness owns per-package completion and holds the phase open
   until the package's `.s9pk` image has finished writing to the backup target,

--- a/projects/start-sdk/docs/package-template/package.json
+++ b/projects/start-sdk/docs/package-template/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "2.0.6"
+    "@start9labs/start-sdk": "2.0.7"
   },
   "devDependencies": {
     "@types/node": "^22.19.0",

--- a/projects/start-sdk/docs/src/recipe-backups.md
+++ b/projects/start-sdk/docs/src/recipe-backups.md
@@ -9,6 +9,9 @@ Use `sdk.setupBackups()` with the appropriate builder. `sdk.Backups.ofVolumes('m
 > [!NOTE]
 > Because the service is stopped for the duration of the backup, your backup logic runs against a quiescent volume — nothing is writing to the data while it is copied or dumped. StartOS restarts the service automatically once the backup finishes, but only if it was running when the backup began; a service that was already stopped stays stopped.
 
+> [!NOTE]
+> Progress is reported per phase, weighted so the rsync copy — the slow part — dominates the bar (`DEFAULT_SYNC_WEIGHT` = 80 per sync, `DEFAULT_HOOK_WEIGHT` = 10 per pre/post hook). A pre/post phase appears only when you set that hook. Override any phase's weight with the optional `weight` argument to `setPreBackup` / `setPostBackup` / `setPreRestore` / `setPostRestore`, or the `weight` field on a sync (`addSync` / `addVolume`).
+
 **Reference:** [Main](main.md) · [File Models](file-models.md)
 
 ## Examples

--- a/projects/start-sdk/lib/backup/Backups.ts
+++ b/projects/start-sdk/lib/backup/Backups.ts
@@ -5,7 +5,10 @@ import { Affine, asError } from '../util'
 import { InitKind, InitScript } from '@start9labs/start-core/inits'
 import { SubContainer, execFile } from '../util/SubContainer'
 import { Mounts } from '../mainFn/Mounts'
-import { FullProgressTracker } from '@start9labs/start-core/util/FullProgressTracker'
+import {
+  FullProgressTracker,
+  PhaseHandle,
+} from '@start9labs/start-core/util/FullProgressTracker'
 
 const BACKUP_HOST_PATH = '/media/startos/backup'
 const BACKUP_CONTAINER_MOUNT = '/backup-target'
@@ -114,10 +117,10 @@ export type BackupSync<Volumes extends string> = {
 /** Effects type narrowed for backup/restore contexts, preventing reuse outside that scope */
 export type BackupEffects = T.Effects & Affine<'Backups'>
 
-/** A pre/post backup or restore hook, given a progress tracker for its phase. */
+/** A pre/post backup or restore hook, given a handle to its own progress phase. */
 export type BackupHook = (
   effects: BackupEffects,
-  progress: FullProgressTracker,
+  progress: PhaseHandle,
 ) => Promise<void>
 
 /**
@@ -721,7 +724,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       effects.setBackupProgress({ progress }),
     )
     const preHook = this.preBackup
-      ? tracker.addNestedPhase('pre-backup', this.preBackupWeight)
+      ? tracker.addPhase('pre-backup', this.preBackupWeight)
       : undefined
     const syncs = this.backupSet.map(s =>
       tracker.addPhase(
@@ -730,7 +733,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       ),
     )
     const postHook = this.postBackup
-      ? tracker.addNestedPhase('post-backup', this.postBackupWeight)
+      ? tracker.addPhase('post-backup', this.postBackupWeight)
       : undefined
 
     if (preHook) {
@@ -809,7 +812,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       progress ??
       new FullProgressTracker(p => effects.setInitProgress({ progress: p }))
     const preHook = this.preRestore
-      ? tracker.addNestedPhase('pre-restore', this.preRestoreWeight)
+      ? tracker.addPhase('pre-restore', this.preRestoreWeight)
       : undefined
     const syncs = this.backupSet.map(s =>
       tracker.addPhase(
@@ -818,7 +821,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       ),
     )
     const postHook = this.postRestore
-      ? tracker.addNestedPhase('post-restore', this.postRestoreWeight)
+      ? tracker.addPhase('post-restore', this.postRestoreWeight)
       : undefined
 
     if (preHook) {

--- a/projects/start-sdk/lib/backup/Backups.ts
+++ b/projects/start-sdk/lib/backup/Backups.ts
@@ -93,6 +93,13 @@ export const DEFAULT_OPTIONS: T.SyncOptions = {
   delete: true,
   exclude: [],
 }
+/**
+ * Default progress weight of each rsync sync phase. rsync dominates a backup's
+ * runtime, so it dominates the progress bar relative to the pre/post hooks.
+ */
+export const DEFAULT_SYNC_WEIGHT = 80
+/** Default progress weight of a pre/post backup or restore hook phase. */
+export const DEFAULT_HOOK_WEIGHT = 10
 /** A single source-to-destination sync pair for backup and restore */
 export type BackupSync<Volumes extends string> = {
   dataPath: `/media/startos/volumes/${Volumes}/${string}`
@@ -100,10 +107,18 @@ export type BackupSync<Volumes extends string> = {
   options?: Partial<T.SyncOptions>
   backupOptions?: Partial<T.SyncOptions>
   restoreOptions?: Partial<T.SyncOptions>
+  /** Progress weight of this sync's phase (default {@link DEFAULT_SYNC_WEIGHT}). */
+  weight?: number
 }
 
 /** Effects type narrowed for backup/restore contexts, preventing reuse outside that scope */
 export type BackupEffects = T.Effects & Affine<'Backups'>
+
+/** A pre/post backup or restore hook, given a progress tracker for its phase. */
+export type BackupHook = (
+  effects: BackupEffects,
+  progress: FullProgressTracker,
+) => Promise<void>
 
 /**
  * Configures backup and restore operations using rsync.
@@ -120,23 +135,16 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
     private restoreOptions: Partial<T.SyncOptions> = {},
     private backupOptions: Partial<T.SyncOptions> = {},
     private backupSet = [] as BackupSync<M['volumes'][number]>[],
-    private preBackup = async (
-      effects: BackupEffects,
-      progress: FullProgressTracker,
-    ) => {},
-    private postBackup = async (
-      effects: BackupEffects,
-      progress: FullProgressTracker,
-    ) => {},
-    private preRestore = async (
-      effects: BackupEffects,
-      progress: FullProgressTracker,
-    ) => {},
-    private postRestore = async (
-      effects: BackupEffects,
-      progress: FullProgressTracker,
-    ) => {},
   ) {}
+
+  private preBackup?: BackupHook
+  private postBackup?: BackupHook
+  private preRestore?: BackupHook
+  private postRestore?: BackupHook
+  private preBackupWeight = DEFAULT_HOOK_WEIGHT
+  private postBackupWeight = DEFAULT_HOOK_WEIGHT
+  private preRestoreWeight = DEFAULT_HOOK_WEIGHT
+  private postRestoreWeight = DEFAULT_HOOK_WEIGHT
 
   /**
    * Create a Backups configuration that backs up entire volumes by name.
@@ -635,13 +643,9 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
    * Register a hook to run before backup rsync begins (e.g. dump a database).
    * @param fn - Async function receiving backup-scoped effects and a progress tracker for this hook
    */
-  setPreBackup(
-    fn: (
-      effects: BackupEffects,
-      progress: FullProgressTracker,
-    ) => Promise<void>,
-  ) {
+  setPreBackup(fn: BackupHook, weight: number = DEFAULT_HOOK_WEIGHT) {
     this.preBackup = fn
+    this.preBackupWeight = weight
     return this
   }
 
@@ -649,13 +653,9 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
    * Register a hook to run after backup rsync completes.
    * @param fn - Async function receiving backup-scoped effects and a progress tracker for this hook
    */
-  setPostBackup(
-    fn: (
-      effects: BackupEffects,
-      progress: FullProgressTracker,
-    ) => Promise<void>,
-  ) {
+  setPostBackup(fn: BackupHook, weight: number = DEFAULT_HOOK_WEIGHT) {
     this.postBackup = fn
+    this.postBackupWeight = weight
     return this
   }
 
@@ -663,13 +663,9 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
    * Register a hook to run before restore rsync begins.
    * @param fn - Async function receiving backup-scoped effects and a progress tracker for this hook
    */
-  setPreRestore(
-    fn: (
-      effects: BackupEffects,
-      progress: FullProgressTracker,
-    ) => Promise<void>,
-  ) {
+  setPreRestore(fn: BackupHook, weight: number = DEFAULT_HOOK_WEIGHT) {
     this.preRestore = fn
+    this.preRestoreWeight = weight
     return this
   }
 
@@ -677,13 +673,9 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
    * Register a hook to run after restore rsync completes.
    * @param fn - Async function receiving backup-scoped effects and a progress tracker for this hook
    */
-  setPostRestore(
-    fn: (
-      effects: BackupEffects,
-      progress: FullProgressTracker,
-    ) => Promise<void>,
-  ) {
+  setPostRestore(fn: BackupHook, weight: number = DEFAULT_HOOK_WEIGHT) {
     this.postRestore = fn
+    this.postRestoreWeight = weight
     return this
   }
 
@@ -698,6 +690,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       options: T.SyncOptions
       backupOptions: T.SyncOptions
       restoreOptions: T.SyncOptions
+      weight: number
     }>,
   ) {
     return this.addSync({
@@ -727,14 +720,23 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
     const tracker = new FullProgressTracker(progress =>
       effects.setBackupProgress({ progress }),
     )
-    const preHook = tracker.addNestedPhase('pre-backup', 1)
-    const syncs = this.backupSet.map((s, i) =>
-      tracker.addPhase(`rsync:${s.backupPath}`, 1),
+    const preHook = this.preBackup
+      ? tracker.addNestedPhase('pre-backup', this.preBackupWeight)
+      : undefined
+    const syncs = this.backupSet.map(s =>
+      tracker.addPhase(
+        `rsync:${s.backupPath}`,
+        s.weight ?? DEFAULT_SYNC_WEIGHT,
+      ),
     )
-    const postHook = tracker.addNestedPhase('post-backup', 1)
+    const postHook = this.postBackup
+      ? tracker.addNestedPhase('post-backup', this.postBackupWeight)
+      : undefined
 
-    await this.preBackup(effects as BackupEffects, preHook)
-    preHook.complete()
+    if (preHook) {
+      await this.preBackup!(effects as BackupEffects, preHook)
+      preHook.complete()
+    }
 
     for (let i = 0; i < this.backupSet.length; i++) {
       const item = this.backupSet[i]!
@@ -772,9 +774,13 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       await fs.writeFile('/media/startos/backup/dataVersion.txt', dataVersion, {
         encoding: 'utf-8',
       })
-    await this.postBackup(effects as BackupEffects, postHook)
-    postHook.complete()
-    tracker.complete()
+    if (postHook) {
+      await this.postBackup!(effects as BackupEffects, postHook)
+      postHook.complete()
+    }
+    // Don't mark the tracker complete: the OS backup harness holds this
+    // package's phase open until the s9pk image finishes writing, so it reports
+    // 100%, not "done".
     await tracker.sync()
     return
   }
@@ -802,14 +808,23 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
     const tracker =
       progress ??
       new FullProgressTracker(p => effects.setInitProgress({ progress: p }))
-    const preHook = tracker.addNestedPhase('pre-restore', 1)
+    const preHook = this.preRestore
+      ? tracker.addNestedPhase('pre-restore', this.preRestoreWeight)
+      : undefined
     const syncs = this.backupSet.map(s =>
-      tracker.addPhase(`restore:${s.dataPath}`, 1),
+      tracker.addPhase(
+        `restore:${s.dataPath}`,
+        s.weight ?? DEFAULT_SYNC_WEIGHT,
+      ),
     )
-    const postHook = tracker.addNestedPhase('post-restore', 1)
+    const postHook = this.postRestore
+      ? tracker.addNestedPhase('post-restore', this.postRestoreWeight)
+      : undefined
 
-    await this.preRestore(effects as BackupEffects, preHook)
-    preHook.complete()
+    if (preHook) {
+      await this.preRestore!(effects as BackupEffects, preHook)
+      preHook.complete()
+    }
 
     for (let i = 0; i < this.backupSet.length; i++) {
       const item = this.backupSet[i]!
@@ -845,8 +860,10 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       })
       .catch(_ => null)
     if (dataVersion) await effects.setDataVersion({ version: dataVersion })
-    await this.postRestore(effects as BackupEffects, postHook)
-    postHook.complete()
+    if (postHook) {
+      await this.postRestore!(effects as BackupEffects, postHook)
+      postHook.complete()
+    }
     await tracker.sync()
     return
   }

--- a/projects/start-sdk/package-lock.json
+++ b/projects/start-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",

--- a/projects/start-sdk/package.json
+++ b/projects/start-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/shared-libs/crates/start-core/src/backup/backup_bulk.rs
+++ b/shared-libs/crates/start-core/src/backup/backup_bulk.rs
@@ -306,11 +306,11 @@ async fn perform_backup(
         .map(|id| {
             (
                 id.clone(),
-                progress.add_phase(InternedString::from(id.clone()), Some(1)),
+                progress.add_phase(InternedString::from(id.clone()), Some(100)),
             )
         })
         .collect();
-    let mut os_data_phase = progress.add_phase("OS Data".into(), Some(1));
+    let mut os_data_phase = progress.add_phase("OS Data".into(), Some(10));
     let _progress_db_sync =
         NonDetachingJoinHandle::from(tokio::spawn(progress.clone().sync_to_db(
             ctx.db.clone(),

--- a/shared-libs/crates/start-core/src/service/mod.rs
+++ b/shared-libs/crates/start-core/src/service/mod.rs
@@ -740,7 +740,15 @@ impl Service {
         }
         .await;
 
-        backup.await?;
+        let backup_res = backup.await;
+
+        // Complete the phase only now — after the s9pk write — so a package
+        // isn't reported done while its image is still streaming to the target.
+        if let Some(mut handle) = self.seed.backup_phase.replace(None) {
+            handle.complete();
+        }
+
+        backup_res?;
         s9pk_res
     }
 

--- a/shared-libs/crates/start-core/src/service/transition/backup.rs
+++ b/shared-libs/crates/start-core/src/service/transition/backup.rs
@@ -31,9 +31,6 @@ impl ServiceActorSeed {
                     ))
                 };
                 let id = &self.id;
-                if let Some(mut handle) = self.backup_phase.replace(None) {
-                    handle.complete();
-                }
                 self.ctx
                     .db
                     .mutate(|db| {


### PR DESCRIPTION
Fixes two backup progress-reporting issues @dr-bonez flagged.

## Bug 1 — packages report complete early, then a gap before the next starts

A package's per-package progress phase was marked complete by the service actor's backup transition (`service/transition/backup.rs`) the moment the container's *data* backup procedure + unmount resolved. But `Service::backup` (`service/mod.rs`) then still writes the entire package **`.s9pk` image** to the backup target (`serialize(…, verify=true)`), and that write is outside the tracked phase. The per-package loop only advances once `Service::backup` returns — which waits on that write. So for a package whose image is larger than its data (common), the phase showed **complete** while the image was still streaming to a slow USB/network target, then paused before the next package began.

**Fix (hold the phase open, no new sub-progress):**
- OS: move `handle.complete()` out of the actor transition and into `Service::backup`, after both the container backup future *and* the s9pk write resolve. The OS backup harness now owns per-package completion.
- SDK: `Backups.createBackup` no longer calls `tracker.complete()`. The container reports up to 100% but never terminally "done"; the OS finalizes the phase once the whole package (image included) is written. During the image write the package shows **100% + still working**, then completes and advances — instead of a premature green check with a gap.

Caveat: packages built against start-sdk ≤ 2.0.6 still self-complete their tracker and will show the early "complete" until rebuilt against ≥ 2.0.7. Nothing regresses for them.

## Bug 2 — rsync package backups sit at 33% until complete

`createBackup` built three equal-weight phases — `pre-backup`, `rsync:<path>`, `post-backup`, contribution `1` each. The default pre-backup hook completes instantly (→ a full 1/3), so the weighted overall was `floor(1 + rsyncFraction + 0) / 3 = 1/3 = 33%` for the *entire* rsync, jumping only when the rsync phase completed. The tiny integer weights let `computeOverall`'s rounding swallow all of the rsync's fractional progress.

**Fix (reweight, per @dr-bonez's spec):**
- Each rsync sync phase weighs **80** (`DEFAULT_SYNC_WEIGHT`); each pre/post hook phase weighs **10** (`DEFAULT_HOOK_WEIGHT`).
- Pre/post phases are added **only when the hook is set** — a hook-less backup is just its rsync phase(s) and maps rsync progress directly onto the bar.
- All weights are overridable: an optional `weight` arg on `setPreBackup` / `setPostBackup` / `setPreRestore` / `setPostRestore`, and a `weight` field on `BackupSync` (and `addVolume`'s options).

The dominant rsync weight means the per-package bar now tracks the transfer smoothly instead of snapping at 33%.

## Notes
- **Restore:** I applied the same reweight + conditional-pre/post treatment to `restoreBackup` (it had the identical equal-weight-1 shape and would show the same stall). Easy to drop the restore half if you'd rather keep this backup-only.
- **SDK version:** bumped `@start9labs/start-sdk` 2.0.6 → 2.0.7 (2.0.6 is a cut tag), added the changelog entry, and ran `make sync-template`.
- **Out of scope (flagging):** the OS-level *overall* bar still advances one-whole-package at a time — `progress.rs` `update_overall` truncates `(ratio * contribution) as u64` with a per-package contribution of 1. Not touched here since it's separate from the two reported bugs; happy to follow up if you want the overall to track intra-package too.

## Verification
- Rust: `cargo check -p start-core` clean; rustfmt clean.
- SDK: `tsc --noEmit` clean; 80/80 jest tests pass; prettier clean.
- Not exercised on a live VM backup (needs a package with a sizable image + a backup target to watch the progress UI) — worth a manual pass before release.