### PR TITLE
feat(backup): show an "Initializing" progress phase during target mount

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -239,6 +239,10 @@ file tracks notable changes since the move to the monorepo.
   before returning — so a slow target looked like the request itself had timed
   out. Opening the store, and any failure doing so, now happens in the
   background and is reported through the usual backup progress and notifications.
+- **Backup progress shows an "Initializing" phase while the target is prepared.**
+  Backup progress now displays a labeled "Initializing" phase while StartOS
+  mounts the target and opens its encrypted store, instead of a bare 0% with no
+  phases; the per-package and OS-data phases appear once that work finishes.
 - **Mixed-case domains now match the browser.** Domain names are lowercased
   when added or removed (UI and CLI alike), so a domain entered with capital
   letters can no longer end up unreachable against the browser's lowercased

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -1507,6 +1507,13 @@ backup.bulk.reclaim-failed:
   fr_FR: "Impossible de récupérer l'espace de l'ancienne sauvegarde : %{error}"
   pl_PL: "Nie udało się odzyskać miejsca po starej kopii zapasowej: %{error}"
 
+backup.bulk.initializing:
+  en_US: "Initializing"
+  de_DE: "Initialisierung"
+  es_ES: "Inicializando"
+  fr_FR: "Initialisation"
+  pl_PL: "Inicjalizacja"
+
 backup.bulk.reclaiming-space:
   en_US: "Reclaiming Space"
   de_DE: "Speicherplatz wird freigegeben"

