### PR TITLE
docs(start-sdk): require npm overrides for the SDK in packages with service dependencies

### DIFF
--- a/projects/start-sdk/docs/package-template/package.json
+++ b/projects/start-sdk/docs/package-template/package.json
@@ -8,6 +8,9 @@
   "dependencies": {
     "@start9labs/start-sdk": "2.0.9"
   },
+  "overrides": {
+    "@start9labs/start-sdk": "$@start9labs/start-sdk"
+  },
   "devDependencies": {
     "@types/node": "^22.19.0",
     "@vercel/ncc": "^0.38.4",

--- a/projects/start-sdk/docs/src/dependencies.md
+++ b/projects/start-sdk/docs/src/dependencies.md
@@ -38,6 +38,29 @@ dependencies: {
 }
 ```
 
+### Adding the Dependency to `package.json`
+
+Importing a dependency's types — its manifest, its interface constants, an action object — means installing its packaging repo as an npm dependency, pinned to a branch:
+
+```json
+"dependencies": {
+  "@start9labs/start-sdk": "2.0.9",
+  "synapse-startos": "github:Start9Labs/synapse-startos#next"
+},
+"overrides": {
+  "@start9labs/start-sdk": "$@start9labs/start-sdk"
+}
+```
+
+Nothing from that repo ships in your package. StartOS installs each service separately; the dependency is present purely so your code compiles against its real types instead of hand-copied string literals.
+
+> [!IMPORTANT]
+> **The `overrides` entry is required whenever you depend on another packaging repo.** That repo declares its own `@start9labs/start-sdk` version, and if it differs from yours by even a patch, npm nests a second copy of the SDK under it. Both copies then get bundled into your `javascript/index.js` — roughly doubling it — and the two sets of SDK classes are distinct types at runtime.
+>
+> The `$` form points at your own root pin, so it keeps tracking your SDK version with no further edits. It also makes a genuine mismatch _loud_: your `tsconfig.json` includes `node_modules/**/startos`, so the dependency's source is type-checked against **your** SDK. If it uses an API your version doesn't have, you get a build error naming the file — rather than a silently duplicated SDK. Fix that by bumping your own SDK to match.
+>
+> It costs nothing where it isn't needed: with no nested copy to collapse, the lockfile and the built bundle are byte-identical.
+
 ## What `setupDependencies` Returns
 
 The object you return from `setupDependencies()` declares what state each dependency should be in for your service to be considered "fully operational." It drives the **warning UI** the user sees on the service detail page — if a listed dependency isn't installed, isn't running, or has a listed health check failing, StartOS shows them a warning indicator and links them to the offending service.
@@ -106,7 +129,7 @@ sdk.action.createTask(
 > [!NOTE]
 >
 > - Import the action object from the dependency's published package.
-> - The dependency must be listed in your `package.json` (e.g., `"synapse-startos": "file:../synapse-wrapper"`).
+> - The dependency must be listed in your `package.json` — see [Adding the Dependency to `package.json`](#adding-the-dependency-to-packagejson), including the required `overrides` entry.
 > - `when: { condition: 'input-not-matches', once: false }` re-triggers until the action's input matches.
 > - `replayId` prevents duplicate tasks across restarts.
 

--- a/projects/start-sdk/docs/src/tasks.md
+++ b/projects/start-sdk/docs/src/tasks.md
@@ -113,7 +113,7 @@ export const setDependencies = sdk.setupDependencies(async ({ effects }) => {
 With `condition: 'input-not-matches'`, the task is **satisfied** when the action's current input is a superset of **any** entry in `accept` (each entry is matched partially — only the fields you list must agree). When none match, the task is shown and the action form is pre-filled with `set`. Use multiple `accept` entries to tolerate several already-good configurations while still steering the user to one recommended value; for the common case where any value but one specific target is unacceptable, pass a single `accept` entry equal to `set`.
 
 > [!NOTE]
-> The dependency must be listed in your `package.json` so the action can be imported (e.g., `"synapse-startos": "file:../synapse-wrapper"`). See [Dependencies](./dependencies.md) for more on cross-service integration.
+> The dependency must be listed in your `package.json` so the action can be imported — as a branch-pinned git dependency, alongside the `overrides` entry that keeps a single copy of the SDK in your bundle. See [Adding the Dependency to `package.json`](./dependencies.md#adding-the-dependency-to-packagejson), and [Dependencies](./dependencies.md) for more on cross-service integration.
 
 ### Idempotency and `replayId`
 


### PR DESCRIPTION
## Summary

A packaging repo that depends on another packaging repo pulls in that repo's own `@start9labs/start-sdk` pin. When the two differ by even a patch, npm nests a second copy under the dependency and `ncc` bundles **both** — every SDK class, including `StartSdk` itself, emitted twice.

This was live across both registries. 44 packages shipped 2–9 copies; the worst (`canary`) had nine. `lnbits` went from 4.68 MB to 2.83 MB once collapsed.

## What this changes

- **`package-template/package.json`** gains an `overrides` entry, so scaffolded packages are immune from the start.
- **`dependencies.md`** gets a new *Adding the Dependency to `package.json`* section covering the git pin and why the override is required.
- **`tasks.md`** points at it instead of repeating the rule.

## Why the `$` form

`"$@start9labs/start-sdk"` references the root pin, so it keeps tracking the package's own SDK version with no further edits — the alternative, keeping every provider's SDK in lockstep with every dependent, breaks again on the next SDK release.

It also makes a real mismatch **louder**, not quieter. `tsconfig.json` includes `node_modules/**/startos`, so a dependency's source is type-checked against the root SDK: if it uses an API the root doesn't have, the build fails naming the file, instead of silently resolving to a second nested copy.

## Cost where it isn't needed

Nothing. Verified on a package with no service dependencies and on one whose tree was already single-copy — in both cases the lockfile and the built bundle came out byte-identical, because npm only records the override when it actually changes resolution. That's why the template carries it unconditionally rather than as a conditional instruction.

## Notes

- No SDK version bump. Nothing in `lib/` changes, and bumping would force the template pin off 2.0.9 and re-introduce the version skew this removes.
- `pre-check start-sdk` reads only `.dependencies["@start9labs/start-sdk"]` and the absence of a lockfile — the new key affects neither. `sync-template` uses `npm pkg set dependencies…`, so it won't clobber it.
- `prettier --check` passes on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)