### PR TITLE
fix(ui): snake invisible-wall deaths and held-key input lag

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -351,6 +351,13 @@ file tracks notable changes since the move to the monorepo.
   snake hit the (invisible) boundary well inside the dark box — a seemingly
   causeless game over. The dark box now shrink-wraps the playfield exactly, so
   its edge is the wall.
+- **Snake turns no longer lag behind held or mashed keys.** Every keypress —
+  including keyboard auto-repeat, which fires faster than the game advances —
+  was queued and consumed one per tick, so held or redundant presses delayed
+  the next real turn by a tick each; a key held for a couple of seconds banked
+  a near-second of input lag, reading as the snake ignoring a well-timed turn.
+  Redundant presses are now dropped and stale ones skipped, so a turn lands on
+  the tick after its keypress.
 
 ### Removed
 

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -346,18 +346,6 @@ file tracks notable changes since the move to the monorepo.
   after time synchronized. A failed query (e.g. a D-Bus activation timeout
   under boot load) is now treated as "not synchronized yet" — logged and
   retried on the existing cadence.
-- **Snake no longer dies at an invisible wall.** The game's dark background
-  extended past the sides of the actual playfield, so on most window shapes the
-  snake hit the (invisible) boundary well inside the dark box — a seemingly
-  causeless game over. The dark box now shrink-wraps the playfield exactly, so
-  its edge is the wall.
-- **Snake turns no longer lag behind held or mashed keys.** Every keypress —
-  including keyboard auto-repeat, which fires faster than the game advances —
-  was queued and consumed one per tick, so held or redundant presses delayed
-  the next real turn by a tick each; a key held for a couple of seconds banked
-  a near-second of input lag, reading as the snake ignoring a well-timed turn.
-  Redundant presses are now dropped and stale ones skipped, so a turn lands on
-  the tick after its keypress.
 
 ### Removed
 

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -346,6 +346,11 @@ file tracks notable changes since the move to the monorepo.
   after time synchronized. A failed query (e.g. a D-Bus activation timeout
   under boot load) is now treated as "not synchronized yet" — logged and
   retried on the existing cadence.
+- **Snake no longer dies at an invisible wall.** The game's dark background
+  extended past the sides of the actual playfield, so on most window shapes the
+  snake hit the (invisible) boundary well inside the dark box — a seemingly
+  causeless game over. The dark box now shrink-wraps the playfield exactly, so
+  its edge is the wall.
 
 ### Removed
 

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/general/snake.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/general/snake.component.ts
@@ -28,6 +28,13 @@ interface Snake {
 
 type RGB = [number, number, number]
 
+const DIRECTIONS: Record<string, Point> = {
+  ArrowUp: { x: 0, y: -1 },
+  ArrowDown: { x: 0, y: 1 },
+  ArrowLeft: { x: -1, y: 0 },
+  ArrowRight: { x: 1, y: 0 },
+}
+
 const HEAD_COLOR: RGB = [47, 223, 117] // #2fdf75
 const TAIL_COLOR: RGB = [20, 90, 48] // #145a30
 const GRID_W = 40
@@ -231,9 +238,7 @@ export class SnakeComponent {
       this.state.set('playing')
       this.lastTime = 0
       // Queue directional input so first keypress sets direction
-      if (e.key.startsWith('Arrow')) {
-        this.moveQueue.push(e.key)
-      }
+      this.queueMove(e.key)
       return
     }
 
@@ -243,7 +248,7 @@ export class SnakeComponent {
     }
 
     if (current === 'playing') {
-      this.moveQueue.push(e.key)
+      this.queueMove(e.key)
     }
   }
 
