### PR TITLE
fix(backup): don't start backup until the service has stopped

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -190,6 +190,14 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **Backups wait for the service to fully stop before its data is copied.** A
+  package's data is now captured only after its service has completely stopped,
+  and the package isn't reported finished until it has left the backing-up
+  state. Previously the backup could begin as soon as the package's `.s9pk`
+  image finished serializing — often before the graceful shutdown had
+  completed — so a slow-to-stop service could still be writing while its files
+  were read, risking a torn or inconsistent snapshot of databases and other
+  stateful data.
 - **URL-plugin services no longer accumulate duplicate exported addresses.**
   `export_url` now dedupes a binding's `available` set by the same address
   identity `clear_urls` retains on (ignoring the row-action fields), so

--- a/shared-libs/crates/start-core/src/service/mod.rs
+++ b/shared-libs/crates/start-core/src/service/mod.rs
@@ -18,7 +18,6 @@ use itertools::Itertools;
 use nix::sys::signal::Signal;
 use persistent_container::PersistentContainer;
 use rpc_toolkit::HandlerArgs;
-use rpc_toolkit::yajrc::RpcError;
 use serde::{Deserialize, Serialize};
 use service_actor::ServiceActor;
 use termion::raw::IntoRawMode;
@@ -740,6 +739,11 @@ impl Service {
         }
         .await;
 
+        // Awaiting the handle reads the backup result but does not drive it —
+        // the actor drives the backup once the service has stopped, and the
+        // handle doesn't resolve until the service has left the backing-up
+        // state. So the backup never starts before the service is stopped, and
+        // this call doesn't return until the backing-up transition is complete.
         let backup_res = backup.await;
 
         // Complete the phase only now — after the s9pk write — so a package
