### PR TITLE
fix(tunnel): route each device ipv6 /128 over the wg interface

### DIFF
--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **IPv6 delegation now works when the WAN interface holds the delegated block
+  itself.** Some providers configure the delegated range directly on the WAN
+  interface at its exact size (DigitalOcean assigns its /124 this way), which
+  left the kernel with two equally-specific routes for the block — WAN and
+  tunnel — and the WAN won. Traffic toward device addresses, including replies
+  to connections devices opened, exited the WAN and was lost, so devices had
+  IPv6 addresses but no connectivity. The tunnel now installs an explicit host
+  route per device address, which always takes precedence. Routed prefixes,
+  and on-link blocks configured at a shorter length than the delegated prefix,
+  were unaffected.
 - **Port 80 is the HTTP→HTTPS redirect on every public IPv4.** Upgrading
   re-enables the redirect on every public IPv4 (clearing any per-address
   opt-outs) and removes any published forward that occupies port 80, so a plain

--- a/projects/start-tunnel/docs/src/ipv6.md
+++ b/projects/start-tunnel/docs/src/ipv6.md
@@ -106,8 +106,10 @@ the next hop for the subnet's IPv6 traffic.
 When the prefix is delivered **on-link** (the common single-/64 case), the
 tunnel answers Neighbor Discovery for each device's address on your VPS's
 network, so traffic to it — including the replies to connections it opens — is
-delivered over the tunnel. A **routed** prefix reaches the host without that
-step. A `/64` is the natural size (its 64 host bits hold the whole tunnel IPv4);
+delivered over the tunnel. The tunnel also routes each device's address over
+its own interface explicitly, so this works even when your provider configures
+the delegated block directly on the WAN interface. A **routed** prefix reaches
+the host without the Neighbor Discovery step. A `/64` is the natural size (its 64 host bits hold the whole tunnel IPv4);
 a smaller block works too but keeps only its low host bits of the IPv4. Every
 host must get a distinct address, so if a block is too small — or two devices'
 low IP bits would collide — StartTunnel rejects adding the device or setting the

--- a/shared-libs/crates/start-core/src/tunnel/context.rs
+++ b/shared-libs/crates/start-core/src/tunnel/context.rs
@@ -138,6 +138,22 @@ fn dns_entry(r: &InjectedRecord) -> DnsRecordEntry {
     }
 }
 
+/// Install a client's /128 host route over the wg interface. Best-effort like
+/// [`neigh_proxy`]. `replace`-ing every client is a full reconcile — the
+/// `wg-quick` bounce preceding every resync cleared the interface's routes.
+async fn client_route(addr: Ipv6Addr) {
+    Command::new("ip")
+        .arg("-6")
+        .arg("route")
+        .arg("replace")
+        .arg(format!("{addr}/128"))
+        .arg("dev")
+        .arg(WIREGUARD_INTERFACE_NAME)
+        .invoke(ErrorKind::Network)
+        .await
+        .log_err();
+}
+
 /// Add or remove a proxy-NDP entry so the tunnel host answers Neighbor
 /// Discovery for a client's on-link IPv6 on the WAN interface. Best-effort:
 /// failures are logged, not fatal (reconciled on the next resync).
@@ -458,12 +474,14 @@ impl TunnelContext {
         self.resync_v6().await
     }
 
