### PR TITLE
fix: drop duplicated title from OS update notification body

### DIFF
--- a/shared-libs/crates/start-core/src/version/update_details/v0_4_0.md
+++ b/shared-libs/crates/start-core/src/version/update_details/v0_4_0.md
@@ -1,5 +1,3 @@
-# StartOS v0.4.0
-
 ## Warning
 
 Previous backups are incompatible with v0.4.0. It is strongly recommended that you (1) immediately update all services, (2) start them and let each run until it reports healthy — some services finish updating on first start — and then (3) create a fresh backup.

--- a/shared-libs/crates/start-core/src/version/update_details/v0_4_0_highlights.md
+++ b/shared-libs/crates/start-core/src/version/update_details/v0_4_0_highlights.md
@@ -1,5 +1,3 @@
-# Welcome to stable StartOS 0.4.0
-
 StartOS 0.4.0 has left early access. You updated from a pre-release, so here is what's new since the previous beta:
 
 ## Backups — please read


### PR DESCRIPTION
The notification a user receives after updating to a new OS version showed its title twice: once in the modal header (the dialog `label`) and again as the first line of the body.

The modal is opened by `NotificationService.viewModal` for code-2 (OS update) notifications with `label: title` and `data:` the release-notes markdown. Both `update_details` markdown files (`v0_4_0.md`, `v0_4_0_highlights.md`) — the only bodies rendered there — led with an H1 (`# StartOS v0.4.0` / `# Welcome to stable StartOS 0.4.0`) that repeated the header title, so the same copy stacked on top of itself.

This removes the redundant leading heading from both files. The title now shows only in the modal header; the body starts with real content.

No changelog/docs entry: the 0.4.0 welcome notification is new to the still-unreleased 0.4.0 line (latest cut tag is `v0.4.0-beta.9`), so this is pre-release copy polish, not a change to shipped behavior. The files are `include_str!` raw content, so there is no i18n/bindings impact.