### PR TITLE
fix(backup): validate password up front, background the encrypted mount

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -206,6 +206,14 @@ file tracks notable changes since the move to the monorepo.
   package's data copies rather than jumping only when a package finishes.
   Intra-package movement comes from the package's own reported progress, which
   packages built against start-sdk ≥ 2.0.7 report continuously.
+- **Starting a backup returns as soon as the job is queued.** The "create
+  backup" request now validates the backup password against the target and then
+  hands the rest to the background job, so the initial call returns promptly.
+  Previously it also opened the target's encrypted store on the request thread —
+  which, for a large backup or a slow drive, could read for a minute or more
+  before returning — so a slow target looked like the request itself had timed
+  out. Opening the store, and any failure doing so, now happens in the
+  background and is reported through the usual backup progress and notifications.
 - **Mixed-case domains now match the browser.** Domain names are lowercased
   when added or removed (UI and CLI alike), so a domain entered with capital
   letters can no longer end up unreachable against the browser's lowercased

--- a/shared-libs/crates/start-core/src/backup/backup_bulk.rs
+++ b/shared-libs/crates/start-core/src/backup/backup_bulk.rs
@@ -223,30 +223,46 @@ pub async fn backup_all(
         BackupStatusGuard::new(ctx.db.clone()),
     );
 
+    let disk_guard = TmpMountGuard::mount(&fs, BackupWrite).await?;
+
     // `check_password` above already validated the master password, so a rejected
     // password here can only mean the target's existing backup was encrypted with a
     // different one. Distinguish it so the client can ask for that password instead of
