### PR TITLE
fix: stub missing instructions.md when migrating v1 packages

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -190,6 +190,11 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **Migrating a 0.3.5.1 package that lacks instructions no longer fails.**
+  Converting a legacy (Embassy) package to the new s9pk format now carries over
+  its instructions when present and falls back to a placeholder when absent, so a
+  package with no `instructions.md` can no longer break the 0.3.5.1 → 0.4.0
+  upgrade. Previously the converted package omitted the file entirely.
 - **URL-plugin services no longer accumulate duplicate exported addresses.**
   `export_url` now dedupes a binding's `available` set by the same address
   identity `clear_urls` retains on (ignoring the row-action fields), so

--- a/shared-libs/crates/start-core/src/s9pk/v2/compat.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/compat.rs
@@ -24,6 +24,8 @@ use crate::{ImageId, VolumeId};
 
 pub const MAGIC_AND_VERSION: &[u8] = &[0x3b, 0x3b, 0x01];
 
+const STUB_INSTRUCTIONS: &[u8] = b"# Instructions\n\nThis package was migrated from an earlier version of StartOS and did not include instructions. See the service's website or upstream documentation for setup and usage.\n";
+
 impl S9pk<TmpSource<PackSource>> {
     #[instrument(skip_all)]
     pub async fn from_v1<R: AsyncRead + AsyncSeek + Unpin + Send + Sync>(
@@ -66,6 +68,28 @@ impl S9pk<TmpSource<PackSource>> {
             Entry::file(TmpSource::new(
                 tmp_dir.clone(),
                 PackSource::Buffered(license.into()),
+            )),
+        )?;
+
+        // instructions.md — v1 packages may lack instructions; stub a placeholder so a
+        // missing file never breaks migration.
+        let instructions = match reader.instructions().await {
+            Ok(handle) => handle.to_vec().await.unwrap_or_default(),
+            Err(e) => {
+                tracing::warn!("could not read instructions from v1 s9pk, using placeholder: {e}");
+                Vec::new()
+            }
+        };
+        let instructions: Arc<[u8]> = if instructions.is_empty() {
+            Arc::from(STUB_INSTRUCTIONS)
+        } else {
+            Arc::from(instructions)
+        };
+        archive.insert_path(
+            "instructions.md",
+            Entry::file(TmpSource::new(
+                tmp_dir.clone(),
+                PackSource::Buffered(instructions),
             )),
         )?;
 


### PR DESCRIPTION
## Problem

A 0.3.5.1 → 0.4.0 upgrade aborts on an installed package whose s9pk has no `instructions.md`:

```
0: file instructions.md missing from archive
   at shared-libs/crates/start-core/src/s9pk/merkle_archive/expected.rs:34
SPANTRACE
0: start_core::service::service_map::install
   ...
   at shared-libs/crates/start-core/src/version/v0_3_6_alpha_0.rs:346
```

The v1→v2 conversion (`S9pk::from_v1` in `s9pk/v2/compat.rs`) writes `LICENSE.md`, the icon, images, assets, javascript and the manifest — but **never wrote `instructions.md`**. So *every* migrated legacy package produced an archive missing the file, and `service_map::install`'s validation (`validate_and_filter` → `check_file("instructions.md")`) rejected it, halting the migration and looping the retry.

## Fix

`from_v1` now writes `instructions.md` into the converted archive:

- carries over the package's instructions from the v1 s9pk when present;
- falls back to a short placeholder (`instructions_or_stub`) when the file is absent, empty, or unreadable.

A missing file can no longer break migration, and migrated packages now retain their instructions (previously dropped entirely) on the **Instructions** tab. `validate_for` already logged-and-continued on a missing `instructions.md`; this closes the gap at the source so the archive always contains the file.

## Testing

Exercised on a real v1 (0.3.x) s9pk — `hello-world` v0.3.5 (magic `3b 3b 01`) — via `start-cli s9pk convert`:

| | `instructions.md` in converted v2 archive |
|---|---|
| **master** (no fix) | ❌ missing — reproduces the reported failure |
| **this branch** | ✅ present, with the package's real instructions carried over |

- `cargo test -p start-core` — new unit tests `stubs_missing_instructions` (empty → placeholder) and `preserves_present_instructions` (present → preserved) pass. The stub branch is what `hello-world` doesn't exercise (it ships instructions), so it's covered deterministically here.
- `cargo check -p start-core` / `cargo build -p start-cli` build clean (only pre-existing warnings).

The full `from_v1` path shells out to docker/mksquashfs; the conversion above ran it end-to-end.