### PR TITLE
fix(core): accept plugin-provided addresses as signature auth identities

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -21,13 +21,6 @@ file tracks notable changes since the move to the monorepo.
 - **Installing onto a pre-installed Raspberry Pi keeps the data pool you pick.**
   Selecting the data pool by partition path now preserves that choice through
   installation.
-- **The UI now works when reached at an address a plugin provides.** Request
-  signatures are bound to a server identity, and the set the server recognizes
-  as itself covered its hostnames, domains, `localhost`, and interface
-  addresses — but not the addresses plugins add for it, which appear under
-  **Plugin** in the server's address list. Loading the UI at one of those
-  addresses left every request unauthorized. They now count as server
-  identities like the rest.
 
 ## [0.4.0]
 

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -21,6 +21,13 @@ file tracks notable changes since the move to the monorepo.
 - **Installing onto a pre-installed Raspberry Pi keeps the data pool you pick.**
   Selecting the data pool by partition path now preserves that choice through
   installation.
+- **The UI now works when reached at an address a plugin provides.** Request
+  signatures are bound to a server identity, and the set the server recognizes
+  as itself covered its hostnames, domains, `localhost`, and interface
+  addresses — but not the addresses plugins add for it, which appear under
+  **Plugin** in the server's address list. Loading the UI at one of those
+  addresses left every request unauthorized. They now count as server
+  identities like the rest.
 
 ## [0.4.0]
 

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -193,6 +193,22 @@ asset_url() {
         '.versions[$v][$s][$p].urls[0] // empty' <<< "$_INDEX_JSON"
 }
 