-    // reporting the master password as wrong.
-    let disk_guard = TmpMountGuard::mount(&fs, BackupWrite).await?;
-    let mut backup_guard =
-        BackupMountGuard::mount(disk_guard.clone(), &server_id, &old_password_decrypted)
-            .await
-            .map_err(|e| {
-                if e.kind == ErrorKind::IncorrectPassword {
-                    Error::new(
-                        eyre!("{}", t!("backup.bulk.password-mismatch")),
-                        ErrorKind::BackupPasswordMismatch,
-                    )
-                } else {
-                    e
-                }
-            })?;
-    if old_password.is_some() {
-        backup_guard.change_password(&password)?;
-    }
-    let legacy_present =
-        crate::disk::util::has_legacy_backup(backup_guard.backup_disk_path(), &server_id).await;
+    // reporting the master password as wrong. This reads only unencrypted-metadata.json;
+    // the encrypted mount (which replays the whole segment log and can be slow on large
+    // or slow targets) runs in the background task below rather than blocking the request.
+    BackupMountGuard::<TmpMountGuard>::validate_password(
+        disk_guard.path(),
+        &server_id,
+        &old_password_decrypted,
+    )
+    .await
+    .map_err(|e| {
+        if e.kind == ErrorKind::IncorrectPassword {
+            Error::new(
+                eyre!("{}", t!("backup.bulk.password-mismatch")),
+                ErrorKind::BackupPasswordMismatch,
+            )
+        } else {
+            e
+        }
+    })?;
+
     tokio::task::spawn(async move {
+        let mut backup_guard =
+            match BackupMountGuard::mount(disk_guard.clone(), &server_id, &old_password_decrypted)
+                .await
+            {
+                Ok(guard) => guard,
+                Err(e) => return status_guard.handle_result(false, Err(e)).await.unwrap(),
+            };
+        if old_password.is_some() {
+            if let Err(e) = backup_guard.change_password(&password) {
+                return status_guard.handle_result(false, Err(e)).await.unwrap();
+            }
+        }
+        let legacy_present =
+            crate::disk::util::has_legacy_backup(backup_guard.backup_disk_path(), &server_id).await;
         status_guard
             .handle_result(
                 legacy_present,

--- a/shared-libs/crates/start-core/src/disk/mount/backup.rs
+++ b/shared-libs/crates/start-core/src/disk/mount/backup.rs
@@ -96,6 +96,40 @@ impl<G: GenericMountGuard> BackupMountGuard<G> {
         }
         Ok((unencrypted_metadata, enc_key))
     }
+
+    /// Cheap up-front check that `password` matches the target's existing
+    /// backup, reading only `unencrypted-metadata.json` — no encrypted mount or
+    /// segment-log replay. `Ok` when the target has no backup yet (nothing to
+    /// match against).
+    #[instrument(skip_all)]
+    pub async fn validate_password(
+        backup_disk_path: &Path,
+        server_id: &str,
+        password: &str,
+    ) -> Result<(), Error> {
+        let unencrypted_metadata_path = backup_disk_path
+            .join(BACKUP_DIR_NAME)
+            .join(server_id)
+            .join("unencrypted-metadata.json");
+        let bytes = match tokio::fs::read(&unencrypted_metadata_path).await {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => {
+                return Err(e).with_ctx(|_| {
+                    (
+                        crate::ErrorKind::Filesystem,
+                        unencrypted_metadata_path.display().to_string(),
+                    )
+                });
+            }
+        };
+        let unencrypted_metadata: BackupUnencryptedMetadata = IoFormat::Json.from_slice(&bytes)?;
+        if let Some(hash) = unencrypted_metadata.password_hash.as_ref() {
+            check_password(hash, password)?;
+        }
+        Ok(())
+    }
+
     #[instrument(skip_all)]
     pub async fn mount(
         backup_disk_mount_guard: G,


### PR DESCRIPTION
## Problem

A user's **create-backup** request timed out with a healthy target (a generic USB flash drive, BTRFS). From their kernel/OS logs: the block device mounts in <1s, then the request sits **~60s** while mounted and the backup-fs FUSE layer ends with `could not load backup: Io(NotFound)` (a partially-written crypt on the drive), while the client's socket drops (`Trying to work with closed connection`).

Root cause of the *timeout symptom* (separate from the drive's crypt state): `backup_all` opens the target's **encrypted store on the request thread** before returning `Ok(())`. `BackupMountGuard::mount` → `Controller::new` → `SegmentLog::open_sized` **replays the entire segment log** (reads + decrypts every `*.seg`) to rebuild its in-RAM index before the FS is usable. On a large backup or a slow target that's O(backup-size) of I/O — a minute-plus here — and there's no timeout on the path, so the initial call blocks that long and the client (or an intervening proxy) gives up first. The error the server eventually produces is correct; it just arrives after the caller already left.

## Change

Keep only the cheap, must-be-synchronous work on the request path, background the expensive part:

- **New `BackupMountGuard::validate_password`** — reads only `unencrypted-metadata.json` and runs `check_password` against the stored hash. No encrypted mount, no segment replay. `Ok` when the target has no backup yet (nothing to match).
- **`backup_all`** now: mount the target block device (fast) → `validate_password` synchronously (so a wrong password is still returned inline as `BackupPasswordMismatch`) → return. The `BackupMountGuard::mount` (segment replay), optional `change_password`, and legacy check move into the **existing** background task. Any failure there now clears the progress and posts a backup-failed notification via the status guard, instead of hanging the request.

Net: the initial spinner is snappy again, a wrong password still fails inline, and a slow/broken target degrades to a proper "backup failed" notification rather than a perceived timeout.

## Scope / non-goals

Deliberately minimal for the release. No repair/reinit functionality, no new timeouts — just moving the encrypted mount off the request path. The `backup_progress` flag is still set in the sync mutate, so the UI shows progress immediately; on sync-validation failure the `BackupStatusGuard` drop clears it as before.

## Testing

- `cargo check -p start-core` passes (no new warnings from the changed files).
- `cargo fmt` clean.
- Logic is a straight sync→spawn move; `backup_all` has no unit coverage (needs a mounted target), so the end-to-end path is best verified on a device: confirm create returns immediately, a wrong target password still errors inline, and a broken/slow target surfaces a backup-failed notification instead of hanging.