@@ -794,7 +798,11 @@ struct ServiceActorSeed {
     id: PackageId,
     /// Needed to interact with the container for the service
     persistent_container: PersistentContainer,
-    backup: SyncMutex<Option<BoxFuture<'static, Result<(), RpcError>>>>,
+    /// The backup work, stored for the actor to drive once the service has
+    /// stopped. Its result is delivered to the caller through the paired
+    /// `RemoteHandle` (see `transition::backup`), so this half only needs to be
+    /// driven to completion.
+    backup: SyncMutex<Option<BoxFuture<'static, ()>>>,
     /// Set while a backup procedure is running so the service container can
     /// stream progress updates back via the `setBackupProgress` effect.
     backup_phase: SyncMutex<Option<crate::progress::PhaseProgressTrackerHandle>>,

--- a/shared-libs/crates/start-core/src/service/transition/backup.rs
+++ b/shared-libs/crates/start-core/src/service/transition/backup.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
+use futures::FutureExt;
 use futures::future::BoxFuture;
-use futures::{FutureExt, TryFutureExt};
-use rpc_toolkit::yajrc::RpcError;
 
 use crate::disk::mount::filesystem::ReadWrite;
 use crate::prelude::*;
@@ -18,44 +17,51 @@ use crate::util::actor::{ConflictBuilder, Handler};
 use crate::util::serde::NoOutput;
 
 impl ServiceActorSeed {
+    async fn leave_backing_up(&self) -> Result<(), Error> {
+        let id = &self.id;
+        self.ctx
+            .db
+            .mutate(|db| {
+                db.as_public_mut()
+                    .as_package_data_mut()
+                    .as_idx_mut(id)
+                    .or_not_found(id)?
+                    .as_status_info_mut()
+                    .as_desired_mut()
+                    .map_mutate(|s| {
+                        Ok(match s {
+                            DesiredStatus::BackingUp {
+                                on_complete: StartStop::Start,
+                            } => DesiredStatus::Running,
+                            DesiredStatus::BackingUp {
+                                on_complete: StartStop::Stop,
+                            } => DesiredStatus::Stopped,
+                            x => x,
+                        })
+                    })?;
+                Ok(())
+            })
+            .await
+            .result
+    }
+
     pub fn backup(&self) -> Transition<'_> {
         Transition {
             kind: TransitionKind::BackingUp,
             future: async {
-                let res = if let Some(fut) = self.backup.replace(None) {
-                    fut.await.map_err(Error::from)
+                // The backup future clears BackingUp itself when it finishes, so
+                // here we just drive it to completion. If there's nothing to
+                // resume, recover the state so it can't get stuck, then report.
+                if let Some(backup) = self.backup.replace(None) {
+                    backup.await;
+                    Ok(())
                 } else {
+                    self.leave_backing_up().await?;
                     Err(Error::new(
                         eyre!("{}", t!("service.transition.backup.no-backup-to-resume")),
                         ErrorKind::Cancelled,
                     ))
-                };
-                let id = &self.id;
-                self.ctx
-                    .db
-                    .mutate(|db| {
-                        db.as_public_mut()
-                            .as_package_data_mut()
-                            .as_idx_mut(id)
-                            .or_not_found(id)?
-                            .as_status_info_mut()
-                            .as_desired_mut()
-                            .map_mutate(|s| {
-                                Ok(match s {
-                                    DesiredStatus::BackingUp {
-                                        on_complete: StartStop::Start,
-                                    } => DesiredStatus::Running,
-                                    DesiredStatus::BackingUp {
-                                        on_complete: StartStop::Stop,
-                                    } => DesiredStatus::Stopped,
-                                    x => x,
-                                })
-                            })?;
-                        Ok(())
-                    })
-                    .await
-                    .result?;
-                res
+                }
             }
             .boxed(),
         }
@@ -80,8 +86,13 @@ impl Handler<Backup> for ServiceActor {
         let seed = self.0.clone();
         seed.backup_phase.replace(Some(progress));
 
-        let transition = async move {
-            async {
+        // Split the backup into a driver (`remote`, stored for the actor to run
+        // once the service has stopped) and a handle (returned to the caller).
+        // Awaiting the handle only reads the result — it never drives the work —
+        // so the backup can't start before the actor runs it, and the handle
+        // doesn't resolve until the service has left the backing-up state.
+        let (remote, handle) = async move {
+            let res = async {
                 let backup_guard = seed
                     .persistent_container
                     .mount_backup(path, ReadWrite)
@@ -93,13 +104,14 @@ impl Handler<Backup> for ServiceActor {
 
                 Ok::<_, Error>(())
             }
-            .await
-            .map_err(RpcError::from)
+            .await;
+            seed.leave_backing_up().await?;
+            res
         }
-        .shared();
+        .remote_handle();
 
-        self.0.backup.replace(Some(transition.clone().boxed()));
+        self.0.backup.replace(Some(remote.boxed()));
 
-        Ok(transition.map_err(Error::from).boxed())
+        Ok(handle.boxed())
     }
 }


### PR DESCRIPTION
## Problem

Two coupled bugs in the package backup flow, one root cause: `Service::backup` (`shared-libs/crates/start-core/src/service/mod.rs`) awaited the shared backup future **itself**, driving it rather than just reading its result.

1. **Backup could start before the service was stopped.** The stop→backup ordering lives in the actor state machine (`service_actor.rs`): it only runs the `backup()` transition once the service has stopped (`started == None`). But `Service::backup` held a clone of the same `.shared()` future and polled it as soon as the concurrent s9pk serialization finished — while the actor was still awaiting the graceful `stop()` (up to the 30s SIGTERM timeout). Since a `Shared` runs on first poll from *any* clone, `Service::backup`'s poll won that window: `CreateBackup` ran against a **still-running** service's live data volume, with no fsfreeze/quiesce anywhere in the path. Result: a torn/inconsistent snapshot — worst for exactly the slow-to-stop stateful services (databases, wallets) that most need a clean backup. Silent; the backup reports success.

2. **Backup reported complete before the service left `BackingUp`.** `Service::backup` returned when the backup *work* future resolved, but the actor's transition clears the `BackingUp` status *after* awaiting that same future — so the per-package backup could be reported done while the service was still in the backing-up state.

## Fix

Replace `.shared()` with `.remote_handle()`, so the two roles are split at the type level:

- The **driver** half (`Remote`) is stored in the actor's cell and driven by the actor's `backup()` transition — which only runs once the service has stopped.
- The **handle** half is returned to `Service::backup`. Awaiting a `RemoteHandle` only *reads* the result — it never polls/drives the underlying work. So a backup **cannot** start before the actor runs it; the caller literally can't drive it early.

To also fix (2), the leave-`BackingUp` state mutation is moved into the driven future (extracted as `ServiceActorSeed::leave_backing_up`), so the handle doesn't resolve until the service has actually left the backing-up state. That let the previous watch-based approach be dropped entirely.

## Scope / risk

Two files (`service/mod.rs`, `service/transition/backup.rs`) — no new dependencies (`remote_handle` is already in `futures`), no changes to the container runtime. The actor is now the *sole* driver by construction. The anomalous empty-cell recovery path (nothing queued to resume) still leaves `BackingUp` and reports the same `no-backup-to-resume` error as before. The concurrent s9pk serialization is preserved.

`cargo check -p start-core` and `cargo fmt --check` pass.

Fixes the ordering hazard surfaced in the backup-flow audit.