### PR TITLE
fix(net): dedupe url-plugin exported addresses by address identity

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -190,6 +190,12 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **URL-plugin services no longer accumulate duplicate exported addresses.**
+  `export_url` now dedupes a binding's `available` set by the same address
+  identity `clear_urls` retains on (ignoring the row-action fields), so
+  re-exporting a URL whose `remove_action`/`overflow_actions` changed updates
+  the existing entry instead of inserting a second, `Ord`-distinct copy that
+  `clear_urls` would also keep.
 - **Each package's backup progress stays open until its image finishes
   writing.** A package's backup phase now completes only once the whole package
   backup — including streaming its `.s9pk` image to the backup target — is done,

--- a/shared-libs/crates/start-core/src/service/effects/net/plugin.rs
+++ b/shared-libs/crates/start-core/src/service/effects/net/plugin.rs
@@ -109,6 +109,11 @@ pub async fn export_url(
                 .as_addresses_mut()
                 .as_available_mut()
                 .mutate(|available: &mut BTreeSet<_>| {
+                    // Dedupe by the same address identity `clear_urls` retains
+                    // on (row-action fields excluded). Without this, re-exporting
+                    // a URL whose actions changed inserts a second `Ord`-distinct
+                    // entry that `clear_urls` also keeps, accumulating duplicates.
+                    available.retain(|h| !hostname_info.matches_hostname_info(h, &plugin_id));
                     available.insert(entry);
                     Ok(())
                 })?;


### PR DESCRIPTION
## What

`export_url` and `clear_urls` disagree on what identifies an exported plugin address:

- **`export_url`** inserts `hostname_info.to_hostname_info(...)` into a binding's `available: BTreeSet<HostnameInfo>`. `BTreeSet` ordering spans the **full** `HostnameInfo`, whose `Plugin` metadata includes `remove_action` and `overflow_actions`.
- **`clear_urls`** retains entries via `matches_hostname_info`, which compares **address fields only** (`package_id`, `ssl`, `public`, `hostname`, `port`, `info`) and deliberately ignores the row-action fields.

So if a plugin re-exports the same logical URL with different `remove_action`/`overflow_actions`, `export_url` inserts a **second, `Ord`-distinct** entry, and `clear_urls` keeps **both** (both match the same `except` entry). Duplicate addresses accumulate on the binding.

## Change

`shared-libs/crates/start-core/src/service/effects/net/plugin.rs` — in `export_url`, `retain` out any existing entry with the same address identity (using the very predicate `clear_urls` retains on) before inserting, so a re-export **updates** the entry rather than duplicating it. Insert and clear now share one notion of identity.

```rust
available.retain(|h| !hostname_info.matches_hostname_info(h, &plugin_id));
available.insert(entry);
```

## Context

Surfaced while diagnosing a tor-startos `exportUrls` high-CPU spin (Start9Labs/tor-startos#15). That spin is fixed on the package side (a host watch that re-fired on its own writes); this is the OS-side consistency issue the same investigation turned up — independent of the spin, and safe on its own.

## Verification

`cargo check -p start-core` clean (pre-existing warnings only). Pure logic change, no platform-specific paths. Behavior for the common case (same address re-exported with identical actions, as every current plugin does) is unchanged: `retain` removes the identical entry and `insert` re-adds it, leaving the set byte-identical.