### PR TITLE
fix(os-install): preserve data pool selected by partition path (pre-installed Pi)

### DIFF
--- a/shared-libs/crates/start-core/src/os_install/mod.rs
+++ b/shared-libs/crates/start-core/src/os_install/mod.rs
@@ -170,6 +170,22 @@ fn plan_data_drive(
                 .map(|g| (p.logicalname.clone(), g))
         })
     });
+
+    // A pre-installed device (e.g. a Raspberry Pi) offers its data partition as
+    // its own drive, so `target` can be a partition path that this enumeration
+    // lists only nested under its disk, not as a top-level DiskInfo. Resolve the
+    // pool on that exact partition directly so Preserve attaches it.
+    if disk.is_none() {
+        if let Some(guid) = disks.iter().find_map(|d| {
+            d.partitions
+                .iter()
+                .find(|p| p.logicalname == target)
+                .and_then(|p| p.guid.as_ref().filter(|g| is_startos_pool_guid(g)).cloned())
+        }) {
+            return Ok(DataDrivePlan::Attach(guid));
+        }
+    }
+
     let same_drive = os_drive == Some(target);
     match (same_drive, disk_pool, partition_pool) {
         // Pool spans the whole data drive: preservable only if the OS goes
@@ -868,6 +884,25 @@ mod tests {
         let disks = vec![single_drive_035()];
         let err = plan_data_drive(&disks, None, &preserve("/dev/sda")).unwrap_err();
         assert!(matches!(err.kind, ErrorKind::InvalidRequest));
+    }
+
+    /// Pre-installed device (e.g. Raspberry Pi): the data partition is selected
+    /// by its own partition path, and this enumeration lists it only nested
+    /// under the OS disk. The pool (here an unencrypted `_UNENC` VG) must still
+    /// resolve and attach.
+    #[test]
+    fn preserve_data_partition_by_path_attaches() {
+        let disks = vec![disk(
+            "/dev/mmcblk0",
+            None,
+            vec![
+                partition("/dev/mmcblk0p1", None),
+                partition("/dev/mmcblk0p4", None),
+                partition("/dev/mmcblk0p5", Some("EMBASSY_AAAA_UNENC")),
+            ],
+        )];
+        let plan = plan_data_drive(&disks, None, &preserve("/dev/mmcblk0p5")).unwrap();
+        assert_eq!(plan, DataDrivePlan::Attach("EMBASSY_AAAA_UNENC".into()));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A pre-installed device (Raspberry Pi) offers its **data partition** — e.g. `/dev/mmcblk0p5` — as its own data-drive selection during setup. Choosing **Preserve** for it failed with:

> "Preserve" was selected, but no StartOS data was found on /dev/mmcblk0p5.

…even though the pool was intact and the setup wizard had just offered the drive as preservable.

## Root cause

The two decisions run over **two different disk enumerations**:

- **Setup wizard drive list** (`setup::list_disks`) enumerates with the real `OsPartitionInfo` (`from_fstab`). The booted OS disk (`mmcblk0`) is marked `internal`, so its data partition is **promoted to a top-level `DiskInfo`** keyed by the partition path (`/dev/mmcblk0p5`, guid `EMBASSY_…_UNENC`). → UI offers Preserve.
- **Install plan** (`install_os_inner`) enumerates with `OsPartitionInfo::default()` (empty). `mmcblk0` is **not** `internal`, so `p5` stays **nested** under `/dev/mmcblk0`. `plan_data_drive` then does `disks.iter().find(|d| d.logicalname == "/dev/mmcblk0p5")` → `None` → `(_, None, None)` → the "no StartOS data" error.

So the exact partition path the frontend sent (proven by the error string, which prints `data_drive.logicalname`) had no matching top-level disk in the install-time view — it was only present as a nested partition. The failure is guid-independent; it bites any pool (`STARTOS_`/`EMBASSY_`, encrypted or `_UNENC`) on a Pi data partition.

## Fix

Resolve the pool on the **exact selected partition path** directly when the target isn't a top-level disk:

```rust
if disk.is_none() {
    if let Some(guid) = disks.iter().find_map(|d| {
        d.partitions.iter().find(|p| p.logicalname == target)
            .and_then(|p| p.guid.as_ref().filter(|g| is_startos_pool_guid(g)).cloned())
    }) {
        return Ok(DataDrivePlan::Attach(guid));
    }
}
```

## Why it's low-risk

- Only ever returns `DataDrivePlan::Attach` (import of an existing VG). It **never** returns `Create`, so it cannot reformat / destroy data. A bad attach fails cleanly at `import()`.
- Gated on `disk.is_none()`, and on the install path (empty `OsPartitionInfo`) a partition path can never *also* be a top-level disk in the same enumeration — so it can't shadow an existing arm.
- `p.logicalname == target` is exact, globally-unique device-path equality (both sides `canonicalize`d in `list()`), so it can only match the partition the user selected — never a pool on another disk.
- Existing whole-disk flows (x86) select a disk that *is* enumerated top-level, so `disk` is `Some` and the branch is skipped. All 8 pre-existing `plan_data_drive` tests pass unchanged.

## Tests

Added `preserve_data_partition_by_path_attaches` covering the Pi case (`/dev/mmcblk0p5` with an `EMBASSY_…_UNENC` pool). `cargo test -p start-core --lib os_install::tests` → 9 passed.

No version bump / changelog — hotfix on already-released code.
