### PR TITLE
fix(start-sdk): type getBridgeAddress non-null when fallbackPort is given

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.0.9 — StartOS 0.4.0-beta.10 (2026-07-25)
+
+### Fixed
+
+- **`sdk.host.getBridgeAddress` now types its result as non-null when
+  `fallbackPort` is given.** `fallbackPort` exists precisely so the value is
+  never `null` — it resolves to `<osIp>:<fallbackPort>` while the dependency is
+  absent — but 2.0.8 typed every call `string | null` regardless, so the one
+  case the option exists for still forced callers to handle a `null` that cannot
+  occur. Assigning it straight to a non-nullable config field (Bitcoin's
+  `proxy`, LND's `tor.socks`) failed to compile. `getBridgeAddress` is now
+  overloaded on the presence of `fallbackPort`, matching the per-package helper
+  it replaced, which carried the same overload
+
 ## 2.0.8 — StartOS 0.4.0-beta.10 (2026-07-25)
 
 ### Added

--- a/projects/start-sdk/docs/package-template/package.json
+++ b/projects/start-sdk/docs/package-template/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "2.0.8"
+    "@start9labs/start-sdk": "2.0.9"
   },
   "devDependencies": {
     "@types/node": "^22.19.0",

--- a/projects/start-sdk/package-lock.json
+++ b/projects/start-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",

--- a/projects/start-sdk/package.json
+++ b/projects/start-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/shared-libs/ts-modules/start-core/lib/util/GetHostInfo.ts
+++ b/shared-libs/ts-modules/start-core/lib/util/GetHostInfo.ts
@@ -109,7 +109,9 @@ export function getHost<Mapped>(
  * `null` while the dependency is absent. Only for a flag that should be passed
  * unconditionally against an allocator-guaranteed port, such as tor's 9050.
  */
-export class GetBridgeAddress extends Watchable<string | null> {
+export class GetBridgeAddress<
+  A extends string | null = string | null,
+> extends Watchable<A> {
   protected readonly label = 'GetBridgeAddress'
 
   constructor(
@@ -125,7 +127,7 @@ export class GetBridgeAddress extends Watchable<string | null> {
     super(effects)
   }
 
-  protected async fetch(callback?: () => void): Promise<string | null> {
+  protected async fetch(callback?: () => void): Promise<A> {
     const { hostId, packageId, internalPort, ssl, fallbackPort } = this.opts
     const host = await this.effects.getHostInfo({ hostId, packageId, callback })
     const addr =
@@ -141,9 +143,9 @@ export class GetBridgeAddress extends Watchable<string | null> {
         kind: 'ipv4',
         predicate: a => ssl === undefined || a.ssl === ssl,
       }).hostnames[0]
-    if (addr?.port != null) return `${addr.hostname}:${addr.port}`
-    if (fallbackPort === undefined) return null
-    return `${await this.effects.getOsIp()}:${fallbackPort}`
+    if (addr?.port != null) return `${addr.hostname}:${addr.port}` as A
+    if (fallbackPort === undefined) return null as A
+    return `${await this.effects.getOsIp()}:${fallbackPort}` as A
   }
 }
 
@@ -155,8 +157,28 @@ export function getBridgeAddress(
     packageId?: PackageId
     internalPort: number
     ssl?: boolean
+    fallbackPort: number
+  },
+): GetBridgeAddress<string>
+export function getBridgeAddress(
+  effects: Effects,
+  opts: {
+    hostId: HostId
+    packageId?: PackageId
+    internalPort: number
+    ssl?: boolean
+    fallbackPort?: undefined
+  },
+): GetBridgeAddress<string | null>
+export function getBridgeAddress(
+  effects: Effects,
+  opts: {
+    hostId: HostId
+    packageId?: PackageId
+    internalPort: number
+    ssl?: boolean
     fallbackPort?: number
   },
-): GetBridgeAddress {
+): GetBridgeAddress<string> | GetBridgeAddress<string | null> {
   return new GetBridgeAddress(effects, opts)
 }


### PR DESCRIPTION
Ships as **start-sdk 2.0.9**. Fixes an API gap in 2.0.8 that blocks every package adopting `sdk.host.getBridgeAddress`.

## The bug

`fallbackPort` exists so the value is **never** `null` — it resolves to `<osIp>:<fallbackPort>` while the dependency is absent, which is the whole point for a flag that must be passed unconditionally (Bitcoin's `-onion`, LND's `tor.socks`, CLN's `proxy`).

2.0.8 typed every call `string | null` regardless, so the one case the option exists for still forced callers to handle a `null` that cannot occur. Assigning the result straight to a non-nullable config field fails to compile:

```
Type 'string | null' is not assignable to type 'AllowReadonly<string | undefined>'
Type 'string | null' is not assignable to type 'AnyJson'
```

The per-package helper this replaced already carried the overload; I dropped it when moving the code into the SDK.

## The fix

`GetBridgeAddress` is generic over its result, and `getBridgeAddress` is overloaded on the presence of `fallbackPort`:

```typescript
getBridgeAddress(effects, { …, fallbackPort: number }): GetBridgeAddress<string>
getBridgeAddress(effects, { …, fallbackPort?: undefined }): GetBridgeAddress<string | null>
```

## Verification

`npm link`ed the build into seven packages that fail to compile against 2.0.8 — lnd, cln, bitcoin-core/31.x, btcpayserver, monerod, robosats, am-i-exposed. All seven now `tsc --noEmit` clean. `make -C projects/start-sdk bundle` and `make -C shared-libs/ts-modules/start-core test` pass.

This link-and-typecheck step is what would have caught the gap before 2.0.8 shipped; the SDK's own `tsc` cannot, since nothing in the SDK consumes the overload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)