### PR TITLE
fix: preserve asset file permissions when migrating v1 packages

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -203,6 +203,12 @@ file tracks notable changes since the move to the monorepo.
   its instructions when present and falls back to a placeholder when absent, so a
   package with no `instructions.md` can no longer break the 0.3.5.1 → 0.4.0
   upgrade. Previously the converted package omitted the file entirely.
+- **Migrated 0.3.5.1 packages keep their asset file permissions.** Converting a
+  legacy (Embassy) package to the new s9pk format now preserves the mode bits of
+  files in the package's assets, so an executable asset (a script or bundled
+  binary) stays executable in the migrated package. Previously the assets were
+  unpacked without their permissions and re-packed at the default mode, dropping
+  the executable bit and breaking any asset the service ran directly.
 - **URL-plugin services no longer accumulate duplicate exported addresses.**
   `export_url` now dedupes a binding's `available` set by the same address
   identity `clear_urls` retains on (ignoring the row-action fields), so

--- a/shared-libs/crates/start-core/src/s9pk/v2/compat.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/compat.rs
@@ -141,7 +141,10 @@ impl S9pk<TmpSource<PackSource>> {
         // assets
         let asset_dir = tmp_dir.join("assets");
         tokio::fs::create_dir_all(&asset_dir).await?;
-        tokio_tar::Archive::new(reader.assets().await?)
+        // preserve file modes — the default drops them, stripping +x off executable assets
+        tokio_tar::ArchiveBuilder::new(reader.assets().await?)
+            .set_preserve_permissions(true)
+            .build()
             .unpack(&asset_dir)
             .await?;
         let sqfs_path = asset_dir.with_extension("squashfs");


### PR DESCRIPTION
## Problem

`S9pk::from_v1` (the 0.3.5.1 → 0.4.0 package migration) unpacks the package's assets tar into a scratch directory and then re-packs it with `mksquashfs`. It built the reader with `tokio_tar::Archive::new(...)`, whose default `preserve_permissions` is `false` — so on extraction the tar header modes are discarded and each file is recreated at the process umask default (e.g. `0644`). Any **executable** asset (a shell script or bundled binary the service runs directly) therefore lost its `+x` bit in the migrated package.

## Fix

Build the reader with `ArchiveBuilder::new(...).set_preserve_permissions(true).build()` so the tar header modes carry through the unpack and into the resulting `assets.squashfs`.

```rust
tokio_tar::ArchiveBuilder::new(reader.assets().await?)
    .set_preserve_permissions(true)
    .build()
    .unpack(&asset_dir)
    .await?;
```

## Scope check

`assets` is the only `from_v1` input that needs this — LICENSE.md / instructions.md / icon are stored as opaque byte blobs (no per-file modes), `embassy.js` is interpreted rather than exec'd, and docker image modes come from the OCI layers. `mksquashfs` preserves on-disk modes by default, and `astral-tokio-tar`'s `unpack` defers directory entries to the end in topological order, so a read-only directory in the tar can't break extraction of its children.

## Note for reviewer

Preserving the full mode also carries any **setuid/setgid** bits present in the (untrusted) v1 assets tar through to the squashfs. This isn't a live escalation — assets are mounted inside the unprivileged, id-mapped LXC (uid 0 → 100000), and it matches how natively-built v2 packages are squashed — so I left it as-is to keep migrated packages consistent with native ones. If you'd rather strip setuid/setgid on migration (or add `nosuid` to the asset mount more broadly), happy to follow up.

## Testing

- `cargo check -p start-core` passes (only pre-existing warnings).
- The full `from_v1` path can't run in CI unit tests (it shells out to a container runtime + `mksquashfs`), and there are no existing tests for the compat conversion, so end-to-end verification is manual: migrate a v1 package containing an `+x` asset and confirm the mode survives in the squashfs.

Docs: `projects/start-os/CHANGELOG.md` updated under the unreleased `0.4.0-beta.10` `### Fixed` section.