--- a/shared-libs/crates/start-core/src/backup/backup_bulk.rs
+++ b/shared-libs/crates/start-core/src/backup/backup_bulk.rs
@@ -345,11 +345,6 @@ async fn perform_backup(
     let mut package_backups: BTreeMap<PackageId, PackageBackupInfo> =
         backup_guard.metadata.package_backups.clone();
 
-    // The target is mounted and its store is open; close out the Initializing
-    // phase before the reclaim/per-package/OS phases take over. The db-sync task
-    // (spawned in backup_all) keeps streaming as these phases are added.
-    init_phase.complete();
-
     let mut reclaim_phase = if crate::backup::trash::has_trash(disk_guard.path()).await {
         Some(progress.add_phase(
             InternedString::intern(&*t!("backup.bulk.reclaiming-space")),
@@ -368,6 +363,12 @@ async fn perform_backup(
         })
         .collect();
     let mut os_data_phase = progress.add_phase("OS Data".into(), Some(10));
+
+    // The target is mounted and its store is open; close out the Initializing
+    // phase now that the reclaim/per-package/OS phases exist, so the phase list
+    // is already populated when it flips to complete. The db-sync task (spawned
+    // in backup_all) keeps streaming these phases.
+    init_phase.complete();
 
     if let Some(phase) = &mut reclaim_phase {
         phase.start();

--- a/shared-libs/crates/start-core/src/backup/backup_bulk.rs
+++ b/shared-libs/crates/start-core/src/backup/backup_bulk.rs
@@ -26,7 +26,7 @@ use crate::disk::mount::filesystem::BackupWrite;
 use crate::disk::mount::guard::{GenericMountGuard, TmpMountGuard};
 use crate::notifications::{NotificationLevel, notify};
 use crate::prelude::*;
-use crate::progress::{FullProgress, FullProgressTracker};
+use crate::progress::{FullProgress, FullProgressTracker, PhaseProgressTrackerHandle};
 use crate::util::future::NonDetachingJoinHandle;
 use crate::util::io::{AtomicFile, dir_copy};
 use crate::util::serde::IoFormat;
@@ -195,6 +195,21 @@ pub async fn backup_all(
         .decrypt(&ctx)?;
     let password = password.decrypt(&ctx)?;
 
+    // Progress is shown from the moment the request is accepted. The
+    // "Initializing" phase covers mounting the target and opening its encrypted
+    // store — work that runs before perform_backup adds the per-package phases —
+    // so the UI shows a labeled phase instead of a bare 0% during that window.
+    let progress = FullProgressTracker::new();
+    let mut init_phase = progress.add_phase(
+        InternedString::intern(&*t!("backup.bulk.initializing")),
+        None,
+    );
+    init_phase.start();
+    // The mutate closure runs under catch_unwind, so it can't capture the
+    // tracker (its watch channels aren't unwind-safe); seed the db with a plain
+    // snapshot instead.
+    let init_progress = progress.snapshot();
+
     let ((fs, package_ids, server_id), status_guard) = (
         ctx.db
             .mutate(|db| {
@@ -211,7 +226,7 @@ pub async fn backup_all(
                         .map(|(id, _)| id)
                         .collect()
                 };
-                assure_backing_up(db, &package_ids)?;
+                assure_backing_up(db, &init_progress)?;
                 Ok((
                     fs,
                     package_ids,
@@ -248,7 +263,23 @@ pub async fn backup_all(
         }
     })?;
 
+    // Stream progress to the db for the rest of the backup, starting now so the
+    // Initializing phase is live during the encrypted mount. The handle lives in
+    // the backup task below, so it is not aborted when this request returns.
+    let progress_db_sync = NonDetachingJoinHandle::from(tokio::spawn(progress.clone().sync_to_db(
+        ctx.db.clone(),
+        |db| {
+            db.as_public_mut()
+                .as_server_info_mut()
+                .as_status_info_mut()
+                .as_backup_progress_mut()
+                .transpose_mut()
+        },
+        Some(Duration::from_millis(300)),
+    )));
+
     tokio::task::spawn(async move {
+        let _progress_db_sync = progress_db_sync;
         let mut backup_guard =
             match BackupMountGuard::mount(disk_guard.clone(), &server_id, &old_password_decrypted)
                 .await
@@ -266,7 +297,15 @@ pub async fn backup_all(
         status_guard
             .handle_result(
                 legacy_present,
-                perform_backup(&ctx, backup_guard, disk_guard, &package_ids).await,
+                perform_backup(
+                    &ctx,
+                    progress,
+                    init_phase,
+                    backup_guard,
+                    disk_guard,
+                    &package_ids,
+                )
+                .await,
             )
             .await
             .unwrap();
@@ -274,11 +313,8 @@ pub async fn backup_all(
     Ok(())
 }
 
-#[instrument(skip(db, packages))]
-fn assure_backing_up<'a>(
-    db: &mut DatabaseModel,
-    packages: impl IntoIterator<Item = &'a PackageId>,
-) -> Result<(), Error> {
+#[instrument(skip(db, initial))]
+fn assure_backing_up(db: &mut DatabaseModel, initial: &FullProgress) -> Result<(), Error> {
     let backing_up = db
         .as_public_mut()
         .as_server_info_mut()
@@ -290,14 +326,15 @@ fn assure_backing_up<'a>(
             ErrorKind::InvalidRequest,
         ));
     }
-    let _ = packages;
-    backing_up.ser(&Some(FullProgress::new()))?;
+    backing_up.ser(&Some(initial.clone()))?;
     Ok(())
 }
 
-#[instrument(skip(ctx, backup_guard, disk_guard))]
+#[instrument(skip(ctx, progress, init_phase, backup_guard, disk_guard))]
 async fn perform_backup(
     ctx: &RpcContext,
+    progress: FullProgressTracker,
+    mut init_phase: PhaseProgressTrackerHandle,
     backup_guard: BackupMountGuard<TmpMountGuard>,
     disk_guard: TmpMountGuard,
     package_ids: &OrdSet<PackageId>,
@@ -308,7 +345,11 @@ async fn perform_backup(
     let mut package_backups: BTreeMap<PackageId, PackageBackupInfo> =
         backup_guard.metadata.package_backups.clone();
 
-    let progress = FullProgressTracker::new();
+    // The target is mounted and its store is open; close out the Initializing
+    // phase before the reclaim/per-package/OS phases take over. The db-sync task
+    // (spawned in backup_all) keeps streaming as these phases are added.
+    init_phase.complete();
+
     let mut reclaim_phase = if crate::backup::trash::has_trash(disk_guard.path()).await {
         Some(progress.add_phase(
             InternedString::intern(&*t!("backup.bulk.reclaiming-space")),
@@ -327,18 +368,6 @@ async fn perform_backup(
         })
         .collect();
     let mut os_data_phase = progress.add_phase("OS Data".into(), Some(10));
-    let _progress_db_sync =
-        NonDetachingJoinHandle::from(tokio::spawn(progress.clone().sync_to_db(
-            ctx.db.clone(),
-            |db| {
-                db.as_public_mut()
-                    .as_server_info_mut()
-                    .as_status_info_mut()
-                    .as_backup_progress_mut()
-                    .transpose_mut()
-            },
-            Some(Duration::from_millis(300)),
-        )));
 
     if let Some(phase) = &mut reclaim_phase {
         phase.start();


### PR DESCRIPTION
## Problem

During a create backup, the progress display sat at a bare **0% with no phases** from the moment the request was accepted until `perform_backup` added the per-package phases — i.e. the entire window that mounts the target and opens (and, on a large/slow target, replays) its encrypted store. `assure_backing_up` seeded `backup_progress` with an empty `FullProgress`, and the real phases only appeared once the mount finished.

## Change

Add an **Initializing** phase that covers that window:

- `backup_all` creates the `FullProgressTracker` up front, adds an `Initializing` phase (started), and seeds `backup_progress` with its snapshot in the same mutate that atomically claims the "backing up" slot.
- The progress→db stream is started **before** the encrypted mount, so `Initializing` is live during it; its `NonDetachingJoinHandle` is moved into the background backup task so it isn't aborted when the request returns.
- The tracker + phase handle are threaded into `perform_backup`, which `complete()`s `Initializing` once the store is open, then adds the reclaim / per-package / OS-data phases (unchanged) to the same tracker.

Result: instead of a blank 0%, the UI shows an `Initializing` phase while the target mounts / the store opens, then transitions into the per-package phases.

Notes:
- The `ctx.db.mutate` closure runs under `catch_unwind`, so it can't capture the tracker (its `watch` channels aren't unwind-safe) — the mutate seeds a plain `FullProgress` **snapshot** instead.
- `Initializing` is added with no overall-percentage contribution, so it reads as a labeled spinner and doesn't skew the overall bar; the per-package/OS contributions are unchanged.
- New i18n key `backup.bulk.initializing` (all five locales).

## Testing

`cargo check -p start-core` and `cargo fmt` clean. Progress reporting isn't unit-tested here (needs a mounted target + running services), so the phase transition is best confirmed on a device / VM: start a backup and watch the progress show `Initializing` during the mount, then the package phases.