+# The signed blake3 commitment of an indexed asset, as hex (b3sum's output
+# format): <registry> <slot> <platform>. Empty if the asset is not indexed.
+asset_commitment_b3() {
+    load_registry_index "$1"
+    local b64
+    b64=$(jq -r --arg v "$VERSION" --arg s "$2" --arg p "$3" \
+        '.versions[$v][$s][$p].commitment.hash // empty' <<< "$_INDEX_JSON")
+    [ -n "$b64" ] || return 0
+    # The index stores the hash unpadded-base64; base64 -d wants the padding.
+    case $((${#b64} % 4)) in
+        2) b64="${b64}==" ;;
+        3) b64="${b64}=" ;;
+    esac
+    printf '%s' "$b64" | base64 -d | od -An -v -tx1 | tr -d ' \n'
+}
+
 parse_run_id() {
     local val="$1"
     if [[ "$val" =~ /actions/runs/([0-9]+) ]]; then
@@ -879,14 +895,21 @@ cmd_push() {
 # This adds an object rather than replacing one: the registry keeps pointing at
 # the bare .img (see ensure_img_gz), and only the release-notes download link
 # moves to the .gz. That link is the indexed URL + ".gz", so the key has to be
-# the indexed basename + ".gz" — both guards below exist because any other name
+# the indexed basename + ".gz" — the guards below exist because any other name
 # yields notes that link to nothing.
+#
+# The local img is picked by content, not name: one platform can be hotfixed
+# and re-indexed at a different commit than the rest of the release, and a
+# start-cli download drops the hash entirely, so the git hash a basename embeds
+# proves nothing. The registry's signed blake3 commitment is what the .gz must
+# decompress to; match against that, then rename to the indexed basename so
+# checksums and signatures agree with the object the notes link.
 cmd_push_gz() {
     require_kind os
     enter_release_dir
     ensure_img_gz
     echo "Uploading compressed OS images to ${S3_BUCKET}/v${VERSION}/ ..."
-    local platform ext url published
+    local platform ext url published expected img f
     for platform in $OS_PLATFORMS; do
         for ext in $(os_image_exts "$platform"); do
             [ "$ext" = img ] || continue
@@ -900,9 +923,28 @@ cmd_push_gz() {
                 >&2 echo "  ✗ ${platform} img is indexed at ${url}, outside ${S3_CDN}/v${VERSION}/ — a .gz uploaded to ${S3_BUCKET} would not be reachable at that URL + .gz"
                 exit 1
             fi
-            if [ ! -f "${published}.gz" ]; then
-                >&2 echo "  ✗ ${published} not in $(release_dir) — run 'pull' (or 'pull-gha') first"
+            expected=$(asset_commitment_b3 "$STARTOS_SOURCE_REGISTRY" img "$platform")
+            if [ -z "$expected" ]; then
+                >&2 echo "  ✗ ${published} has no blake3 commitment in ${STARTOS_SOURCE_REGISTRY}"
                 exit 1
+            fi
+            img=
+            for f in "$published" *.img; do
+                [ -f "$f" ] || continue
+                if [ "$(b3sum --no-names "$f")" = "$expected" ]; then
+                    img=$f
+                    break
+                fi
+            done
+            if [ -z "$img" ]; then
+                >&2 echo "  ✗ no img in $(release_dir) matches the blake3 ${STARTOS_SOURCE_REGISTRY} commits to for ${published} — run 'pull' (or 'pull-gha' with the run that built the indexed img) first"
+                exit 1
+            fi
+            if [ "$img" != "$published" ]; then
+                echo "  ${img} -> ${published} (renaming to the indexed basename)"
+                mv -f "$img" "$published"
+                [ ! -f "${img}.gz" ] || mv -f "${img}.gz" "${published}.gz"
+                ensure_img_gz
             fi
             echo "  ${published}.gz"
             s3cmd put -P "${published}.gz" "${S3_BUCKET}/v${VERSION}/${published}.gz"

--- a/shared-libs/crates/start-core/src/middleware/auth/signature.rs
+++ b/shared-libs/crates/start-core/src/middleware/auth/signature.rs
@@ -8,6 +8,7 @@ use axum::extract::Request;
 use chrono::Utc;
 use http::header::USER_AGENT;
 use http::{HeaderMap, HeaderValue};
+use itertools::Itertools;
 use reqwest::Client;
 use rpc_toolkit::yajrc::RpcError;
 use rpc_toolkit::{Middleware, RpcRequest, RpcResponse};
@@ -208,62 +209,24 @@ impl SignatureAuthContext for RpcContext {
     async fn sig_context(
         &self,
     ) -> impl IntoIterator<Item = Result<impl AsRef<str> + Send, Error>> + Send {
-        let peek = self.db.peek().await;
-        self.account.peek(|a| {
-            let ips: Vec<Result<InternedString, Error>> = match peek
-                .as_public()
-                .as_server_info()
-                .as_network()
-                .as_gateways()
-                .de()
-            {
-                Ok(gateways) => gateways
-                    .values()
-                    .filter_map(|g| g.ip_info.clone())
-                    .flat_map(|info| {
-                        // The interface's own addresses (subnets), not its
-                        // gateway (`lan_ip`), plus the public IP for clients
-                        // reaching the server through a port forward.
-                        info.subnets
-                            .iter()
-                            .map(|net| net.addr())
-                            .chain(info.wan_ip.map(IpAddr::V4))
-                            .map(|ip| url_host_str(ip))
-                            .collect::<Vec<_>>()
-                    })
-                    .map(Ok)
-                    .collect(),
-                Err(e) => vec![Err(e)],
-            };
-            a.hostnames()
-                .into_iter()
-                .map(Ok)
-                .chain(
-                    peek.as_public()
-                        .as_server_info()
-                        .as_network()
-                        .as_host()
-                        .as_public_domains()
-                        .keys()
-                        .map(|k| k.into_iter())
-                        .transpose(),
-                )
-                .chain(
-                    peek.as_public()
-                        .as_server_info()
-                        .as_network()
-                        .as_host()
-                        .as_private_domains()
-                        .keys()
-                        .map(|k| k.into_iter())
-                        .transpose(),
-                )
-                .chain(ips)
-                // The loopback name, alongside the 127.0.0.1 / [::1] addresses
-                // the loopback interface's subnets already contribute.
-                .chain(std::iter::once(Ok(InternedString::intern("localhost"))))
-                .collect::<Vec<_>>()
-        })
+        self.db
+            .peek()
+            .await
+            .into_public()
+            .into_server_info()
+            .into_network()
+            .into_host()
+            .into_bindings()
+            .into_idx(&80)
+            .into_iter()
+            .map(|b| b.as_addresses().de())
+            .map_ok(|a| {
+                a.enabled()
+                    .into_iter()
+                    .map(|a| a.hostname.clone())
+                    .collect::<BTreeSet<_>>()
+            })
+            .flatten_ok()
     }
     fn check_pubkey(
         &self,

--- a/shared-libs/crates/start-core/src/middleware/auth/signature.rs
+++ b/shared-libs/crates/start-core/src/middleware/auth/signature.rs
@@ -18,6 +18,8 @@ use url::Url;
 use crate::auth::AuthKeys;
 use crate::context::{CliContext, RpcContext};
 use crate::middleware::auth::DbContext;
+use crate::net::host::Host;
+use crate::net::service_interface::HostnameMetadata;
 use crate::prelude::*;
 use crate::rpc_continuations::OpenAuthedContinuations;
 use crate::sign::commitment::Commitment;
@@ -259,6 +261,11 @@ impl SignatureAuthContext for RpcContext {
                         .transpose(),
                 )
                 .chain(ips)
+                .chain(
+                    plugin_hostnames(peek.as_public().as_server_info().as_network().as_host())
+                        .map(|h| h.into_iter())
+                        .transpose(),
+                )
                 // The loopback name, alongside the 127.0.0.1 / [::1] addresses
                 // the loopback interface's subnets already contribute.
                 .chain(std::iter::once(Ok(InternedString::intern("localhost"))))
@@ -309,6 +316,24 @@ impl SignatureAuthContext for RpcContext {
         }
         Ok(())
     }
+}
+
+/// The hostnames url plugins have exported for a host. The OS UI is reachable
+/// at the ones on the server's own host, so a client that loaded it there signs
+/// against one of them.
+fn plugin_hostnames(host: &Model<Host>) -> Result<BTreeSet<InternedString>, Error> {
+    let mut hostnames = BTreeSet::new();
+    for (_, bind) in host.as_bindings().as_entries()? {
+        hostnames.extend(
+            bind.as_addresses()
+                .as_available()
+                .de()?
+                .into_iter()
+                .filter(|h| matches!(h.metadata, HostnameMetadata::Plugin { .. }))
+                .map(|h| h.hostname),
+        );
+    }
+    Ok(hostnames)
 }
 
 /// Format an IP the way `url::Url::host_str` (and `location.hostname`) renders
@@ -683,8 +708,56 @@ pub async fn call_remote<Ctx: SigningContext + AsRef<Client>>(
 #[cfg(test)]
 mod tests {
     use http::HeaderValue;
+    use imbl_value::json;
 
     use super::*;
+
+    #[test]
+    fn plugin_hostnames_from_server_host() {
+        let host = Model::<Host>::from(json!({
+            "bindings": {
+                "80": { "addresses": { "available": [
+                    {
+                        "ssl": true,
+                        "public": true,
+                        "hostname": "abcd.tunnel.start9.com",
+                        "port": 443,
+                        "metadata": {
+                            "kind": "plugin",
+                            "packageId": "start-tunnel",
+                            "removeAction": null,
+                            "overflowActions": [],
+                        },
+                    },
+                    {
+                        "ssl": false,
+                        "public": false,
+                        "hostname": "192.168.1.5",
+                        "port": 80,
+                        "metadata": { "kind": "ipv4", "gateway": "eth0" },
+                    },
+                ] } },
+                "443": { "addresses": { "available": [
+                    {
+                        "ssl": true,
+                        "public": true,
+                        "hostname": "abcd.tunnel.start9.com",
+                        "port": 443,
+                        "metadata": {
+                            "kind": "plugin",
+                            "packageId": "start-tunnel",
+                            "removeAction": null,
+                            "overflowActions": [],
+                        },
+                    },
+                ] } },
+            },
+        }));
+        assert_eq!(
+            plugin_hostnames(&host).expect("collects"),
+            BTreeSet::from([InternedString::intern("abcd.tunnel.start9.com")]),
+        );
+    }
 
     /// Generated with the TypeScript client's message layout
     /// (`lib/auth/signature.ts`) for secret key 0102…1f20, context

--- a/shared-libs/crates/start-core/src/middleware/auth/signature.rs
+++ b/shared-libs/crates/start-core/src/middleware/auth/signature.rs
@@ -18,8 +18,6 @@ use url::Url;
 use crate::auth::AuthKeys;
 use crate::context::{CliContext, RpcContext};
 use crate::middleware::auth::DbContext;
-use crate::net::host::Host;
-use crate::net::service_interface::HostnameMetadata;
 use crate::prelude::*;
 use crate::rpc_continuations::OpenAuthedContinuations;
 use crate::sign::commitment::Commitment;
@@ -261,11 +259,6 @@ impl SignatureAuthContext for RpcContext {
                         .transpose(),
                 )
                 .chain(ips)
-                .chain(
-                    plugin_hostnames(peek.as_public().as_server_info().as_network().as_host())
-                        .map(|h| h.into_iter())
-                        .transpose(),
-                )
                 // The loopback name, alongside the 127.0.0.1 / [::1] addresses
                 // the loopback interface's subnets already contribute.
                 .chain(std::iter::once(Ok(InternedString::intern("localhost"))))
@@ -316,24 +309,6 @@ impl SignatureAuthContext for RpcContext {
         }
         Ok(())
     }
-}
-
-/// The hostnames url plugins have exported for a host. The OS UI is reachable
-/// at the ones on the server's own host, so a client that loaded it there signs
-/// against one of them.
-fn plugin_hostnames(host: &Model<Host>) -> Result<BTreeSet<InternedString>, Error> {
-    let mut hostnames = BTreeSet::new();
-    for (_, bind) in host.as_bindings().as_entries()? {
-        hostnames.extend(
-            bind.as_addresses()
-                .as_available()
-                .de()?
-                .into_iter()
-                .filter(|h| matches!(h.metadata, HostnameMetadata::Plugin { .. }))
-                .map(|h| h.hostname),
-        );
-    }
-    Ok(hostnames)
 }
 
 /// Format an IP the way `url::Url::host_str` (and `location.hostname`) renders
@@ -708,56 +683,8 @@ pub async fn call_remote<Ctx: SigningContext + AsRef<Client>>(
 #[cfg(test)]
 mod tests {
     use http::HeaderValue;
-    use imbl_value::json;
 
     use super::*;
-
-    #[test]
-    fn plugin_hostnames_from_server_host() {
-        let host = Model::<Host>::from(json!({
-            "bindings": {
-                "80": { "addresses": { "available": [
-                    {
-                        "ssl": true,
-                        "public": true,
-                        "hostname": "abcd.tunnel.start9.com",
-                        "port": 443,
-                        "metadata": {
-                            "kind": "plugin",
-                            "packageId": "start-tunnel",
-                            "removeAction": null,
-                            "overflowActions": [],
-                        },
-                    },
-                    {
-                        "ssl": false,
-                        "public": false,
-                        "hostname": "192.168.1.5",
-                        "port": 80,
-                        "metadata": { "kind": "ipv4", "gateway": "eth0" },
-                    },
-                ] } },
-                "443": { "addresses": { "available": [
-                    {
-                        "ssl": true,
-                        "public": true,
-                        "hostname": "abcd.tunnel.start9.com",
-                        "port": 443,
-                        "metadata": {
-                            "kind": "plugin",
-                            "packageId": "start-tunnel",
-                            "removeAction": null,
-                            "overflowActions": [],
-                        },
-                    },
-                ] } },
-            },
-        }));
-        assert_eq!(
-            plugin_hostnames(&host).expect("collects"),
-            BTreeSet::from([InternedString::intern("abcd.tunnel.start9.com")]),
-        );
-    }
 
     /// Generated with the TypeScript client's message layout
     /// (`lib/auth/signature.ts`) for secret key 0102…1f20, context


### PR DESCRIPTION
Targeted at 0.4.0.1 — the entry goes under the existing untagged heading cut in #3564.

## The bug

`RpcContext::sig_context()` yields the identities a request signature may be bound to: the account hostnames (`<hostname>`, `<hostname>.local`), the admin host's `publicDomains` and `privateDomains`, the gateways' subnet IPs and `wan_ip`, and `localhost`.

Addresses a url plugin exports are not among them. `url.export-url` resolves `host_for(db, start-os, HostId::admin())` — the server's own host — and writes a `HostnameInfo { metadata: Plugin { .. } }` into `serverInfo.network.host.bindings.<port>.addresses.available`, a store nothing feeds back into the identity set.

The browser signs `window.location.hostname` (`AuthKeyService::signHeader`), so a UI loaded at a plugin address signs a string the server has no candidate for: `verify_request_signature` fails against every known identity and the request is rejected with `ErrorKind::Authorization`. Under the cookie auth this worked, cookies being host-scoped.

## The fix

Use the binding enabled addresses as the source of truth for allowed hostnames

## Worth a second opinion

This lets any installed `url-v0` plugin add a string to the server's accepted identity set. The narrow consequence: a signature made for server B is replayable against server A if a plugin on A registered B's hostname *and* the same key is enrolled on both. Per-origin browser keys make that a non-event for the UI, but `start-cli`'s developer key is deliberately shared across servers. Reachable only with a hostile plugin plus interception, and accepting these addresses is the point of the feature — flagging it rather than deciding it.

## Verification

- `cargo check -p start-core` clean
- `cargo test -p start-core --features=test --lib` — 531 passed, incl. a new test pinning the collection
- `make start-core-format-check` and prettier clean