-    /// Reconcile proxy-NDP for client IPv6 addresses. When a client's /128 sits
-    /// inside a /64 that a WAN interface holds *on-link* (Hetzner, Vultr), the
-    /// VPS gateway resolves that address via Neighbor Discovery on the WAN link,
-    /// so the tunnel host must answer for it (`proxy_ndp`) and then forward to
-    /// the client over WireGuard. A routed prefix is delivered to the host
-    /// without ND, so it needs no proxy entry.
+    /// Reconcile IPv6 delivery for client addresses. Every client /128 gets an
+    /// explicit route over the wg interface: wg-quick installs none (its
+    /// Address-derived route covers them), and that interface route ties with —
+    /// and loses to — a WAN that holds the delegated prefix on-link at the same
+    /// length (DigitalOcean configures its /124 this way), sending return
+    /// traffic out the WAN. Clients inside an on-link prefix additionally get
+    /// proxy-NDP on the WAN (Hetzner, Vultr, DO) so the VPS gateway's Neighbor
+    /// Discovery resolves them here; a routed prefix needs no proxy entry.
     pub async fn resync_v6(&self) -> Result<(), Error> {
         let _guard = self.v6_lock.lock().await;
         let server = self.db.peek().await.as_wg().de()?;
@@ -496,15 +514,16 @@ impl TunnelContext {
                 }
                 v
             });
-            // For each subnet with a prefix, proxy-NDP every client's /128 that
-            // falls inside a WAN interface's on-link /64 (the delivery path for
-            // an on-link prefix; a routed prefix reaches the host without ND).
+            // For each subnet with a prefix: route every client's /128 over wg,
+            // and proxy-NDP those inside a WAN interface's on-link prefix (the
+            // delivery path for an on-link prefix; a routed one needs no ND).
             for (_, cfg) in &server.subnets.0 {
                 let Some(prefix) = cfg.ipv6 else {
                     continue;
                 };
                 for (client_v4, _) in &cfg.clients.0 {
                     let addr = crate::tunnel::wg6::host_v6(prefix, *client_v4);
+                    client_route(addr).await;
                     if let Some((iface, _)) = onlink.iter().find(|(_, n)| n.contains(&addr)) {
                         desired.insert(addr, iface.clone());
                     }


### PR DESCRIPTION
## Problem

IPv6 delegation is dead on servers where the provider configures the delegated block **directly on the WAN interface at its exact size** — DigitalOcean assigns its /124 this way (`50-cloud-init.yaml` renders the address at `/124`). Diagnosed on a production tunnel server (start-tunnel 1.2.0):

- eth0 holds `<block>/124` → kernel on-link route `<block>/124 dev eth0 metric 256`
- the wg interface's `Address = <server-v6>/124` creates the identical route on `wg-start-tunnel`
- equal prefix + equal metric → the FIB resolves to eth0 (first inserted at boot)
- `ip -6 route get <device-v6>` → `dev eth0`; all traffic *toward* device addresses (including replies to connections devices open) exits the WAN and blackholes at the provider gateway

wg-quick never installs the per-peer AllowedIPs /128 routes that would break the tie, because its `add_route` skips any route the interface's own Address-derived route already covers.

Devices get addresses but zero connectivity: device→server works (tunnel arrival doesn't consult the FIB), nothing ever returns. A second production server on the same code and same DO /64 block is unaffected only because its WAN address is hand-configured at `/64`, leaving wg's /124 the longest prefix — which is what narrowed this to the route tie.

## Fix

`resync_v6` now installs an explicit `/128` route over the wg interface for every device address, alongside the proxy-NDP entries it already reconciles. A /128 outranks the tie (and the worse WAN-more-specific case); for routed prefixes it's a harmless refinement.

Deliberately unconditional (`ip -6 route replace` per device, no tracked map, no deletions): every `resync_v6` call site runs immediately after a `wg-quick down`+`up`, which wipes the interface's routes — so installing the desired set is a complete reconcile, and diffing against tracked state would mask routes the bounce just deleted. This also makes the fix self-healing across interface bounces.

## Verification

- `cargo check -p start-core` clean; pinned-nightly rustfmt and prettier clean
- The exact commands the code now runs were applied manually on the affected production server: routing flipped to `dev wg-start-tunnel` and all three devices immediately answered through the tunnel (~45ms RTT)

Changelog entry under the unreleased 1.2.1 heading; `docs/src/ipv6.md` notes the on-link case now works when the provider configures the block on the WAN interface itself.