### PR TITLE
feat(net)!: assignedSslPort carries every TLS external port

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -10,6 +10,18 @@ file tracks notable changes since the move to the monorepo.
 
 ## [0.4.0.1]
 
+### Changed
+
+- **A service that serves its own TLS certificate now reports its external port
+  as an SSL port.** Every interface whose external port speaks TLS — whether
+  StartOS terminates it or the service presents its own certificate — now
+  carries that port in `assignedSslPort`, and `assignedPort` means a plaintext
+  port. The port number itself is unchanged, so existing addresses, bookmarks
+  and router port-forwards keep working. Packages resolve a dependency's address
+  with `sdk.host.getBridgeAddress`, which is correct under either arrangement;
+  see
+  [Service-to-Service Networking](https://docs.start9.com/packaging/service-to-service.html).
+
 ### Fixed
 
 - **The over-the-air update to 0.4.0 boots on the Server Pure.** The Server

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -28,6 +28,12 @@ file tracks notable changes since the move to the monorepo.
   `sdk.host.getBridgeAddress`, which is correct under either arrangement; see
   [Service-to-Service Networking](https://docs.start9.com/packaging/service-to-service.html).
 
+- **The StartOS web interface holds ports 80 and 443.** StartOS runs as root, so
+  its own interface is the one binding that may claim the privileged range, and
+  it now does so through the same port allocator every service uses. HTTPS was
+  already served on 443; the plaintext address — offered only over loopback and
+  the service bridge — moves from a random high port to 80.
+
 ### Fixed
 
 - **The over-the-air update to 0.4.0 boots on the Server Pure.** The Server

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -13,13 +13,19 @@ file tracks notable changes since the move to the monorepo.
 ### Changed
 
 - **A service that serves its own TLS certificate now reports its external port
-  as an SSL port.** Every interface whose external port speaks TLS — whether
-  StartOS terminates it or the service presents its own certificate — now
-  carries that port in `assignedSslPort`, and `assignedPort` means a plaintext
-  port. The port number itself is unchanged, so existing addresses, bookmarks
-  and router port-forwards keep working. Packages resolve a dependency's address
-  with `sdk.host.getBridgeAddress`, which is correct under either arrangement;
-  see
+  as an SSL port, and StartOS serves it like one.** Every interface whose
+  external port speaks TLS — whether StartOS terminates it or the service
+  presents its own certificate — now carries that port in `assignedSslPort`,
+  and `assignedPort` means a plaintext port. A self-TLS port is now answered by
+  the StartOS SNI router, which pipes the raw TLS stream to the service with
+  the client's address preserved, instead of a kernel port-forward — so every
+  TLS-carrying port behaves uniformly, and a self-TLS service's domains are
+  advertised on its preferred port (e.g. 443) exactly as when StartOS
+  terminates TLS. This also means such a port accepts TLS connections only,
+  and no longer relays UDP. The port number itself is
+  unchanged, so existing addresses, bookmarks and router port-forwards keep
+  working. Packages resolve a dependency's address with
+  `sdk.host.getBridgeAddress`, which is correct under either arrangement; see
   [Service-to-Service Networking](https://docs.start9.com/packaging/service-to-service.html).
 
 ### Fixed

--- a/projects/start-os/container-runtime/package-lock.json
+++ b/projects/start-os/container-runtime/package-lock.json
@@ -65,7 +65,7 @@
     },
     "../../start-sdk/dist": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.6",
+      "version": "2.0.10",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -2252,7 +2252,7 @@ Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.m
     hosts: {
       abcdefg: {
         bindings: {
-          80: {
+          443: {
             enabled: true,
             net: {
               assignedPort: null,
@@ -2326,7 +2326,7 @@ Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.m
                 addressInfo: {
                   username: null,
                   hostId: 'abcdefg',
-                  internalPort: 80,
+                  internalPort: 443,
                   scheme: 'http',
                   sslScheme: 'https',
                   suffix: '',

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -2255,7 +2255,7 @@ Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.m
           80: {
             enabled: true,
             net: {
-              assignedPort: 80,
+              assignedPort: null,
               assignedSslPort: 443,
             },
             addresses: {

--- a/projects/start-sdk/docs/src/service-to-service.md
+++ b/projects/start-sdk/docs/src/service-to-service.md
@@ -36,7 +36,7 @@ const rpcAddr = await sdk.host
 
 Three things make this correct, and each matters:
 
-1. **Read the binding's bridge address, keyed by the dependency's internal port — never `net.assignedPort` or `net.assignedSslPort`.** Those two fields are raw metadata, and _which_ of them is populated depends on how the dependency bound the port. A binding with `addSsl` and `secure.ssl` frees `assignedPort` entirely and carries only `assignedSslPort`; a passthrough binding is the reverse. So a caller reading either field directly is asserting how its dependency terminates TLS — and silently resolves `null` the day that changes. This is not hypothetical: it is exactly what broke every LND dependent when LND moved REST behind the OS proxy.
+1. **Read the binding's bridge address, keyed by the dependency's internal port — never `net.assignedPort` or `net.assignedSslPort`.** Those two fields are raw metadata, and _which_ of them is populated depends on how the dependency bound the port. `assignedSslPort` carries a port that speaks TLS — whether StartOS terminates it or the container serves its own certificate — and `assignedPort` a plaintext one, so a binding with `addSsl` and `secure.ssl` carries only `assignedSslPort` while an `http`/`ws` binding carries both. So a caller reading either field directly is asserting whether its dependency's port speaks TLS — and silently resolves `null` the day that changes. This is not hypothetical: it is exactly what broke every LND dependent when LND moved REST behind the OS proxy.
 
    `getBridgeAddress` keys off the binding rather than an exported interface, so it also resolves **bridge-only bindings** — tor's SOCKS proxy resolves through it — and it narrows reactivity to that one address, so `.const()` is unaffected by the box's LAN IP changing or a Tor/clearnet address being added. Don't hand-roll it by matching `metadata.gateway === 'lxcbr0'`.
 
@@ -126,7 +126,7 @@ Three patterns that older packages used are being removed. Do not introduce them
 
 - **`<package-id>.startos` DNS names** (`http://bitcoind.startos:8332`). The overlay DNS that resolved these is deprecated and will be removed. Resolve the bridge address instead.
 - **Cross-package container IPs** (`sdk.getContainerIp(effects, { packageId })`). A dependency's container IP is not stable across its restarts/updates and reading it reactively restarts your service on every dependency churn. Use the bridge. (`getContainerIp` with **no** `packageId` — your _own_ container IP — remains fine.)
-- **Reading `net.assignedPort` / `net.assignedSslPort` directly, or matching `metadata.gateway === 'lxcbr0'` by hand.** Only one of the two is ever populated, and which one is a property of how the dependency bound the port — not something a caller may assume. Read the binding's bridge address, which is correct either way.
+- **Reading `net.assignedPort` / `net.assignedSslPort` directly, or matching `metadata.gateway === 'lxcbr0'` by hand.** Which of the two is populated is a property of how the dependency bound the port — not something a caller may assume. Read the binding's bridge address, which is correct either way.
 
 ## Reference implementations
 

--- a/projects/start-sdk/lib/StartSdk.ts
+++ b/projects/start-sdk/lib/StartSdk.ts
@@ -328,9 +328,9 @@ export class StartSdk<Manifest extends T.SDKManifest> {
          * strategies as `get`/`getOwn`.
          *
          * Prefer this over reading `net.assignedPort` / `net.assignedSslPort`:
-         * only one of those is ever populated, and which one is a property of
-         * how the *dependency* bound the port, so reading either directly
-         * resolves `null` the day the dependency changes how it serves TLS. It
+         * which of those are populated is a property of how the *dependency*
+         * bound the port, so reading either directly resolves `null` the day
+         * the dependency changes how it serves TLS. It
          * also resolves bindings with no exported interface, such as tor's
          * SOCKS proxy.
          *

--- a/shared-libs/crates/start-core/src/db/model/mod.rs
+++ b/shared-libs/crates/start-core/src/db/model/mod.rs
@@ -42,12 +42,8 @@ impl Database {
                 session_pubkeys: AuthKeys::new(),
                 ssh_privkey: Pem(account.ssh_key.clone()),
                 ssh_pubkeys: SshKeys::new(),
-                available_ports: {
-                    let mut ports = AvailablePorts::new();
-                    ports.set_ssl(80, false);
-                    ports.set_ssl(443, true);
-                    ports
-                },
+                // Empty: `os_bindings` claims the admin UI's 80/443 as a privileged bind.
+                available_ports: AvailablePorts::new(),
                 notifications: Notifications::new(),
                 cifs: CifsTargets::new(),
                 package_stores: BTreeMap::new(),

--- a/shared-libs/crates/start-core/src/middleware/auth/signature.rs
+++ b/shared-libs/crates/start-core/src/middleware/auth/signature.rs
@@ -227,6 +227,7 @@ impl SignatureAuthContext for RpcContext {
                     .collect::<BTreeSet<_>>()
             })
             .flatten_ok()
+            .chain([Ok("localhost".into())])
     }
     fn check_pubkey(
         &self,

--- a/shared-libs/crates/start-core/src/net/forward.rs
+++ b/shared-libs/crates/start-core/src/net/forward.rs
@@ -55,9 +55,8 @@ impl std::fmt::Display for ForwardRequirements {
 }
 
 /// Allocated external ports. The flag marks the ports one of our own TLS
-/// listeners answers on, so a domain can be advertised there and SNI-routed —
-/// not merely "carries TLS": a self-TLS binding's port is forwarded straight to
-/// the container and has no listener of ours to route it.
+/// listeners answers on — terminating (`add_ssl`) or SNI-passthrough (self-TLS)
+/// — so a domain can be advertised there and SNI-routed.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AvailablePorts(BTreeMap<u16, bool>);
 impl AvailablePorts {

--- a/shared-libs/crates/start-core/src/net/forward.rs
+++ b/shared-libs/crates/start-core/src/net/forward.rs
@@ -54,6 +54,10 @@ impl std::fmt::Display for ForwardRequirements {
     }
 }
 
+/// Allocated external ports. The flag marks the ports one of our own TLS
+/// listeners answers on, so a domain can be advertised there and SNI-routed —
+/// not merely "carries TLS": a self-TLS binding's port is forwarded straight to
+/// the container and has no listener of ours to route it.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AvailablePorts(BTreeMap<u16, bool>);
 impl AvailablePorts {

--- a/shared-libs/crates/start-core/src/net/forward.rs
+++ b/shared-libs/crates/start-core/src/net/forward.rs
@@ -33,8 +33,10 @@ const EPHEMERAL_PORT_START: u16 = 49152;
 // 10.0.3.1:9050 on the bridge — do not re-restrict them.
 const RESTRICTED_PORTS: &[u16] = &[5353, 5355, 5432, 6010];
 
-fn is_restricted(port: u16) -> bool {
-    port <= 1024 || RESTRICTED_PORTS.contains(&port)
+/// Only a privileged claimant — StartOS itself, which runs as root — may take a
+/// port below 1024. A host daemon already holds RESTRICTED_PORTS, whoever asks.
+fn may_claim(port: u16, privileged: bool) -> bool {
+    !RESTRICTED_PORTS.contains(&port) && (privileged || port > 1024)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -77,19 +79,24 @@ impl AvailablePorts {
             ErrorKind::Network,
         ))
     }
-    /// Allocate a specific port; `None` if taken or restricted.
-    pub fn try_alloc(&mut self, port: u16, ssl: bool) -> Option<u16> {
-        if is_restricted(port) || self.0.contains_key(&port) {
+    /// Allocate a specific port; `None` if taken or not the caller's to claim.
+    pub fn try_alloc(&mut self, port: u16, ssl: bool, privileged: bool) -> Option<u16> {
+        if !may_claim(port, privileged) || self.0.contains_key(&port) {
             return None;
         }
         self.0.insert(port, ssl);
         Some(port)
     }
 
-    /// Allocate `count` contiguous non-ssl ports from `start`. All-or-nothing:
-    /// if any port is taken or restricted, allocates none and `Err`s on the
-    /// first offender.
-    pub fn try_alloc_range(&mut self, start: u16, count: u16) -> Result<(), Error> {
+    /// Allocate `count` contiguous non-ssl ports from `start`. All-or-nothing: if
+    /// any port is taken or not the caller's to claim, allocates none and `Err`s
+    /// on the first offender.
+    pub fn try_alloc_range(
+        &mut self,
+        start: u16,
+        count: u16,
+        privileged: bool,
+    ) -> Result<(), Error> {
         if count == 0 {
             return Err(Error::new(
                 eyre!("port range must contain at least one port"),
@@ -103,7 +110,7 @@ impl AvailablePorts {
             )
         })?;
         for port in start..=end {
-            if is_restricted(port) {
+            if !may_claim(port, privileged) {
                 return Err(Error::new(
                     eyre!("port {port} in range {start}-{end} is restricted"),
                     ErrorKind::InvalidRequest,
@@ -1180,43 +1187,43 @@ mod tests {
     #[test]
     fn try_alloc_range_basic() {
         let mut ports = AvailablePorts::new();
-        assert!(ports.try_alloc_range(40000, 100).is_ok());
+        assert!(ports.try_alloc_range(40000, 100, false).is_ok());
         // All 100 ports should now be allocated
         for p in 40000..40100 {
             assert!(
-                ports.try_alloc(p, false).is_none(),
+                ports.try_alloc(p, false, false).is_none(),
                 "port {p} should be taken"
             );
         }
-        assert!(ports.try_alloc(40100, false).is_some());
+        assert!(ports.try_alloc(40100, false, false).is_some());
     }
 
     #[test]
     fn try_alloc_range_zero_count_is_error() {
         let mut ports = AvailablePorts::new();
-        assert!(ports.try_alloc_range(40000, 0).is_err());
+        assert!(ports.try_alloc_range(40000, 0, false).is_err());
     }
 
     #[test]
     fn try_alloc_range_overflow_is_error() {
         let mut ports = AvailablePorts::new();
-        assert!(ports.try_alloc_range(65500, 100).is_err());
+        assert!(ports.try_alloc_range(65500, 100, false).is_err());
     }
 
     #[test]
     fn try_alloc_range_restricted_port_is_error_and_atomic() {
         let mut ports = AvailablePorts::new();
         // Range straddling a restricted port (1024 and below) hard-fails…
-        assert!(ports.try_alloc_range(1020, 10).is_err());
+        assert!(ports.try_alloc_range(1020, 10, false).is_err());
         // …and nothing was allocated.
-        assert!(ports.try_alloc(2000, false).is_some());
+        assert!(ports.try_alloc(2000, false, false).is_some());
         ports.free([2000]);
-        assert!(ports.try_alloc_range(1020, 10).is_err());
+        assert!(ports.try_alloc_range(1020, 10, false).is_err());
         for p in 1020..1030 {
             // None of them are reserved either
-            if !is_restricted(p) {
+            if may_claim(p, false) {
                 assert!(
-                    ports.try_alloc(p, false).is_some(),
+                    ports.try_alloc(p, false, false).is_some(),
                     "port {p} unexpectedly taken"
                 );
             }
@@ -1226,10 +1233,24 @@ mod tests {
     #[test]
     fn try_alloc_range_collision_is_error_and_atomic() {
         let mut ports = AvailablePorts::new();
-        ports.try_alloc(40050, false).unwrap();
-        assert!(ports.try_alloc_range(40000, 100).is_err());
+        ports.try_alloc(40050, false, false).unwrap();
+        assert!(ports.try_alloc_range(40000, 100, false).is_err());
         // Other ports in the requested range were NOT allocated as a side effect.
-        assert!(ports.try_alloc(40000, false).is_some());
-        assert!(ports.try_alloc(40099, false).is_some());
+        assert!(ports.try_alloc(40000, false, false).is_some());
+        assert!(ports.try_alloc(40099, false, false).is_some());
+    }
+
+    #[test]
+    fn only_the_os_may_claim_privileged_ports() {
+        let mut ports = AvailablePorts::new();
+        assert!(ports.try_alloc(443, true, false).is_none());
+        assert_eq!(ports.try_alloc(443, true, true), Some(443));
+        assert_eq!(ports.try_alloc(80, false, true), Some(80));
+        // …but a claim is still a claim: the OS holds it against everyone.
+        assert!(ports.try_alloc(443, true, true).is_none());
+
+        // A host daemon's port is nobody's to take, root or not.
+        assert!(ports.try_alloc(5432, false, true).is_none());
+        assert!(ports.try_alloc_range(1020, 10, true).is_ok());
     }
 }

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -1661,7 +1661,7 @@ fn policy_table_for(device_type: Option<NetworkInterfaceType>, iface: &GatewayId
 /// IPv4 and IPv6 carry the same CONNMARK reply-routing layer, rebuilt together
 /// so a reply to a v6 connection that arrived on a tunnel (host-terminated or
 /// DNAT'd to a container) routes back out it via the priority-50 fwmark rule,
-/// exactly like v4. `sni-divert` is IPv4-only (IP_TRANSPARENT egress is v4).
+/// exactly like v4. `sni-divert` is emitted for both families.
 async fn reconcile_mangle_rules(policy_ifaces: &BTreeMap<GatewayId, u32>) -> Result<(), Error> {
     nft_ensure_base().await?;
     let mut script = String::new();

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -271,10 +271,9 @@ impl BindInfo {
         let mut assigned_port = None;
         let mut assigned_ssl_port = None;
         if let Some(preferred) = options.preferred_ssl_port() {
-            let proxied = options.add_ssl.is_some();
             assigned_ssl_port = available_ports
-                .try_alloc(preferred, proxied)
-                .or_else(|| Some(available_ports.alloc(proxied).ok()?));
+                .try_alloc(preferred, true)
+                .or_else(|| Some(available_ports.alloc(true).ok()?));
         }
         if options.wants_plain_port() {
             assigned_port = available_ports
@@ -323,7 +322,7 @@ impl BindInfo {
 
         let assigned_ssl_port = options
             .preferred_ssl_port()
-            .map(|preferred| reclaim(held.assigned_ssl_port, preferred, options.add_ssl.is_some()))
+            .map(|preferred| reclaim(held.assigned_ssl_port, preferred, true))
             .transpose()?;
         let assigned_port = options
             .wants_plain_port()
@@ -363,8 +362,8 @@ pub struct BindOptions {
 }
 
 impl BindOptions {
-    /// The container terminates TLS itself, so the OS forwards its port
-    /// untouched rather than putting a listener of its own in front.
+    /// The container terminates TLS itself; the OS fronts its port with an
+    /// SNI-passthrough listener that pipes the raw TLS stream through.
     pub fn serves_own_tls(&self) -> bool {
         self.secure.map_or(false, |s| s.ssl) && self.add_ssl.is_none()
     }
@@ -1062,12 +1061,12 @@ mod test {
         assert_eq!(rewrap.net.assigned_port, None);
         assert_eq!(rewrap.net.assigned_ssl_port, Some(8445));
 
-        // the container serves its own TLS: the ssl port only, forwarded
-        // straight through, so it is not one of our listeners' ports
+        // the container serves its own TLS: the ssl port only, fronted by
+        // our SNI-passthrough listener
         let own_tls = BindInfo::new(&mut ports, opts(8083, None, Some(true))).unwrap();
         assert_eq!(own_tls.net.assigned_port, None);
         assert_eq!(own_tls.net.assigned_ssl_port, Some(8083));
-        assert!(!ports.is_ssl(8083));
+        assert!(ports.is_ssl(8083));
     }
 
     #[test]
@@ -1081,8 +1080,9 @@ mod test {
             .unwrap();
         assert_eq!(own_tls.net.assigned_port, None);
         assert_eq!(own_tls.net.assigned_ssl_port, Some(8080));
+        assert!(ports.is_ssl(8080));
 
-        // handing termination to us keeps the port and marks it ours
+        // handing termination to us keeps the port
         let add_ssl = own_tls
             .update(&mut ports, opts(8080, Some(8080), Some(true)))
             .unwrap();

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -267,17 +267,21 @@ impl BindInfo {
         }
     }
 
-    pub fn new(available_ports: &mut AvailablePorts, options: BindOptions) -> Result<Self, Error> {
+    pub fn new(
+        available_ports: &mut AvailablePorts,
+        options: BindOptions,
+        privileged: bool,
+    ) -> Result<Self, Error> {
         let mut assigned_port = None;
         let mut assigned_ssl_port = None;
         if let Some(preferred) = options.preferred_ssl_port() {
             assigned_ssl_port = available_ports
-                .try_alloc(preferred, true)
+                .try_alloc(preferred, true, privileged)
                 .or_else(|| Some(available_ports.alloc(true).ok()?));
         }
         if options.wants_plain_port() {
             assigned_port = available_ports
-                .try_alloc(options.preferred_external_port, false)
+                .try_alloc(options.preferred_external_port, false, privileged)
                 .or_else(|| Some(available_ports.alloc(false).ok()?));
         }
 
@@ -296,6 +300,7 @@ impl BindInfo {
         self,
         available_ports: &mut AvailablePorts,
         options: BindOptions,
+        privileged: bool,
     ) -> Result<Self, Error> {
         let Self {
             net: held,
@@ -315,8 +320,8 @@ impl BindInfo {
         let mut reclaim = |held: Option<u16>, preferred: u16, ssl: bool| {
             let want = held.or(carried).unwrap_or(preferred);
             available_ports
-                .try_alloc(want, ssl)
-                .or_else(|| available_ports.try_alloc(preferred, ssl))
+                .try_alloc(want, ssl, privileged)
+                .or_else(|| available_ports.try_alloc(preferred, ssl, privileged))
                 .map_or_else(|| available_ports.alloc(ssl), Ok)
         };
 
@@ -1043,27 +1048,29 @@ mod test {
     #[test]
     fn tls_carrying_ports_are_ssl_ports() {
         let mut ports = AvailablePorts::new();
+        let privileged = false;
 
         // plaintext: one forwarded port
-        let plain = BindInfo::new(&mut ports, opts(8080, None, Some(false))).unwrap();
+        let plain = BindInfo::new(&mut ports, opts(8080, None, Some(false)), privileged).unwrap();
         assert_eq!(plain.net.assigned_port, Some(8080));
         assert_eq!(plain.net.assigned_ssl_port, None);
         assert!(!ports.is_ssl(8080));
 
         // we terminate TLS in front of a plaintext container: both ports
-        let add_ssl = BindInfo::new(&mut ports, opts(8081, Some(8444), None)).unwrap();
+        let add_ssl = BindInfo::new(&mut ports, opts(8081, Some(8444), None), privileged).unwrap();
         assert_eq!(add_ssl.net.assigned_port, Some(8081));
         assert_eq!(add_ssl.net.assigned_ssl_port, Some(8444));
         assert!(ports.is_ssl(8444));
 
         // we rewrap the container's TLS: the ssl port only
-        let rewrap = BindInfo::new(&mut ports, opts(8082, Some(8445), Some(true))).unwrap();
+        let rewrap =
+            BindInfo::new(&mut ports, opts(8082, Some(8445), Some(true)), privileged).unwrap();
         assert_eq!(rewrap.net.assigned_port, None);
         assert_eq!(rewrap.net.assigned_ssl_port, Some(8445));
 
         // the container serves its own TLS: the ssl port only, fronted by
         // our SNI-passthrough listener
-        let own_tls = BindInfo::new(&mut ports, opts(8083, None, Some(true))).unwrap();
+        let own_tls = BindInfo::new(&mut ports, opts(8083, None, Some(true)), privileged).unwrap();
         assert_eq!(own_tls.net.assigned_port, None);
         assert_eq!(own_tls.net.assigned_ssl_port, Some(8083));
         assert!(ports.is_ssl(8083));
@@ -1072,11 +1079,12 @@ mod test {
     #[test]
     fn changing_how_a_port_is_served_keeps_its_number() {
         let mut ports = AvailablePorts::new();
-        let plain = BindInfo::new(&mut ports, opts(8080, None, Some(false))).unwrap();
+        let privileged = false;
+        let plain = BindInfo::new(&mut ports, opts(8080, None, Some(false)), privileged).unwrap();
         assert_eq!(plain.net.assigned_port, Some(8080));
 
         let own_tls = plain
-            .update(&mut ports, opts(8080, None, Some(true)))
+            .update(&mut ports, opts(8080, None, Some(true)), privileged)
             .unwrap();
         assert_eq!(own_tls.net.assigned_port, None);
         assert_eq!(own_tls.net.assigned_ssl_port, Some(8080));
@@ -1084,14 +1092,14 @@ mod test {
 
         // handing termination to us keeps the port
         let add_ssl = own_tls
-            .update(&mut ports, opts(8080, Some(8080), Some(true)))
+            .update(&mut ports, opts(8080, Some(8080), Some(true)), privileged)
             .unwrap();
         assert_eq!(add_ssl.net.assigned_ssl_port, Some(8080));
         assert!(ports.is_ssl(8080));
 
         // and back down to plaintext
         let plain = add_ssl
-            .update(&mut ports, opts(8080, None, Some(false)))
+            .update(&mut ports, opts(8080, None, Some(false)), privileged)
             .unwrap();
         assert_eq!(plain.net.assigned_port, Some(8080));
         assert_eq!(plain.net.assigned_ssl_port, None);
@@ -1101,17 +1109,38 @@ mod test {
     #[test]
     fn a_rebind_does_not_migrate_onto_a_freed_preferred_port() {
         let mut ports = AvailablePorts::new();
+        let privileged = false;
         // someone else holds 8080, so this binding lands elsewhere
-        assert_eq!(ports.try_alloc(8080, false), Some(8080));
-        let squatted = BindInfo::new(&mut ports, opts(8080, None, Some(false))).unwrap();
+        assert_eq!(ports.try_alloc(8080, false, privileged), Some(8080));
+        let squatted =
+            BindInfo::new(&mut ports, opts(8080, None, Some(false)), privileged).unwrap();
         let assigned = squatted.net.assigned_port.unwrap();
         assert_ne!(assigned, 8080);
 
         ports.free([8080]);
         let again = squatted
-            .update(&mut ports, opts(8080, None, Some(false)))
+            .update(&mut ports, opts(8080, None, Some(false)), privileged)
             .unwrap();
         assert_eq!(again.net.assigned_port, Some(assigned));
+    }
+
+    /// The admin UI rebinds on every boot, so `update` is what hands 443 back.
+    #[test]
+    fn the_os_ui_keeps_its_well_known_ports_across_rebinds() {
+        let mut ports = AvailablePorts::new();
+        let privileged = true;
+        // exactly what `NetController::os_bindings` asks for
+        let admin = opts(80, Some(443), None);
+
+        let ui = BindInfo::new(&mut ports, admin.clone(), privileged).unwrap();
+        assert_eq!(ui.net.assigned_port, Some(80));
+        assert_eq!(ui.net.assigned_ssl_port, Some(443));
+        assert!(ports.is_ssl(443));
+
+        let ui = ui.update(&mut ports, admin, privileged).unwrap();
+        assert_eq!(ui.net.assigned_port, Some(80));
+        assert_eq!(ui.net.assigned_ssl_port, Some(443));
+        assert!(ports.is_ssl(443));
     }
 
     #[test]

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -270,15 +270,13 @@ impl BindInfo {
     pub fn new(available_ports: &mut AvailablePorts, options: BindOptions) -> Result<Self, Error> {
         let mut assigned_port = None;
         let mut assigned_ssl_port = None;
-        if let Some(ssl) = &options.add_ssl {
+        if let Some(preferred) = options.preferred_ssl_port() {
+            let proxied = options.add_ssl.is_some();
             assigned_ssl_port = available_ports
-                .try_alloc(ssl.preferred_external_port, true)
-                .or_else(|| Some(available_ports.alloc(true).ok()?));
+                .try_alloc(preferred, proxied)
+                .or_else(|| Some(available_ports.alloc(proxied).ok()?));
         }
-        if options
-            .secure
-            .map_or(true, |s| !(s.ssl && options.add_ssl.is_some()))
-        {
+        if options.wants_plain_port() {
             assigned_port = available_ports
                 .try_alloc(options.preferred_external_port, false)
                 .or_else(|| Some(available_ports.alloc(false).ok()?));
@@ -301,48 +299,44 @@ impl BindInfo {
         options: BindOptions,
     ) -> Result<Self, Error> {
         let Self {
-            net: mut lan,
+            net: held,
             addresses,
             interfaces,
             ..
         } = self;
-        if options
-            .secure
-            .map_or(true, |s| !(s.ssl && options.add_ssl.is_some()))
-        // doesn't make sense to have 2 listening ports, both with ssl
-        {
-            lan.assigned_port = if let Some(port) = lan.assigned_port.take() {
-                Some(port)
-            } else if let Some(port) =
-                available_ports.try_alloc(options.preferred_external_port, false)
-            {
-                Some(port)
-            } else {
-                Some(available_ports.alloc(false)?)
-            };
-        } else {
-            if let Some(port) = lan.assigned_port.take() {
-                available_ports.free([port]);
-            }
-        }
-        if let Some(ssl) = &options.add_ssl {
-            lan.assigned_ssl_port = if let Some(port) = lan.assigned_ssl_port.take() {
-                Some(port)
-            } else if let Some(port) = available_ports.try_alloc(ssl.preferred_external_port, true)
-            {
-                Some(port)
-            } else {
-                Some(available_ports.alloc(true)?)
-            };
-        } else {
-            if let Some(port) = lan.assigned_ssl_port.take() {
-                available_ports.free([port]);
-            }
-        }
+        // Release both ports up front so the numbers below can be reclaimed. The
+        // external port is in the user's address book and keys their per-address
+        // overrides, so a binding that changes how its port is served keeps the
+        // same number — carrying it to the other field when it holds just one.
+        available_ports.free(held.assigned_port.into_iter().chain(held.assigned_ssl_port));
+        let carried = match (held.assigned_port, held.assigned_ssl_port) {
+            (Some(port), None) | (None, Some(port)) => Some(port),
+            _ => None,
+        };
+        let mut reclaim = |held: Option<u16>, preferred: u16, ssl: bool| {
+            let want = held.or(carried).unwrap_or(preferred);
+            available_ports
+                .try_alloc(want, ssl)
+                .or_else(|| available_ports.try_alloc(preferred, ssl))
+                .map_or_else(|| available_ports.alloc(ssl), Ok)
+        };
+
+        let assigned_ssl_port = options
+            .preferred_ssl_port()
+            .map(|preferred| reclaim(held.assigned_ssl_port, preferred, options.add_ssl.is_some()))
+            .transpose()?;
+        let assigned_port = options
+            .wants_plain_port()
+            .then(|| reclaim(held.assigned_port, options.preferred_external_port, false))
+            .transpose()?;
+
         Ok(Self {
             enabled: true,
             options,
-            net: lan,
+            net: NetInfo {
+                assigned_port,
+                assigned_ssl_port,
+            },
             addresses,
             interfaces,
         })
@@ -366,6 +360,33 @@ pub struct BindOptions {
     pub preferred_external_port: u16,
     pub add_ssl: Option<AddSslOptions>,
     pub secure: Option<Security>,
+}
+
+impl BindOptions {
+    /// The container terminates TLS itself, so the OS forwards its port
+    /// untouched rather than putting a listener of its own in front.
+    pub fn serves_own_tls(&self) -> bool {
+        self.secure.map_or(false, |s| s.ssl) && self.add_ssl.is_none()
+    }
+
+    /// Preferred external port for the TLS-carrying listener: the OS's own when
+    /// it terminates (`add_ssl`), otherwise the binding's, since a self-TLS
+    /// binding has no second port to take one from.
+    pub fn preferred_ssl_port(&self) -> Option<u16> {
+        self.add_ssl
+            .as_ref()
+            .map(|s| s.preferred_external_port)
+            .or_else(|| {
+                self.serves_own_tls()
+                    .then_some(self.preferred_external_port)
+            })
+    }
+
+    /// A plaintext external port exists unless the container itself speaks TLS
+    /// — two listening ports both carrying TLS makes no sense.
+    pub fn wants_plain_port(&self) -> bool {
+        !self.secure.map_or(false, |s| s.ssl)
+    }
 }
 
 /// How the OS reverse proxy validates the container's TLS certificate when it
@@ -1004,6 +1025,93 @@ mod test {
                 scope_id: 0,
             },
         }
+    }
+
+    fn opts(preferred: u16, add_ssl: Option<u16>, ssl: Option<bool>) -> BindOptions {
+        BindOptions {
+            preferred_external_port: preferred,
+            add_ssl: add_ssl.map(|preferred_external_port| AddSslOptions {
+                preferred_external_port,
+                add_x_forwarded_headers: false,
+                alpn: None,
+                upstream_cert_validation: None,
+                auth: None,
+            }),
+            secure: ssl.map(|ssl| Security { ssl }),
+        }
+    }
+
+    #[test]
+    fn tls_carrying_ports_are_ssl_ports() {
+        let mut ports = AvailablePorts::new();
+
+        // plaintext: one forwarded port
+        let plain = BindInfo::new(&mut ports, opts(8080, None, Some(false))).unwrap();
+        assert_eq!(plain.net.assigned_port, Some(8080));
+        assert_eq!(plain.net.assigned_ssl_port, None);
+        assert!(!ports.is_ssl(8080));
+
+        // we terminate TLS in front of a plaintext container: both ports
+        let add_ssl = BindInfo::new(&mut ports, opts(8081, Some(8444), None)).unwrap();
+        assert_eq!(add_ssl.net.assigned_port, Some(8081));
+        assert_eq!(add_ssl.net.assigned_ssl_port, Some(8444));
+        assert!(ports.is_ssl(8444));
+
+        // we rewrap the container's TLS: the ssl port only
+        let rewrap = BindInfo::new(&mut ports, opts(8082, Some(8445), Some(true))).unwrap();
+        assert_eq!(rewrap.net.assigned_port, None);
+        assert_eq!(rewrap.net.assigned_ssl_port, Some(8445));
+
+        // the container serves its own TLS: the ssl port only, forwarded
+        // straight through, so it is not one of our listeners' ports
+        let own_tls = BindInfo::new(&mut ports, opts(8083, None, Some(true))).unwrap();
+        assert_eq!(own_tls.net.assigned_port, None);
+        assert_eq!(own_tls.net.assigned_ssl_port, Some(8083));
+        assert!(!ports.is_ssl(8083));
+    }
+
+    #[test]
+    fn changing_how_a_port_is_served_keeps_its_number() {
+        let mut ports = AvailablePorts::new();
+        let plain = BindInfo::new(&mut ports, opts(8080, None, Some(false))).unwrap();
+        assert_eq!(plain.net.assigned_port, Some(8080));
+
+        let own_tls = plain
+            .update(&mut ports, opts(8080, None, Some(true)))
+            .unwrap();
+        assert_eq!(own_tls.net.assigned_port, None);
+        assert_eq!(own_tls.net.assigned_ssl_port, Some(8080));
+
+        // handing termination to us keeps the port and marks it ours
+        let add_ssl = own_tls
+            .update(&mut ports, opts(8080, Some(8080), Some(true)))
+            .unwrap();
+        assert_eq!(add_ssl.net.assigned_ssl_port, Some(8080));
+        assert!(ports.is_ssl(8080));
+
+        // and back down to plaintext
+        let plain = add_ssl
+            .update(&mut ports, opts(8080, None, Some(false)))
+            .unwrap();
+        assert_eq!(plain.net.assigned_port, Some(8080));
+        assert_eq!(plain.net.assigned_ssl_port, None);
+        assert!(!ports.is_ssl(8080));
+    }
+
+    #[test]
+    fn a_rebind_does_not_migrate_onto_a_freed_preferred_port() {
+        let mut ports = AvailablePorts::new();
+        // someone else holds 8080, so this binding lands elsewhere
+        assert_eq!(ports.try_alloc(8080, false), Some(8080));
+        let squatted = BindInfo::new(&mut ports, opts(8080, None, Some(false))).unwrap();
+        let assigned = squatted.net.assigned_port.unwrap();
+        assert_ne!(assigned, 8080);
+
+        ports.free([8080]);
+        let again = squatted
+            .update(&mut ports, opts(8080, None, Some(false)))
+            .unwrap();
+        assert_eq!(again.net.assigned_port, Some(assigned));
     }
 
     #[test]

--- a/shared-libs/crates/start-core/src/net/host/mod.rs
+++ b/shared-libs/crates/start-core/src/net/host/mod.rs
@@ -267,10 +267,11 @@ impl Model<Host> {
                     });
                 }
                 if let Some(mut port) = net.assigned_ssl_port {
+                    // The domain rides the preferred port whenever one of our
+                    // TLS listeners answers there — SNI routes it, terminating
+                    // (add_ssl) or passthrough (self-TLS) alike.
                     if let Some(preferred) = opt
-                        .add_ssl
-                        .as_ref()
-                        .map(|s| s.preferred_external_port)
+                        .preferred_ssl_port()
                         .filter(|p| available_ports.is_ssl(*p))
                     {
                         port = preferred;
@@ -278,22 +279,8 @@ impl Model<Host> {
                     available.insert(HostnameInfo {
                         ssl: true,
                         public: true,
-                        hostname: domain.clone(),
-                        port: Some(port),
-                        metadata: metadata.clone(),
-                    });
-                }
-                if opt.serves_own_tls()
-                    && available_ports.is_ssl(opt.preferred_external_port)
-                    && net.assigned_ssl_port != Some(opt.preferred_external_port)
-                {
-                    // One of our listeners holds the preferred port, so it can
-                    // SNI-passthrough to the service's own TLS as well.
-                    available.insert(HostnameInfo {
-                        ssl: true,
-                        public: true,
                         hostname: domain,
-                        port: Some(opt.preferred_external_port),
+                        port: Some(port),
                         metadata,
                     });
                 }
@@ -324,9 +311,7 @@ impl Model<Host> {
                 }
                 if let Some(mut port) = net.assigned_ssl_port {
                     if let Some(preferred) = opt
-                        .add_ssl
-                        .as_ref()
-                        .map(|s| s.preferred_external_port)
+                        .preferred_ssl_port()
                         .filter(|p| available_ports.is_ssl(*p))
                     {
                         port = preferred;
@@ -334,22 +319,8 @@ impl Model<Host> {
                     available.insert(HostnameInfo {
                         ssl: true,
                         public: false,
-                        hostname: domain.clone(),
-                        port: Some(port),
-                        metadata: HostnameMetadata::PrivateDomain {
-                            gateways: domain_gateways.clone(),
-                        },
-                    });
-                }
-                if opt.serves_own_tls()
-                    && available_ports.is_ssl(opt.preferred_external_port)
-                    && net.assigned_ssl_port != Some(opt.preferred_external_port)
-                {
-                    available.insert(HostnameInfo {
-                        ssl: true,
-                        public: false,
                         hostname: domain,
-                        port: Some(opt.preferred_external_port),
+                        port: Some(port),
                         metadata: HostnameMetadata::PrivateDomain {
                             gateways: domain_gateways,
                         },

--- a/shared-libs/crates/start-core/src/net/host/mod.rs
+++ b/shared-libs/crates/start-core/src/net/host/mod.rs
@@ -584,12 +584,13 @@ impl Model<Host> {
         available_ports: &mut AvailablePorts,
         internal_port: u16,
         options: BindOptions,
+        privileged: bool,
     ) -> Result<(), Error> {
         self.as_bindings_mut().mutate(|b| {
             let info = if let Some(info) = b.remove(&internal_port) {
-                info.update(available_ports, options)?
+                info.update(available_ports, options, privileged)?
             } else {
-                BindInfo::new(available_ports, options)?
+                BindInfo::new(available_ports, options, privileged)?
             };
             b.insert(internal_port, info);
             Ok(())
@@ -607,6 +608,7 @@ impl Model<Host> {
         internal_start_port: u16,
         external_start_port: u16,
         number_of_ports: u16,
+        privileged: bool,
     ) -> Result<(), Error> {
         if number_of_ports < 2 {
             return Err(Error::new(
@@ -650,7 +652,11 @@ impl Model<Host> {
                         e.external_start_port..=e.external_start_port + (e.number_of_ports - 1),
                     );
                 }
-                available_ports.try_alloc_range(external_start_port, number_of_ports)?;
+                available_ports.try_alloc_range(
+                    external_start_port,
+                    number_of_ports,
+                    privileged,
+                )?;
             }
             ranges.insert(
                 internal_start_port,

--- a/shared-libs/crates/start-core/src/net/host/mod.rs
+++ b/shared-libs/crates/start-core/src/net/host/mod.rs
@@ -147,7 +147,7 @@ impl Model<Host> {
                     };
                     if let Some(port) = net.assigned_port.filter(|_| {
                         opt.secure
-                            .map_or(gateway_secure, |s| !(s.ssl && opt.add_ssl.is_some()))
+                            .map_or(gateway_secure, |_| opt.wants_plain_port())
                     }) {
                         let mut hi = HostnameInfo {
                             ssl: opt.secure.map_or(false, |s| s.ssl),
@@ -184,7 +184,7 @@ impl Model<Host> {
                     if let Some(port) = net.assigned_port.filter(|_| {
                         opt.secure.map_or(
                             false, // the public internet is never secure
-                            |s| !(s.ssl && opt.add_ssl.is_some()),
+                            |_| opt.wants_plain_port(),
                         )
                     }) {
                         available.insert(HostnameInfo {
@@ -210,10 +210,10 @@ impl Model<Host> {
             // mdns
             let mdns_host = mdns.local_domain_name();
             let mdns_gateways = mdns_gateways(gateways);
-            if let Some(port) = net.assigned_port.filter(|_| {
-                opt.secure
-                    .map_or(true, |s| !(s.ssl && opt.add_ssl.is_some()))
-            }) {
+            if let Some(port) = net
+                .assigned_port
+                .filter(|_| opt.secure.map_or(true, |_| opt.wants_plain_port()))
+            {
                 let mdns_gateways = if opt.secure.is_some() {
                     mdns_gateways.clone()
                 } else {
@@ -235,7 +235,7 @@ impl Model<Host> {
                     });
                 }
             }
-            if let Some(port) = net.assigned_ssl_port {
+            if let Some(port) = net.assigned_ssl_port.filter(|_| !mdns_gateways.is_empty()) {
                 available.insert(HostnameInfo {
                     ssl: true,
                     public: false,
@@ -255,7 +255,7 @@ impl Model<Host> {
                 if let Some(port) = net.assigned_port.filter(|_| {
                     opt.secure.map_or(
                         false, // the public internet is never secure
-                        |s| !(s.ssl && opt.add_ssl.is_some()),
+                        |_| opt.wants_plain_port(),
                     )
                 }) {
                     available.insert(HostnameInfo {
@@ -278,17 +278,17 @@ impl Model<Host> {
                     available.insert(HostnameInfo {
                         ssl: true,
                         public: true,
-                        hostname: domain,
+                        hostname: domain.clone(),
                         port: Some(port),
-                        metadata,
+                        metadata: metadata.clone(),
                     });
-                } else if opt.secure.map_or(false, |s| s.ssl)
-                    && opt.add_ssl.is_none()
+                }
+                if opt.serves_own_tls()
                     && available_ports.is_ssl(opt.preferred_external_port)
-                    && net.assigned_port != Some(opt.preferred_external_port)
+                    && net.assigned_ssl_port != Some(opt.preferred_external_port)
                 {
-                    // Service handles its own TLS and the preferred port is
-                    // allocated as SSL — add an address for passthrough vhost.
+                    // One of our listeners holds the preferred port, so it can
+                    // SNI-passthrough to the service's own TLS as well.
                     available.insert(HostnameInfo {
                         ssl: true,
                         public: true,
@@ -301,10 +301,10 @@ impl Model<Host> {
 
             // private domains
             for (domain, domain_gateways) in this.private_domains.de()? {
-                if let Some(port) = net.assigned_port.filter(|_| {
-                    opt.secure
-                        .map_or(true, |s| !(s.ssl && opt.add_ssl.is_some()))
-                }) {
+                if let Some(port) = net
+                    .assigned_port
+                    .filter(|_| opt.secure.map_or(true, |_| opt.wants_plain_port()))
+                {
                     let gateways = if opt.secure.is_some() {
                         domain_gateways.clone()
                     } else {
@@ -334,16 +334,16 @@ impl Model<Host> {
                     available.insert(HostnameInfo {
                         ssl: true,
                         public: false,
-                        hostname: domain,
+                        hostname: domain.clone(),
                         port: Some(port),
                         metadata: HostnameMetadata::PrivateDomain {
-                            gateways: domain_gateways,
+                            gateways: domain_gateways.clone(),
                         },
                     });
-                } else if opt.secure.map_or(false, |s| s.ssl)
-                    && opt.add_ssl.is_none()
+                }
+                if opt.serves_own_tls()
                     && available_ports.is_ssl(opt.preferred_external_port)
-                    && net.assigned_port != Some(opt.preferred_external_port)
+                    && net.assigned_ssl_port != Some(opt.preferred_external_port)
                 {
                     available.insert(HostnameInfo {
                         ssl: true,

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -395,71 +395,88 @@ impl NetServiceData {
                 }
             }
 
-            // SSL vhosts
-            if let Some(ssl) = &bind.options.add_ssl {
-                let connect_ssl: Result<Arc<TlsClientConfig>, AlpnInfo> =
+            // How our listener dials the container when it terminates TLS
+            // (add_ssl); a self-TLS passthrough never dials TLS — it pipes raw.
+            let connect_ssl: Result<Arc<TlsClientConfig>, AlpnInfo> =
+                if let Some(ssl) = &bind.options.add_ssl {
                     if let Some(alpn) = ssl.alpn.clone() {
                         Err(alpn)
                     } else if bind.options.secure.as_ref().map_or(false, |s| s.ssl) {
                         Ok(ctrl.upstream_client_config(&ssl.upstream_cert_validation))
                     } else {
                         Err(AlpnInfo::Reflect)
-                    };
-
-                if let Some(assigned_ssl_port) = bind.net.assigned_ssl_port {
-                    // Collect private IPs from enabled LAN-only addresses' gateways
-                    // (a GUA set to LAN+WAN is WAN, so it lands in the public set).
-                    let server_private_ips: BTreeSet<IpAddr> = enabled_addresses
-                        .iter()
-                        .filter(|a| !a.public)
-                        .flat_map(|a| a.metadata.gateways())
-                        .filter_map(|gw| net_ifaces.get(gw).and_then(|info| info.ip_info.as_ref()))
-                        .flat_map(|ip_info| ip_info.subnets.iter().map(|s| s.addr()))
-                        .collect();
-
-                    // Public gateways, split by family: a bare public IPv4 (WAN IP)
-                    // and a LAN+WAN GUA are independently toggleable, and the vhost
-                    // must accept (and forward) each family only where that family
-                    // is actually public — so a GUA-only-public gateway never
-                    // accepts or forwards bare IPv4. The controller derives the IPv4
-                    // `*` pinhole from `public_v4`; the GUA needs no NAT.
-                    let server_public_v4 = ssl_vhost_public_v4(enabled_addresses.iter().copied());
-                    // Per-IP (per-GUA), not per-gateway: one gateway can carry
-                    // several GUAs that are independently Local vs Public, so only
-                    // the specific enabled-public GUAs accept WAN. Scoped to the SSL
-                    // exposure (`a.ssl`), since this `*` vhost terminates TLS on the
-                    // ssl port — a GUA public only on a non-SSL port is served by the
-                    // v6 DNAT forward, not this vhost.
-                    let server_public_v6: BTreeSet<Ipv6Addr> = enabled_addresses
-                        .iter()
-                        .filter(|a| a.public && a.ssl)
-                        .filter_map(|a| a.gua().map(|g| *g.ip()))
-                        .collect();
-
-                    // * vhost (on assigned_ssl_port)
-                    if !server_private_ips.is_empty()
-                        || !server_public_v4.is_empty()
-                        || !server_public_v6.is_empty()
-                    {
-                        vhosts.insert(
-                            (None, assigned_ssl_port),
-                            ProxyTarget {
-                                public_v4: server_public_v4,
-                                public_v6: server_public_v6,
-                                private: server_private_ips.clone(),
-                                acme: None,
-                                addr,
-                                add_x_forwarded_headers: ssl.add_x_forwarded_headers,
-                                auth: ssl.auth.clone(),
-                                connect_ssl: connect_ssl.clone(),
-                                passthrough: false,
-                                preserve_source_ip: false,
-                            },
-                        );
                     }
+                } else {
+                    Err(AlpnInfo::Reflect)
+                };
+
+            // `*` vhost: every assigned_ssl_port is answered by a listener of
+            // ours — terminating (add_ssl), or an SNI-agnostic passthrough when
+            // the container serves its own TLS.
+            if let Some(assigned_ssl_port) = bind.net.assigned_ssl_port {
+                // Collect private IPs from enabled LAN-only addresses' gateways
+                // (a GUA set to LAN+WAN is WAN, so it lands in the public set).
+                let server_private_ips: BTreeSet<IpAddr> = enabled_addresses
+                    .iter()
+                    .filter(|a| !a.public)
+                    .flat_map(|a| a.metadata.gateways())
+                    .filter_map(|gw| net_ifaces.get(gw).and_then(|info| info.ip_info.as_ref()))
+                    .flat_map(|ip_info| ip_info.subnets.iter().map(|s| s.addr()))
+                    .collect();
+
+                // Public gateways, split by family: a bare public IPv4 (WAN IP)
+                // and a LAN+WAN GUA are independently toggleable, and the vhost
+                // must accept (and forward) each family only where that family
+                // is actually public — so a GUA-only-public gateway never
+                // accepts or forwards bare IPv4. The controller derives the IPv4
+                // `*` pinhole from `public_v4`; the GUA needs no NAT.
+                let server_public_v4 = ssl_vhost_public_v4(enabled_addresses.iter().copied());
+                // Per-IP (per-GUA), not per-gateway: one gateway can carry
+                // several GUAs that are independently Local vs Public, so only
+                // the specific enabled-public GUAs accept WAN. Scoped to the SSL
+                // exposure (`a.ssl`), since this `*` vhost answers TLS on the
+                // ssl port — a GUA public only on a non-SSL port is served by the
+                // v6 DNAT forward, not this vhost.
+                let server_public_v6: BTreeSet<Ipv6Addr> = enabled_addresses
+                    .iter()
+                    .filter(|a| a.public && a.ssl)
+                    .filter_map(|a| a.gua().map(|g| *g.ip()))
+                    .collect();
+
+                if !server_private_ips.is_empty()
+                    || !server_public_v4.is_empty()
+                    || !server_public_v6.is_empty()
+                {
+                    let passthrough = bind.options.add_ssl.is_none();
+                    vhosts.insert(
+                        (None, assigned_ssl_port),
+                        ProxyTarget {
+                            public_v4: server_public_v4,
+                            public_v6: server_public_v6,
+                            private: server_private_ips,
+                            acme: None,
+                            addr,
+                            add_x_forwarded_headers: bind
+                                .options
+                                .add_ssl
+                                .as_ref()
+                                .map_or(false, |s| s.add_x_forwarded_headers),
+                            auth: bind.options.add_ssl.as_ref().and_then(|s| s.auth.clone()),
+                            connect_ssl: connect_ssl.clone(),
+                            passthrough,
+                            // The container handles its own TLS and the box is
+                            // its gateway, so preserve the client source IP.
+                            preserve_source_ip: passthrough,
+                        },
+                    );
                 }
 
-                // Domain vhosts: group by (domain, ssl_port), merge public/private sets
+                // Domain vhosts: group by (domain, ssl_port), merge public/private
+                // sets. Terminating when we hold the TLS (add_ssl); an SNI
+                // passthrough to the container's own TLS otherwise. Either way the
+                // domain entry carries its own gateways, so a public domain accepts
+                // WAN even where the bare IP is disabled.
+                let passthrough = bind.options.add_ssl.is_none();
                 for addr_info in &enabled_addresses {
                     if !addr_info.ssl {
                         continue;
@@ -478,17 +495,27 @@ impl NetServiceData {
                         public_v4: BTreeSet::new(),
                         public_v6: BTreeSet::new(),
                         private: BTreeSet::new(),
-                        acme: host_addresses
-                            .iter()
-                            .find(|a| a.address == *domain)
-                            .and_then(|a| a.public.as_ref())
-                            .and_then(|p| p.acme.clone()),
+                        // A passthrough never intermediates ACME — the backend
+                        // is the ACME client and holds the challenge cert.
+                        acme: if passthrough {
+                            None
+                        } else {
+                            host_addresses
+                                .iter()
+                                .find(|a| a.address == *domain)
+                                .and_then(|a| a.public.as_ref())
+                                .and_then(|p| p.acme.clone())
+                        },
                         addr,
-                        add_x_forwarded_headers: ssl.add_x_forwarded_headers,
-                        auth: ssl.auth.clone(),
+                        add_x_forwarded_headers: bind
+                            .options
+                            .add_ssl
+                            .as_ref()
+                            .map_or(false, |s| s.add_x_forwarded_headers),
+                        auth: bind.options.add_ssl.as_ref().and_then(|s| s.auth.clone()),
                         connect_ssl: connect_ssl.clone(),
-                        passthrough: false,
-                        preserve_source_ip: false,
+                        passthrough,
+                        preserve_source_ip: passthrough,
                     });
                     if addr_info.public {
                         // A public domain is dual-stack (A + AAAA): public on its
@@ -513,15 +540,9 @@ impl NetServiceData {
                 }
             }
 
-            // Direct forwards — every external port we put no listener of our
-            // own in front of: the plaintext port, and a self-TLS binding's
-            // port, which carries TLS the container terminates itself.
-            let direct = if bind.options.add_ssl.is_some() {
-                bind.net.assigned_port
-            } else {
-                bind.net.assigned_port.or(bind.net.assigned_ssl_port)
-            };
-            if let Some(external) = direct {
+            // Direct forward — the plaintext port, the only external port with
+            // no listener of ours in front (every TLS port is a vhost above).
+            if let Some(external) = bind.net.assigned_port {
                 // Only addresses at this port drive its forward (a vhost's port has its own).
                 let fwd_public: BTreeSet<GatewayId> = enabled_addresses
                     .iter()
@@ -573,10 +594,11 @@ impl NetServiceData {
                         let Some(gua) = a.gua().filter(|g| g.port() == external) else {
                             continue;
                         };
-                        // Secure when StartOS terminates TLS (add_ssl → a.ssl) or the
-                        // underlying protocol is itself secure. The WAN is never secure, so an
-                        // insecure exposure that requested public serves the LAN instead.
-                        let secure_exposure = a.ssl || bind.options.secure.is_some();
+                        // Secure only when the underlying protocol is itself secure —
+                        // this is the plaintext port, so we never terminate TLS here.
+                        // The WAN is never secure, so an insecure exposure that
+                        // requested public serves the LAN instead.
+                        let secure_exposure = bind.options.secure.is_some();
                         let src_filter = if a.public && secure_exposure {
                             None
                         } else {
@@ -603,68 +625,12 @@ impl NetServiceData {
                                 None => continue,
                             }
                         };
-                        // A public bare GUA is DNAT'd to the container, but no vhost
-                        // owns it (add_ssl builds the `*` vhost; passthroughs are
-                        // domain-only). The forward controller opens its upstream
-                        // pinhole together with the DNAT (see the reconcile below).
+                        // A public bare GUA on a non-TLS port is DNAT'd to the
+                        // container — no vhost owns a non-TLS port. The forward
+                        // controller opens its upstream pinhole together with the
+                        // DNAT (see the reconcile below).
                         gua_forwards
                             .insert((*gua.ip(), gua.port()), (container_v6, *port, src_filter));
-                    }
-                }
-            }
-
-            // Passthrough vhosts: if the service handles its own TLS and a
-            // domain address is enabled on a port other than the one we forward
-            // directly, add a passthrough vhost so the service's TLS endpoint is
-            // reachable there too.
-            if bind.options.serves_own_tls() {
-                let assigned = bind.net.assigned_ssl_port;
-                for addr_info in &enabled_addresses {
-                    if !addr_info.ssl {
-                        continue;
-                    }
-                    let Some(pt_port) = addr_info.port.filter(|p| assigned != Some(*p)) else {
-                        continue;
-                    };
-                    match &addr_info.metadata {
-                        HostnameMetadata::PublicDomain { .. }
-                        | HostnameMetadata::PrivateDomain { .. } => {}
-                        _ => continue,
-                    }
-                    let domain = &addr_info.hostname;
-                    let key = (Some(domain.clone()), pt_port);
-                    let target = vhosts.entry(key).or_insert_with(|| ProxyTarget {
-                        public_v4: BTreeSet::new(),
-                        public_v6: BTreeSet::new(),
-                        private: BTreeSet::new(),
-                        acme: None,
-                        addr,
-                        add_x_forwarded_headers: false,
-                        auth: None,
-                        connect_ssl: Err(AlpnInfo::Reflect),
-                        passthrough: true,
-                        // Container handles its own TLS and the box is its
-                        // gateway, so preserve the client source IP.
-                        preserve_source_ip: true,
-                    });
-                    if addr_info.public {
-                        // Passthrough domain is dual-stack, like the SSL domain vhost.
-                        let gws: BTreeSet<GatewayId> =
-                            addr_info.metadata.gateways().cloned().collect();
-                        target.public_v4.extend(gws.iter().cloned());
-                        target
-                            .public_v6
-                            .extend(crate::net::utils::gua_ips(&net_ifaces, &gws));
-                    } else {
-                        for gw in addr_info.metadata.gateways() {
-                            if let Some(info) = net_ifaces.get(gw) {
-                                if let Some(ip_info) = &info.ip_info {
-                                    for subnet in &ip_info.subnets {
-                                        target.private.insert(subnet.addr());
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
             }

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -319,9 +319,9 @@ struct HostBinds {
     forwards: BTreeMap<u16, (SocketAddrV4, u16, ForwardRequirements, Arc<()>)>,
     vhosts: BTreeMap<(Option<InternedString>, u16), (ProxyTarget, Arc<()>)>,
     private_dns: BTreeMap<InternedString, Arc<()>>,
-    /// Non-SSL v6 forwards: `(host GUA, external port) -> (container v6, internal
-    /// port, LAN source filter)`. A non-SSL GUA has no host terminator, so its
-    /// port is DNAT'd to the container (see `forward6`); tracked so a stale
+    /// Directly-forwarded v6: `(host GUA, external port) -> (container v6,
+    /// internal port, LAN source filter)`. A GUA on a port no listener of ours
+    /// answers is DNAT'd to the container (see `forward6`); tracked so a stale
     /// forward is torn down when the GUA's exposure or target changes.
     gua_forwards: BTreeMap<(Ipv6Addr, u16), (Ipv6Addr, u16, Option<IpNet>)>,
 }
@@ -513,14 +513,16 @@ impl NetServiceData {
                 }
             }
 
-            // Non-SSL forwards
-            if bind
-                .options
-                .secure
-                .map_or(true, |s| !(s.ssl && bind.options.add_ssl.is_some()))
-            {
-                let external = bind.net.assigned_port.or_not_found("assigned lan port")?;
-                // Only addresses at this port drive its forward (ssl-port entries are the vhost's).
+            // Direct forwards — every external port we put no listener of our
+            // own in front of: the plaintext port, and a self-TLS binding's
+            // port, which carries TLS the container terminates itself.
+            let direct = if bind.options.add_ssl.is_some() {
+                bind.net.assigned_port
+            } else {
+                bind.net.assigned_port.or(bind.net.assigned_ssl_port)
+            };
+            if let Some(external) = direct {
+                // Only addresses at this port drive its forward (a vhost's port has its own).
                 let fwd_public: BTreeSet<GatewayId> = enabled_addresses
                     .iter()
                     .filter(|a| a.public && a.port == Some(external))
@@ -560,14 +562,14 @@ impl NetServiceData {
                     ),
                 );
 
-                // Non-SSL GUAs have no host terminator, so DNAT the host's
+                // No listener of ours answers here, so DNAT the host's
                 // GUA:external to the container's v6:internal. A LAN-only GUA is
                 // source-restricted to its on-link subnet; a LAN+WAN GUA is
                 // unrestricted. Fail closed: skip a LAN-only GUA whose subnet we
                 // can't determine rather than expose it unrestricted.
                 if let Some(container_v6) = self.ipv6 {
                     for a in enabled_addresses.iter() {
-                        // SSL-port GUAs are the vhost listener's; DNAT only the non-SSL port.
+                        // A vhost's port is its listener's; DNAT only this one.
                         let Some(gua) = a.gua().filter(|g| g.port() == external) else {
                             continue;
                         };
@@ -611,12 +613,12 @@ impl NetServiceData {
                 }
             }
 
-            // Passthrough vhosts: if the service handles its own TLS
-            // (secure.ssl && no add_ssl) and a domain address is enabled on
-            // an SSL port different from assigned_port, add a passthrough
-            // vhost so the service's TLS endpoint is reachable on that port.
-            if bind.options.secure.map_or(false, |s| s.ssl) && bind.options.add_ssl.is_none() {
-                let assigned = bind.net.assigned_port;
+            // Passthrough vhosts: if the service handles its own TLS and a
+            // domain address is enabled on a port other than the one we forward
+            // directly, add a passthrough vhost so the service's TLS endpoint is
+            // reachable there too.
+            if bind.options.serves_own_tls() {
+                let assigned = bind.net.assigned_ssl_port;
                 for addr_info in &enabled_addresses {
                     if !addr_info.ssl {
                         continue;

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -1115,8 +1115,13 @@ impl NetService {
     ) -> Result<(), Error> {
         let (ctrl, pkg_id) = {
             let data = self.data.lock().await;
-            (data.net_controller()?, data.id.clone())
+            (
+                data.net_controller()?,
+                data.id.clone().unwrap_or_else(PackageId::start_os),
+            )
         };
+        // StartOS runs as root, so the admin UI may claim 80 and 443.
+        let privileged = pkg_id.is_start_os();
         ctrl.db
             .mutate(|db| {
                 let gateways = db
@@ -1127,9 +1132,9 @@ impl NetService {
                     .de()?;
                 let hostname = ServerHostname::load(db.as_public().as_server_info())?;
                 let mut ports = db.as_private().as_available_ports().de()?;
-                let host = host_for(db, pkg_id.as_ref().unwrap_or(&PackageId::start_os()), &id)?;
+                let host = host_for(db, &pkg_id, &id)?;
                 let is_new = !host.as_bindings().contains_key(&internal_port)?;
-                host.add_binding(&mut ports, internal_port, options)?;
+                host.add_binding(&mut ports, internal_port, options, privileged)?;
                 host.update_addresses(&hostname, &gateways, &ports)?;
                 // Isolate a newly-bound binding from any pre-existing public
                 // domain on this host, then re-derive so port forwards match.
@@ -1153,8 +1158,13 @@ impl NetService {
     ) -> Result<(), Error> {
         let (ctrl, pkg_id) = {
             let data = self.data.lock().await;
-            (data.net_controller()?, data.id.clone())
+            (
+                data.net_controller()?,
+                data.id.clone().unwrap_or_else(PackageId::start_os),
+            )
         };
+        // StartOS runs as root, so the admin UI may claim 80 and 443.
+        let privileged = pkg_id.is_start_os();
         ctrl.db
             .mutate(|db| {
                 let gateways = db
@@ -1165,7 +1175,7 @@ impl NetService {
                     .de()?;
                 let hostname = ServerHostname::load(db.as_public().as_server_info())?;
                 let mut ports = db.as_private().as_available_ports().de()?;
-                let host = host_for(db, pkg_id.as_ref().unwrap_or(&PackageId::start_os()), &id)?;
+                let host = host_for(db, &pkg_id, &id)?;
                 let is_new = !host
                     .as_binding_ranges()
                     .contains_key(&internal_start_port)?;
@@ -1174,6 +1184,7 @@ impl NetService {
                     internal_start_port,
                     external_start_port,
                     number_of_ports,
+                    privileged,
                 )?;
                 host.update_addresses(&hostname, &gateways, &ports)?;
                 // Isolate a newly-bound range from any pre-existing public domain

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -372,6 +372,8 @@ impl NetServiceData {
             // to lo / lxcbr0 but never to a gateway (see `enabled_addresses`).
             let enabled_addresses = bind.enabled_addresses();
             let addr: SocketAddr = (self.ip, *port).into();
+            // The container's bridge v6, for the source-preserving leg of a v6 client.
+            let addr_v6 = self.ipv6.map(|ip| SocketAddrV6::new(ip, *port, 0, 0));
 
             // Key private DNS by its live gateways so the resolver only answers
             // locally over those gateways — works even when also public (split DNS).
@@ -456,6 +458,7 @@ impl NetServiceData {
                             private: server_private_ips,
                             acme: None,
                             addr,
+                            addr_v6,
                             add_x_forwarded_headers: bind
                                 .options
                                 .add_ssl
@@ -507,6 +510,7 @@ impl NetServiceData {
                                 .and_then(|p| p.acme.clone())
                         },
                         addr,
+                        addr_v6,
                         add_x_forwarded_headers: bind
                             .options
                             .add_ssl

--- a/shared-libs/crates/start-core/src/net/transparent.rs
+++ b/shared-libs/crates/start-core/src/net/transparent.rs
@@ -7,19 +7,19 @@
 //! client, transiting this host as the backend's gateway) are diverted back into
 //! the proxy socket by policy routing.
 //!
-//! Datapath (all in `table ip startos` / iproute2):
-//! - egress socket: `IP_TRANSPARENT`, bound to the client's `(ip, port)`.
+//! Datapath (`table ip`/`ip6 startos` + iproute2, mirrored per family):
+//! - egress socket: `IP_TRANSPARENT`/`IPV6_TRANSPARENT`, bound to the client's
+//!   `(ip, port)`; the client and backend legs are necessarily one family.
 //! - `mangle_prerouting` `sni-divert`: an inbound packet matching a local
 //!   `IP_TRANSPARENT` socket (i.e. a reply to such an egress) is marked with
 //!   [`DIVERT_MARK`]. Only the inbound/reply direction is touched, so the
 //!   proxy's own egress packets route to the backend normally.
-//! - `ip rule fwmark DIVERT_MARK lookup DIVERT_TABLE priority 49` + `ip route add
-//!   local 0.0.0.0/0 dev lo table DIVERT_TABLE`: deliver the marked replies
-//!   locally, into the transparent socket.
+//! - `ip [-6] rule fwmark DIVERT_MARK lookup DIVERT_TABLE priority 49` + `ip [-6]
+//!   route add local 0.0.0.0/0`|`::/0` `dev lo table DIVERT_TABLE`: deliver the
+//!   marked replies locally, into the transparent socket. v4 and v6 keep
+//!   separate rule/route tables, so one number serves both.
 
-#[cfg(target_os = "linux")]
 use std::net::SocketAddr;
-use std::net::SocketAddrV4;
 
 #[cfg(target_os = "linux")]
 use tokio::net::TcpSocket;
@@ -48,31 +48,57 @@ pub const DIVERT_TABLE: u32 = 1344;
 /// gateway mangle reconcile so it survives that chain's flush; on hosts without
 /// that reconcile (e.g. the tunnel) [`ensure_divert_infra`] adds it directly.
 pub fn divert_mark_rule() -> String {
+    [
+        divert_mark_rule_family("ip"),
+        divert_mark_rule_family("ip6"),
+    ]
+    .concat()
+}
+
+fn divert_mark_rule_family(family: &str) -> String {
     format!(
-        "add rule ip startos mangle_prerouting meta l4proto tcp socket transparent 1 meta mark set {DIVERT_MARK:#010x} comment \"sni-divert\"\n"
+        "add rule {family} startos mangle_prerouting meta l4proto tcp socket transparent 1 meta mark set {DIVERT_MARK:#010x} comment \"sni-divert\"\n"
     )
 }
 
 /// Open the internal leg of a demuxed connection from the client's own source
 /// address, so the backend sees the real peer. Requires `CAP_NET_ADMIN` (startd
-/// runs as root). The reply path is set up by [`ensure_divert_infra`].
+/// runs as root). The reply path is set up by [`ensure_divert_infra`]. `client`
+/// and `target` must be the same family — the source address is bound on the
+/// socket that dials the target.
 #[cfg(target_os = "linux")]
 pub async fn transparent_connect(
-    client: SocketAddrV4,
-    target: SocketAddrV4,
+    client: SocketAddr,
+    target: SocketAddr,
 ) -> std::io::Result<TcpStream> {
-    let sock = TcpSocket::new_v4()?;
+    let sock = match (client, target) {
+        (SocketAddr::V4(_), SocketAddr::V4(_)) => {
+            let sock = TcpSocket::new_v4()?;
+            // Must precede bind: permits binding a non-local (client) address.
+            socket2::SockRef::from(&sock).set_ip_transparent_v4(true)?;
+            sock
+        }
+        (SocketAddr::V6(_), SocketAddr::V6(_)) => {
+            let sock = TcpSocket::new_v6()?;
+            socket2::SockRef::from(&sock).set_ip_transparent_v6(true)?;
+            sock
+        }
+        _ => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("transparent egress needs one family: client {client}, target {target}"),
+            ));
+        }
+    };
     {
         let sref = socket2::SockRef::from(&sock);
-        // Must precede bind: permits binding a non-local (client) address.
-        sref.set_ip_transparent_v4(true)?;
         sref.set_reuse_address(true)?;
         if let Err(e) = sref.set_tcp_keepalive(&default_keepalive()) {
             tracing::debug!("transparent egress keepalive: {e}");
         }
     }
-    sock.bind(SocketAddr::V4(client))?;
-    sock.connect(SocketAddr::V4(target)).await
+    sock.bind(client)?;
+    sock.connect(target).await
 }
 
 /// `IP_TRANSPARENT` is Linux-only and the SNI demux runs only on the Linux
@@ -80,8 +106,8 @@ pub async fn transparent_connect(
 /// cross-platform build (apple-darwin) compiling.
 #[cfg(not(target_os = "linux"))]
 pub async fn transparent_connect(
-    _client: SocketAddrV4,
-    _target: SocketAddrV4,
+    _client: SocketAddr,
+    _target: SocketAddr,
 ) -> std::io::Result<TcpStream> {
     Err(std::io::Error::new(
         std::io::ErrorKind::Unsupported,
@@ -117,78 +143,84 @@ pub async fn ensure_divert_infra() -> Result<bool, Error> {
     let mut repaired = false;
     let table = DIVERT_TABLE.to_string();
 
-    // Local-delivery default in the divert table: marked replies are delivered
-    // to the local transparent socket instead of being forwarded back out.
-    Command::new("ip")
-        .args([
-            "route",
-            "replace",
-            "local",
-            "0.0.0.0/0",
-            "dev",
-            "lo",
-            "table",
-            &table,
-        ])
-        .invoke(ErrorKind::Network)
-        .await?;
-
-    // Policy rule at priority 49 — above the gateway's per-interface symmetric
-    // -return rules at 50 — so diverted replies win.
-    let rules = Command::new("ip")
-        .args(["rule", "list"])
-        .invoke(ErrorKind::Network)
-        .await
-        .unwrap_or_default();
-    if !String::from_utf8_lossy(&rules).contains(&format!("lookup {table}")) {
+    // Both families, and independently: `ip` and `ip -6` keep separate rule and
+    // route tables, so the same DIVERT_TABLE/DIVERT_MARK numbers serve each.
+    for (flag, default_route, family) in [("-4", "0.0.0.0/0", "ip"), ("-6", "::/0", "ip6")] {
+        // Local-delivery default in the divert table: marked replies are delivered
+        // to the local transparent socket instead of being forwarded back out.
         Command::new("ip")
             .args([
-                "rule",
-                "add",
-                "fwmark",
-                &format!("{DIVERT_MARK:#x}"),
-                "lookup",
+                flag,
+                "route",
+                "replace",
+                "local",
+                default_route,
+                "dev",
+                "lo",
+                "table",
                 &table,
-                "priority",
-                "49",
             ])
             .invoke(ErrorKind::Network)
             .await?;
-        repaired = true;
-    }
 
-    // nft `sni-divert` mark rule. The gateway reconcile owns (and re-adds) it on
-    // hosts that run it; install it directly where nothing else does (the tunnel),
-    // skipping if already present so we never duplicate or fight the reconcile.
-    let chain = Command::new("nft")
-        .args(["list", "chain", "ip", "startos", "mangle_prerouting"])
-        .invoke(ErrorKind::Network)
-        .await
-        .unwrap_or_default();
-    if !String::from_utf8_lossy(&chain).contains("sni-divert") {
-        Command::new("nft")
-            .args([
-                "add",
-                "rule",
-                "ip",
-                "startos",
-                "mangle_prerouting",
-                "meta",
-                "l4proto",
-                "tcp",
-                "socket",
-                "transparent",
-                "1",
-                "meta",
-                "mark",
-                "set",
-                &format!("{DIVERT_MARK:#010x}"),
-                "comment",
-                "sni-divert",
-            ])
+        // Policy rule at priority 49 — above the gateway's per-interface symmetric
+        // -return rules at 50 — so diverted replies win.
+        let rules = Command::new("ip")
+            .args([flag, "rule", "list"])
             .invoke(ErrorKind::Network)
-            .await?;
-        repaired = true;
+            .await
+            .unwrap_or_default();
+        if !String::from_utf8_lossy(&rules).contains(&format!("lookup {table}")) {
+            Command::new("ip")
+                .args([
+                    flag,
+                    "rule",
+                    "add",
+                    "fwmark",
+                    &format!("{DIVERT_MARK:#x}"),
+                    "lookup",
+                    &table,
+                    "priority",
+                    "49",
+                ])
+                .invoke(ErrorKind::Network)
+                .await?;
+            repaired = true;
+        }
+
+        // nft `sni-divert` mark rule. The gateway reconcile owns (and re-adds) it on
+        // hosts that run it; install it directly where nothing else does (the tunnel),
+        // skipping if already present so we never duplicate or fight the reconcile.
+        let chain = Command::new("nft")
+            .args(["list", "chain", family, "startos", "mangle_prerouting"])
+            .invoke(ErrorKind::Network)
+            .await
+            .unwrap_or_default();
+        if !String::from_utf8_lossy(&chain).contains("sni-divert") {
+            Command::new("nft")
+                .args([
+                    "add",
+                    "rule",
+                    family,
+                    "startos",
+                    "mangle_prerouting",
+                    "meta",
+                    "l4proto",
+                    "tcp",
+                    "socket",
+                    "transparent",
+                    "1",
+                    "meta",
+                    "mark",
+                    "set",
+                    &format!("{DIVERT_MARK:#010x}"),
+                    "comment",
+                    "sni-divert",
+                ])
+                .invoke(ErrorKind::Network)
+                .await?;
+            repaired = true;
+        }
     }
 
     // rp_filter needs no loosening: a diverted reply's source is the backend,

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -1113,9 +1113,18 @@ where
                     // Degraded, not fatal: the backend sees this host rather than
                     // the client. Better than dropping a working connection.
                     Err(e) => {
-                        tracing::warn!(
-                            "transparent egress to {target} for {client} failed ({e}); connecting plainly, so the backend will see this host as the peer"
-                        );
+                        // A service bound to `0.0.0.0` refuses the v6 leg, which is
+                        // the common case and not worth warning about per
+                        // connection; anything else is a real misconfiguration.
+                        if e.kind() == std::io::ErrorKind::ConnectionRefused {
+                            tracing::debug!(
+                                "{target} has no listener for {client}'s family; connecting plainly"
+                            );
+                        } else {
+                            tracing::warn!(
+                                "transparent egress to {target} for {client} failed ({e}); connecting plainly, so the backend will see this host as the peer"
+                            );
+                        }
                         plain_connect().await?
                     }
                 }

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::future::Future;
-use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
@@ -991,6 +991,14 @@ impl ProxyTarget {
         wan || (self.private.contains(&dst)
             && (subnets.iter().any(|s| s.contains(&src)) || is_private_ip(src)))
     }
+
+    /// Whether `client` is an address of this box, i.e. the connection came from
+    /// a process here rather than from something the box gateways. `private`
+    /// holds the box's own address on each LAN/bridge subnet, which with
+    /// loopback is every address an on-box client connects from in practice.
+    fn client_is_on_box(&self, client: Ipv4Addr) -> bool {
+        client.is_loopback() || self.private.contains(&IpAddr::V4(client))
+    }
 }
 
 impl<A> VHostTarget<A> for ProxyTarget
@@ -1040,25 +1048,40 @@ where
         metadata: &'a <A as Accept>::Metadata,
     ) -> Option<(ServerConfig, Self::PreprocessRes)> {
         let peer = extract::<TcpMetadata, _>(metadata).map(|m| m.peer_addr);
+        let plain_connect = || async {
+            TcpStream::connect(self.addr)
+                .await
+                .with_ctx(|_| (ErrorKind::Network, self.addr))
+                .log_err()
+        };
         let tcp_stream = match (self.preserve_source_ip, peer, self.addr) {
             // Source-preserving passthrough (container): open the internal leg
             // from the client's own address so the backend sees the real peer
             // (RFC §4.6). The box gateways the container, so replies transit it
             // and the divert routes them back. Manual LAN passthroughs and
             // terminating targets connect plainly — the box isn't their gateway.
-            (true, Some(SocketAddr::V4(client)), SocketAddr::V4(target)) => {
+            // Nor is it a client on the box itself, which is its own peer: its
+            // (ip, port) is already bound to its own socket, and a container
+            // can't route a reply back to a loopback source.
+            (true, Some(SocketAddr::V4(client)), SocketAddr::V4(target))
+                if !self.client_is_on_box(*client.ip()) =>
+            {
                 crate::net::transparent::ensure_divert_infra_once()
                     .await
                     .log_err();
-                crate::net::transparent::transparent_connect(client, target)
-                    .await
-                    .with_ctx(|_| (ErrorKind::Network, self.addr))
-                    .log_err()?
+                match crate::net::transparent::transparent_connect(client, target).await {
+                    Ok(stream) => stream,
+                    // Degraded, not fatal: the backend sees this host rather than
+                    // the client. Better than dropping a working connection.
+                    Err(e) => {
+                        tracing::warn!(
+                            "transparent egress to {target} for {client} failed ({e}); connecting plainly, so the backend will see this host as the peer"
+                        );
+                        plain_connect().await?
+                    }
+                }
             }
-            _ => TcpStream::connect(self.addr)
-                .await
-                .with_ctx(|_| (ErrorKind::Network, self.addr))
-                .log_err()?,
+            _ => plain_connect().await?,
         };
         if let Err(e) = socket2::SockRef::from(&tcp_stream)
             .set_tcp_keepalive(&crate::net::utils::default_keepalive())

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -2,10 +2,10 @@ use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::future::Future;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, LazyLock, Weak};
 use std::task::{Poll, ready};
 use std::time::{Duration, Instant};
 
@@ -16,7 +16,7 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use imbl::{OrdMap, OrdSet};
 use imbl_value::{InOMap, InternedString};
-use ipnet::IpNet;
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use rpc_toolkit::{Context, HandlerArgs, HandlerExt, ParentHandler, from_fn, from_fn_async};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
@@ -38,6 +38,7 @@ use crate::db::{DbAccessByKey, DbAccessMut};
 use crate::net::acme::{
     AcmeCertStore, AcmeProvider, AcmeTlsAlpnCache, AcmeTlsHandler, GetAcmeProvider,
 };
+use crate::net::forward::START9_BRIDGE_V6_SUBNET;
 use crate::net::gateway::{
     GatewayInfo, NetworkInterfaceController, NetworkInterfaceListenerAcceptMetadata,
 };
@@ -52,7 +53,7 @@ use crate::util::future::NonDetachingJoinHandle;
 use crate::util::io::ReadWriter;
 use crate::util::serde::{HandlerExtSerde, MaybeUtf8String, display_serializable};
 use crate::util::sync::{SyncMutex, Watch};
-use crate::{GatewayId, HostId, PackageId, ResultExt};
+use crate::{GatewayId, HOST_IP, HostId, PackageId, ResultExt};
 
 /// Identifies which service+host contributed a set of SNI hostname mappings, so
 /// each can be reconciled independently — a service only ever adds or removes
@@ -358,6 +359,8 @@ impl VHostController {
             private: private.clone(),
             acme: None,
             addr: backend,
+            // A manual passthrough is not a container the box gateways.
+            addr_v6: None,
             add_x_forwarded_headers: false,
             auth: None,
             connect_ssl: Err(AlpnInfo::Reflect),
@@ -923,6 +926,10 @@ pub struct ProxyTarget {
     pub private: BTreeSet<IpAddr>,
     pub acme: Option<AcmeProvider>,
     pub addr: SocketAddr,
+    /// The container's IPv6 address on the bridge, when it has one. Only the
+    /// source-preserving leg uses it — the plain connect stays on `addr` — since
+    /// a v6 client's source can only be bound on a socket dialing v6.
+    pub addr_v6: Option<SocketAddrV6>,
     pub add_x_forwarded_headers: bool,
     /// Optional `Authorization` header value to inject on upstream
     /// requests. Implies HTTP-aware proxying (same path as forwarded headers).
@@ -942,6 +949,7 @@ impl PartialEq for ProxyTarget {
             && self.private == other.private
             && self.acme == other.acme
             && self.addr == other.addr
+            && self.addr_v6 == other.addr_v6
             && self.add_x_forwarded_headers == other.add_x_forwarded_headers
             && self.auth == other.auth
             && self.passthrough == other.passthrough
@@ -959,12 +967,28 @@ impl fmt::Debug for ProxyTarget {
             .field("private", &self.private)
             .field("acme", &self.acme)
             .field("addr", &self.addr)
+            .field("addr_v6", &self.addr_v6)
             .field("add_x_forwarded_headers", &self.add_x_forwarded_headers)
             .field("auth", &self.auth.as_ref().map(|_| "<redacted>"))
             .field("connect_ssl", &self.connect_ssl.as_ref().map(|_| ()))
             .field("passthrough", &self.passthrough)
             .field("preserve_source_ip", &self.preserve_source_ip)
             .finish()
+    }
+}
+
+/// Whether `ip` sits on lxcbr0, where the containers are.
+fn on_container_bridge(ip: IpAddr) -> bool {
+    static V6: LazyLock<Ipv6Net> =
+        LazyLock::new(|| START9_BRIDGE_V6_SUBNET.parse().expect("const subnet"));
+    static V4: LazyLock<Ipv4Net> = LazyLock::new(|| {
+        Ipv4Net::new(HOST_IP.into(), 24)
+            .expect("const prefix")
+            .trunc()
+    });
+    match ip {
+        IpAddr::V4(v4) => V4.contains(&v4),
+        IpAddr::V6(v6) => V6.contains(&v6),
     }
 }
 
@@ -992,12 +1016,32 @@ impl ProxyTarget {
             && (subnets.iter().any(|s| s.contains(&src)) || is_private_ip(src)))
     }
 
-    /// Whether `client` is an address of this box, i.e. the connection came from
-    /// a process here rather than from something the box gateways. `private`
-    /// holds the box's own address on each LAN/bridge subnet, which with
-    /// loopback is every address an on-box client connects from in practice.
-    fn client_is_on_box(&self, client: Ipv4Addr) -> bool {
-        client.is_loopback() || self.private.contains(&IpAddr::V4(client))
+    /// Whether the box gateways `client`, which source preservation requires:
+    /// the backend's reply is addressed to the client, and only reaches our
+    /// transparent socket if it transits this host to be diverted. It doesn't
+    /// for a client on the box (also its own peer — its `(ip, port)` is already
+    /// bound to its own socket) nor for one on the container bridge, which the
+    /// backend answers directly over that link.
+    fn gateways_client(&self, client: IpAddr) -> bool {
+        !client.is_loopback() && !self.private.contains(&client) && !on_container_bridge(client)
+    }
+
+    /// The `(client, container)` pair to open the internal leg with when the
+    /// client's source address is to be preserved; `None` to connect plainly.
+    /// Both ends must be one family, so a v6 client needs the container's v6.
+    fn transparent_leg(&self, peer: Option<SocketAddr>) -> Option<(SocketAddr, SocketAddr)> {
+        if !self.preserve_source_ip {
+            return None;
+        }
+        let client = peer?;
+        if !self.gateways_client(client.ip()) {
+            return None;
+        }
+        let target = match client {
+            SocketAddr::V4(_) => matches!(self.addr, SocketAddr::V4(_)).then_some(self.addr)?,
+            SocketAddr::V6(_) => SocketAddr::V6(self.addr_v6?),
+        };
+        Some((client, target))
     }
 }
 
@@ -1054,18 +1098,13 @@ where
                 .with_ctx(|_| (ErrorKind::Network, self.addr))
                 .log_err()
         };
-        let tcp_stream = match (self.preserve_source_ip, peer, self.addr) {
-            // Source-preserving passthrough (container): open the internal leg
-            // from the client's own address so the backend sees the real peer
-            // (RFC §4.6). The box gateways the container, so replies transit it
-            // and the divert routes them back. Manual LAN passthroughs and
-            // terminating targets connect plainly — the box isn't their gateway.
-            // Nor is it a client on the box itself, which is its own peer: its
-            // (ip, port) is already bound to its own socket, and a container
-            // can't route a reply back to a loopback source.
-            (true, Some(SocketAddr::V4(client)), SocketAddr::V4(target))
-                if !self.client_is_on_box(*client.ip()) =>
-            {
+        // Source-preserving passthrough (container): open the internal leg from
+        // the client's own address so the backend sees the real peer (RFC §4.6).
+        // The box gateways the container, so replies transit it and the divert
+        // routes them back. Manual LAN passthroughs and terminating targets
+        // connect plainly — the box isn't their gateway.
+        let tcp_stream = match self.transparent_leg(peer) {
+            Some((client, target)) => {
                 crate::net::transparent::ensure_divert_infra_once()
                     .await
                     .log_err();
@@ -1081,7 +1120,7 @@ where
                     }
                 }
             }
-            _ => plain_connect().await?,
+            None => plain_connect().await?,
         };
         if let Err(e) = socket2::SockRef::from(&tcp_stream)
             .set_tcp_keepalive(&crate::net::utils::default_keepalive())
@@ -1880,6 +1919,7 @@ mod accept_filter_tests {
             private: private.iter().map(|s| s.parse().unwrap()).collect(),
             acme: None,
             addr: "10.0.0.1:443".parse().unwrap(),
+            addr_v6: None,
             add_x_forwarded_headers: false,
             auth: None,
             connect_ssl: Err(AlpnInfo::Reflect),
@@ -1890,6 +1930,27 @@ mod accept_filter_tests {
 
     fn ip(s: &str) -> IpAddr {
         s.parse().unwrap()
+    }
+
+    /// Source preservation needs the backend's reply to transit this host. It
+    /// doesn't for a client that reaches the backend without us.
+    #[test]
+    fn only_a_gatewayed_client_gets_source_preservation() {
+        let t = target(&["enp1s0"], &[], &["192.168.1.5", "fd00:3::1"]);
+
+        // remote, both families: we gateway it
+        assert!(t.gateways_client(ip("192.168.1.99")));
+        assert!(t.gateways_client(ip("2001:db8::99")));
+
+        // this box: its (ip, port) is already bound to its own socket
+        assert!(!t.gateways_client(ip("127.0.0.1")));
+        assert!(!t.gateways_client(ip("::1")));
+        assert!(!t.gateways_client(ip("192.168.1.5")));
+        assert!(!t.gateways_client(ip("fd00:3::1")));
+
+        // on lxcbr0 with the backend, which answers it directly over that link
+        assert!(!t.gateways_client(ip("10.0.3.42")));
+        assert!(!t.gateways_client(ip("fd00:3::c9f:81ff:fe37:c0a9")));
     }
 
     // WAN accept is gated by the family of the address the connection arrived on:

--- a/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
@@ -351,8 +351,15 @@ async fn handle_conn(
         return; // IPv4-only listener; should not occur
     };
     // Open the internal leg from the client's own source address (RFC §4.6).
-    let Ok(mut upstream) = crate::net::transparent::transparent_connect(peer, target).await else {
-        return;
+    // No plain-connect fallback: the backend gates LAN-only addresses on the
+    // source being private, and this server's own wg address is private — a
+    // fallback would present every WAN client as LAN-local.
+    let mut upstream = match crate::net::transparent::transparent_connect(peer, target).await {
+        Ok(upstream) => upstream,
+        Err(e) => {
+            tracing::warn!("SNI demux transparent egress to {target} for {peer} failed: {e}");
+            return;
+        }
     };
     if upstream.write_all(&buf).await.is_err() {
         return;

--- a/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
+++ b/shared-libs/crates/start-core/src/tunnel/forward/sni.rs
@@ -354,7 +354,12 @@ async fn handle_conn(
     // No plain-connect fallback: the backend gates LAN-only addresses on the
     // source being private, and this server's own wg address is private — a
     // fallback would present every WAN client as LAN-local.
-    let mut upstream = match crate::net::transparent::transparent_connect(peer, target).await {
+    let mut upstream = match crate::net::transparent::transparent_connect(
+        SocketAddr::V4(peer),
+        SocketAddr::V4(target),
+    )
+    .await
+    {
         Ok(upstream) => upstream,
         Err(e) => {
             tracing::warn!("SNI demux transparent egress to {target} for {peer} failed: {e}");

--- a/shared-libs/crates/start-core/src/version/v0_4_0_1.rs
+++ b/shared-libs/crates/start-core/src/version/v0_4_0_1.rs
@@ -26,15 +26,21 @@ impl VersionT for Version {
     }
     #[instrument(skip_all)]
     fn up(self, db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+        let mut ssl_ports = Vec::new();
         for_each_host(db, |host| {
-            move_port(host, "assignedPort", "assignedSslPort")
+            move_port(host, "assignedPort", "assignedSslPort");
+            collect_self_tls_ports(host, &mut ssl_ports);
         });
+        set_port_ssl_flags(db, &ssl_ports, true);
         Ok(Value::Null)
     }
     fn down(self, db: &mut Value) -> Result<(), Error> {
+        let mut ssl_ports = Vec::new();
         for_each_host(db, |host| {
-            move_port(host, "assignedSslPort", "assignedPort")
+            collect_self_tls_ports(host, &mut ssl_ports);
+            move_port(host, "assignedSslPort", "assignedPort");
         });
+        set_port_ssl_flags(db, &ssl_ports, false);
         Ok(())
     }
 }
@@ -92,6 +98,38 @@ fn move_port(host: &mut Value, from: &str, to: &str) {
     }
 }
 
+/// A self-TLS binding's port is now answered by our SNI-passthrough listener,
+/// so its `availablePorts` ssl flag flips with the move.
+fn collect_self_tls_ports(host: &Value, ports: &mut Vec<u64>) {
+    let Some(bindings) = host.get("bindings").and_then(|b| b.as_object()) else {
+        return;
+    };
+    for (_, binding) in bindings.iter() {
+        let serves_own_tls = binding.get("options").map_or(false, |o| {
+            o["secure"]["ssl"].as_bool().unwrap_or(false) && o["addSsl"].is_null()
+        });
+        if !serves_own_tls {
+            continue;
+        }
+        if let Some(port) = binding["net"]["assignedSslPort"].as_u64() {
+            ports.push(port);
+        }
+    }
+}
+
+fn set_port_ssl_flags(db: &mut Value, ports: &[u64], ssl: bool) {
+    let Some(available) = db
+        .get_mut("private")
+        .and_then(|p| p.get_mut("availablePorts"))
+        .and_then(|a| a.as_object_mut())
+    else {
+        return;
+    };
+    for port in ports {
+        available.insert(InternedString::from_display(port), Value::Bool(ssl));
+    }
+}
+
 #[cfg(test)]
 mod test {
     use imbl_value::json;
@@ -108,12 +146,17 @@ mod test {
                         "net": net,
                     } } } } }
                 }
-            }
+            },
+            "private": { "availablePorts": { "8080": false } }
         })
     }
 
     fn net_of(db: &Value) -> &Value {
         &db["public"]["packageData"]["pkg"]["hosts"]["main"]["bindings"]["8080"]["net"]
+    }
+
+    fn port_ssl(db: &Value, port: &str) -> Option<bool> {
+        db["private"]["availablePorts"][port].as_bool()
     }
 
     #[test]
@@ -127,14 +170,18 @@ mod test {
         Version.up(&mut d, ()).unwrap();
         assert_eq!(net_of(&d)["assignedSslPort"].as_u64(), Some(8080));
         assert!(net_of(&d)["assignedPort"].is_null());
+        // the port is now one of our SNI-passthrough listeners' ports
+        assert_eq!(port_ssl(&d, "8080"), Some(true));
 
         // idempotent
         Version.up(&mut d, ()).unwrap();
         assert_eq!(net_of(&d)["assignedSslPort"].as_u64(), Some(8080));
+        assert_eq!(port_ssl(&d, "8080"), Some(true));
 
         Version.down(&mut d).unwrap();
         assert_eq!(net_of(&d)["assignedPort"].as_u64(), Some(8080));
         assert!(net_of(&d)["assignedSslPort"].is_null());
+        assert_eq!(port_ssl(&d, "8080"), Some(false));
 
         // the OS terminates TLS here: both ports already mean what they say
         let add_ssl = json!({
@@ -149,6 +196,7 @@ mod test {
         Version.up(&mut d, ()).unwrap();
         assert_eq!(net_of(&d)["assignedPort"].as_u64(), Some(8080));
         assert_eq!(net_of(&d)["assignedSslPort"].as_u64(), Some(8443));
+        assert_eq!(port_ssl(&d, "8080"), Some(false));
 
         // plaintext binding is untouched
         let plain =
@@ -160,5 +208,6 @@ mod test {
         Version.up(&mut d, ()).unwrap();
         assert_eq!(net_of(&d)["assignedPort"].as_u64(), Some(8080));
         assert!(net_of(&d)["assignedSslPort"].is_null());
+        assert_eq!(port_ssl(&d, "8080"), Some(false));
     }
 }

--- a/shared-libs/crates/start-core/src/version/v0_4_0_1.rs
+++ b/shared-libs/crates/start-core/src/version/v0_4_0_1.rs
@@ -24,10 +24,141 @@ impl VersionT for Version {
     fn compat(self) -> &'static VersionRange {
         &V0_3_0_COMPAT
     }
-    fn up(self, _db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+    #[instrument(skip_all)]
+    fn up(self, db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+        for_each_host(db, |host| {
+            move_port(host, "assignedPort", "assignedSslPort")
+        });
         Ok(Value::Null)
     }
-    fn down(self, _db: &mut Value) -> Result<(), Error> {
+    fn down(self, db: &mut Value) -> Result<(), Error> {
+        for_each_host(db, |host| {
+            move_port(host, "assignedSslPort", "assignedPort")
+        });
         Ok(())
+    }
+}
+
+fn for_each_host(db: &mut Value, mut f: impl FnMut(&mut Value)) {
+    if let Some(host) = db
+        .get_mut("public")
+        .and_then(|p| p.get_mut("serverInfo"))
+        .and_then(|s| s.get_mut("network"))
+        .and_then(|n| n.get_mut("host"))
+    {
+        f(host);
+    }
+    if let Some(packages) = db
+        .get_mut("public")
+        .and_then(|p| p.get_mut("packageData"))
+        .and_then(|p| p.as_object_mut())
+    {
+        for (_, package) in packages.iter_mut() {
+            if let Some(hosts) = package.get_mut("hosts").and_then(|h| h.as_object_mut()) {
+                for (_, host) in hosts.iter_mut() {
+                    f(host);
+                }
+            }
+        }
+    }
+}
+
+/// A binding whose container serves its own TLS now holds its external port in
+/// `assignedSslPort`, like every other TLS-carrying binding. The port number
+/// itself is preserved, so addresses the user has bookmarked and per-address
+/// enable/disable overrides (keyed by port) survive the move.
+fn move_port(host: &mut Value, from: &str, to: &str) {
+    let Some(bindings) = host.get_mut("bindings").and_then(|b| b.as_object_mut()) else {
+        return;
+    };
+    for (_, binding) in bindings.iter_mut() {
+        let serves_own_tls = binding.get("options").map_or(false, |o| {
+            o["secure"]["ssl"].as_bool().unwrap_or(false) && o["addSsl"].is_null()
+        });
+        if !serves_own_tls {
+            continue;
+        }
+        let Some(net) = binding.get_mut("net").and_then(|n| n.as_object_mut()) else {
+            continue;
+        };
+        if !net.get(to).map_or(true, |v| v.is_null()) {
+            continue;
+        }
+        let Some(port) = net.get(from).and_then(|p| p.as_u64()) else {
+            continue;
+        };
+        net.insert(to.into(), Value::from(port));
+        net.insert(from.into(), Value::Null);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use imbl_value::json;
+
+    use super::*;
+
+    fn db(options: Value, net: Value) -> Value {
+        json!({
+            "public": {
+                "serverInfo": { "network": { "host": { "bindings": {} } } },
+                "packageData": {
+                    "pkg": { "hosts": { "main": { "bindings": { "8080": {
+                        "options": options,
+                        "net": net,
+                    } } } } }
+                }
+            }
+        })
+    }
+
+    fn net_of(db: &Value) -> &Value {
+        &db["public"]["packageData"]["pkg"]["hosts"]["main"]["bindings"]["8080"]["net"]
+    }
+
+    #[test]
+    fn moves_only_self_tls_bindings() {
+        let self_tls =
+            json!({ "preferredExternalPort": 8080, "addSsl": null, "secure": { "ssl": true } });
+        let mut d = db(
+            self_tls.clone(),
+            json!({ "assignedPort": 8080, "assignedSslPort": null }),
+        );
+        Version.up(&mut d, ()).unwrap();
+        assert_eq!(net_of(&d)["assignedSslPort"].as_u64(), Some(8080));
+        assert!(net_of(&d)["assignedPort"].is_null());
+
+        // idempotent
+        Version.up(&mut d, ()).unwrap();
+        assert_eq!(net_of(&d)["assignedSslPort"].as_u64(), Some(8080));
+
+        Version.down(&mut d).unwrap();
+        assert_eq!(net_of(&d)["assignedPort"].as_u64(), Some(8080));
+        assert!(net_of(&d)["assignedSslPort"].is_null());
+
+        // the OS terminates TLS here: both ports already mean what they say
+        let add_ssl = json!({
+            "preferredExternalPort": 80,
+            "addSsl": { "preferredExternalPort": 443 },
+            "secure": null,
+        });
+        let mut d = db(
+            add_ssl,
+            json!({ "assignedPort": 8080, "assignedSslPort": 8443 }),
+        );
+        Version.up(&mut d, ()).unwrap();
+        assert_eq!(net_of(&d)["assignedPort"].as_u64(), Some(8080));
+        assert_eq!(net_of(&d)["assignedSslPort"].as_u64(), Some(8443));
+
+        // plaintext binding is untouched
+        let plain =
+            json!({ "preferredExternalPort": 8080, "addSsl": null, "secure": { "ssl": false } });
+        let mut d = db(
+            plain,
+            json!({ "assignedPort": 8080, "assignedSslPort": null }),
+        );
+        Version.up(&mut d, ()).unwrap();
+        assert_eq!(net_of(&d)["assignedPort"].as_u64(), Some(8080));
+        assert!(net_of(&d)["assignedSslPort"].is_null());
     }
 }

--- a/shared-libs/ts-modules/start-core/lib/util/GetHostInfo.ts
+++ b/shared-libs/ts-modules/start-core/lib/util/GetHostInfo.ts
@@ -94,11 +94,12 @@ export function getHost<Mapped>(
  *
  * Resolves the binding's own derived address rather than `net.assignedPort` /
  * `net.assignedSslPort`: which of those are populated is a property of how the
- * *dependency* bound the port — a binding with `addSsl` and `secure.ssl`
- * carries only `assignedSslPort`, a passthrough binding only `assignedPort`,
- * and an `http`/`ws` binding (`secure: null` plus a generated `addSsl`) carries
- * *both*. Reading either directly asserts how a dependency terminates TLS and
- * resolves `null` the day that changes.
+ * *dependency* bound the port — `assignedSslPort` carries a port that speaks
+ * TLS, whether StartOS terminates it (`addSsl`) or the container serves its own
+ * certificate, `assignedPort` a plaintext one, and an `http`/`ws` binding
+ * (`secure: null` plus a generated `addSsl`) carries *both*. Reading either
+ * directly asserts whether a dependency's port speaks TLS and resolves `null`
+ * the day that changes.
  *
  * Works for a binding with no exported interface, so it also resolves
  * bridge-only ports such as tor's SOCKS proxy.
@@ -107,10 +108,9 @@ export function getHost<Mapped>(
  * a TLS address (`protocol: 'http'`/`'ws'`, or `secure: null` with `addSsl`).
  * The filter is a no-op when omitted, so the lookup takes whichever leg sorts
  * first rather than the one you meant. Omit it for a single-leg binding, where
- * passing the wrong value resolves `null` — note that a TLS-passthrough binding
+ * passing the wrong value resolves `null` — a TLS-passthrough binding
  * (`secure: {ssl: true}` with `addSsl: null`, e.g. LND's gRPC) publishes its one
- * address on `assignedPort` yet flagged `ssl: true`, so `ssl: false` there
- * resolves nothing.
+ * address flagged `ssl: true`, so `ssl: false` there resolves nothing.
  * @param opts.fallbackPort - Resolve to `<osIp>:<fallbackPort>` instead of
  * `null` while the dependency is absent. Only for a flag that should be passed
  * unconditionally against an allocator-guaranteed port, such as tor's 9050.


### PR DESCRIPTION
Per the Matrix thread: `assignedSslPort` should hold the external port for *all* SSL ports, not just `addSsl`.

## What changed

A binding with `secure: {ssl: true}` and no `addSsl` — the container serves its own certificate and StartOS DNATs the port straight through — kept its external port in `assignedPort`, the plaintext field. The old split was "did we allocate a TLS-terminating port"; it's now "does this external port speak TLS":

| binding | before | after |
| --- | --- | --- |
| plaintext | `assignedPort` | `assignedPort` |
| `addSsl`, plaintext upstream | both | both |
| `addSsl` + `secure.ssl` (we rewrap) | `assignedSslPort` | `assignedSslPort` |
| `secure.ssl`, no `addSsl` (own cert) | **`assignedPort`** | **`assignedSslPort`** |

`BindOptions` gains `serves_own_tls` / `preferred_ssl_port` / `wants_plain_port`, so the allocator, `update_addresses` and the forward wiring stop restating the rule in five slightly different forms. The self-TLS domain address (#3130) was `else`-chained on `assignedSslPort.is_none()`, which this makes false — un-chained and re-keyed. The "Non-SSL forwards" block becomes the direct-forward block: every external port with no listener of ours in front, which is what it always meant, so it covers the self-TLS port too and no longer needs `or_not_found`.

Emitted addresses are unchanged for every family — the old code already flagged these `ssl: true` out of the plain branch, and the `map_or` defaults it carried were only reachable when `secure` is null. One deliberate exception: the mDNS SSL leg is now gated on there being an mDNS gateway, matching the plaintext leg, so a self-TLS binding doesn't gain a `.local` address it never had.

## The one deliberate asymmetry

`AvailablePorts`' bool is **not** set for a self-TLS port. Its four readers all use it as "one of our TLS listeners answers here, so a domain can be advertised there and SNI-routed" — a DNAT'd port isn't that. Flagging it would let package A's DNAT capture a domain that package B advertises on the same preferred port. Documented on the struct.

## No package has to change

`sdk.host.getBridgeAddress` (#3560) resolves the binding's *derived* address, not these fields, so for a self-TLS binding it resolves the identical result before and after — same hostname, same port number, still flagged `ssl: true`. A code search across `Start9Labs` and `Start9-Community` finds zero `*-startos` packages reading `net.assignedPort` directly. Its docstrings did describe the old field mapping, so those are corrected here (`GetHostInfo.ts`, `StartSdk.ts`, `service-to-service.md`) — no SDK library code changed, so no version bump; whether to cut 2.0.10 to get the corrected docstrings onto npm is your call. This follows #3567, which changed the same docstrings without one.

## Migration

Folded into the existing (still untagged) `0.4.0.1` node rather than cutting an 0.4.0.2, per the changelog/tags rule in root `AGENTS.md`. It moves the persisted port between fields for `secure.ssl && addSsl == null` bindings across the server host and every package host. **The number is preserved**, so bookmarks, router forwards and the per-address `enabled`/`disabled`/`guaWan` overrides (keyed by port) all keep working. `availablePorts` needs no edit — these ports were already flagged `false` and stay `false`. Idempotent, with a true inverse in `down`.

`update()` now releases both ports before reallocating, so a binding that *changes* how its port is served keeps its number, carrying it between the fields. Without that, dropping `secure.ssl` in a package update handed the binding a fresh random port.

## Rebase note

The first push carried its own 0.4.0.1 version bump; #3564 has since cut 0.4.0.1 properly (root `package.json` as the source of truth, `build/env/version.sh`, the `current_matches_manifest` test) so all of that is dropped — including the `start-core` `Cargo.toml` bump, which `VERSION_BUMP.md` now says to leave alone on a revision. `should_welcome_to_release` landed independently on master with the same predicate. What's left is the net change, the migration, and the doc corrections.

## Not fixed here

`is_ssl`-derived domain advertisements aren't recomputed for other hosts when a port's role changes, so a binding that advertised a domain on someone else's preferred port can go stale. Pre-existing (the old allocator reached the same state one step later, via a third package reclaiming the freed port) and it needs cross-host recomputation — I have a patch for it and can raise it separately.

## Verified

`cargo test -p start-core --features=test` — 586 pass, including new coverage for all four binding shapes, the port-number carry in both directions, an idempotent re-bind not migrating onto a freed preferred port, and the migration. `make start-core-format-check` and prettier 3.8.3 clean. `manage-release.sh pre-check start-os` passes every content check (changelog heading, docs release link, crate label, tag free).