@@ -278,9 +283,9 @@ export class SnakeComponent {
     const yDiff = this.touchStart.y - yUp
 
     if (Math.abs(xDiff) > Math.abs(yDiff)) {
-      this.moveQueue.push(xDiff > 0 ? 'ArrowLeft' : 'ArrowRight')
+      this.queueMove(xDiff > 0 ? 'ArrowLeft' : 'ArrowRight')
     } else {
-      this.moveQueue.push(yDiff > 0 ? 'ArrowUp' : 'ArrowDown')
+      this.queueMove(yDiff > 0 ? 'ArrowUp' : 'ArrowDown')
     }
 
     this.touchStart = null
@@ -375,22 +380,27 @@ export class SnakeComponent {
     this.drawFrame()
   }
 
+  private queueMove(key: string) {
+    // Dedupe held-key repeats and cap the buffer, so presses can neither
+    // pile up into input lag nor bank turns far ahead
+    if (
+      key in DIRECTIONS &&
+      key !== this.moveQueue.at(-1) &&
+      this.moveQueue.length < 3
+    ) {
+      this.moveQueue.push(key)
+    }
+  }
+
   private update() {
-    // Process next queued move
-    if (this.moveQueue.length) {
-      const move = this.moveQueue.shift()!
-      if (move === 'ArrowLeft' && this.snake.dx === 0) {
-        this.snake.dx = -this.grid
-        this.snake.dy = 0
-      } else if (move === 'ArrowUp' && this.snake.dy === 0) {
-        this.snake.dy = -this.grid
-        this.snake.dx = 0
-      } else if (move === 'ArrowRight' && this.snake.dx === 0) {
-        this.snake.dx = this.grid
-        this.snake.dy = 0
-      } else if (move === 'ArrowDown' && this.snake.dy === 0) {
-        this.snake.dy = this.grid
-        this.snake.dx = 0
+    // Turn on the first applicable queued move; a stale or no-op press is
+    // dropped rather than left to delay a real turn by a tick
+    while (this.moveQueue.length) {
+      const dir = DIRECTIONS[this.moveQueue.shift()!]!
+      if ((dir.x && !this.snake.dx) || (dir.y && !this.snake.dy)) {
+        this.snake.dx = dir.x * this.grid
+        this.snake.dy = dir.y * this.grid
+        break
       }
     }
 

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/general/snake.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/general/snake.component.ts
@@ -116,11 +116,12 @@ function lerpColor(from: RGB, to: RGB, t: number): string {
     }
 
     .game-container {
+      /* Shrink-wrap the canvas: the box edge is the collision boundary */
       position: relative;
+      inline-size: fit-content;
+      margin-inline: auto;
       background: #111;
       border-radius: 0.5rem;
-      display: flex;
-      justify-content: center;
     }
 
     canvas {
@@ -167,6 +168,7 @@ function lerpColor(from: RGB, to: RGB, t: number): string {
 export class SnakeComponent {
   private readonly destroyRef = inject(DestroyRef)
   private readonly dialog = injectContext<TuiDialogContext<number, number>>()
+  private readonly el: HTMLElement = inject(ElementRef).nativeElement
   private readonly canvasRef = viewChild<ElementRef<HTMLCanvasElement>>('game')
 
   readonly state = signal<GameState>('ready')
@@ -297,13 +299,14 @@ export class SnakeComponent {
     if (!canvas) return
 
     this.ctx = canvas.getContext('2d')!
-    const container = canvas.parentElement!
     const dpr = window.devicePixelRatio || 1
 
-    // Size grid based on available width, cap so canvas height stays reasonable
+    // Size grid based on available width, cap so canvas height stays reasonable.
+    // Measure the host — the container shrink-wraps the canvas, so its own
+    // width depends on the canvas.
     const maxHeight = window.innerHeight * 0.55
     this.grid = Math.min(
-      Math.floor(container.clientWidth / GRID_W),
+      Math.floor(this.el.clientWidth / GRID_W),
       Math.floor(maxHeight / GRID_H),
     )
 


### PR DESCRIPTION
## Summary
Fixes the two bugs behind "snake dies when it didn't hit anything", found by
auditing the game after a report of collisions with nothing visibly there.

## Invisible wall (51a914fcc)

The game's `#111` background sat on a full-width `.game-container` with the
transparent canvas centered inside it, while wall collisions use the canvas
dimensions. The canvas is sized as
`min(floor(containerWidth / 40), floor(0.55 * innerHeight / 26))` grid cells,
so on most window shapes the height cap makes it narrower than the container —
leaving same-colored, out-of-bounds strips left and right. The snake died at
the invisible canvas edge, seemingly mid-field, and the death frame draws the
head fully clipped, so it never appears to touch anything.

Fix: the container now shrink-wraps the canvas (`inline-size: fit-content;
margin-inline: auto`), making the visible box edge the collision boundary.
Grid sizing measures the host instead of `canvas.parentElement`, since the
container's width now derives from the canvas. The overlays also now align
with the playfield instead of the wider dialog.

## Input-queue lag (446dbbb3c)

Every keypress while playing was queued — including OS auto-repeat (~30 ms),
which fires faster than the ~50 ms game tick — and `update()` consumed exactly
one entry per tick, with an inapplicable move (no-op repeat, attempted
reversal) still burning the slot. Holding a key grew the queue without bound
at ~0.4 s of lag per second held; panic-mashing added a tick of delay per
redundant press. Turns then executed late and the snake plowed into walls the
player had steered away from.

Fix: input goes through a single `queueMove()` — arrow keys only, consecutive
duplicates dropped (a held key contributes one entry), buffer capped at 3 —
and `update()` drains until the first applicable move instead of consuming
blindly. Turn semantics are unchanged: reversals still rejected, and the
deliberate two-press corner buffer still works.

Known and deliberately left: a mid-game window resize still desyncs the grid
(food becomes uneatable until the next restart). Rare trigger, no unfair
death, self-heals — not worth the fix for an easter egg.

Changelog: two entries under the unreleased 0.4.0-beta.10 `### Fixed`.

Verified: `npm run check:ui`, prod `npm run build:ui`, prettier clean; both
fixes confirmed by playing the game against the mock backend.