### PR TITLE
docs(start-os): recommend flash updating to 0.4.0, and tab the two update paths

### DIFF
--- a/projects/start-os/docs/src/update-040.md
+++ b/projects/start-os/docs/src/update-040.md
@@ -1,9 +1,14 @@
 # Update to StartOS 0.4.0
 
-StartOS 0.4.0 is a completely new operating system. The update is delivered **over the air**: your server updates itself in place through **System → Software Update**, preserving your services and data.
+StartOS 0.4.0 is a completely new operating system. There are two ways to update to it, both of which preserve your services and data and migrate them to the new format — but they are not equally reliable:
+
+- A **flash update** — you boot the 0.4.0 installer from a USB drive and install it over your existing server. **This is the recommended method.**
+- An **over-the-air update** — your server downloads 0.4.0 itself and applies it on the next restart.
+
+Both are covered in [Install StartOS 0.4.0](#install-startos-040) below.
 
 > [!NOTE]
-> **Raspberry Pi cannot update over the air.** Updating a Raspberry Pi means reflashing its microSD card with the 0.4.0 Raspberry Pi image. Complete [Prepare Your Server](#prepare-your-server) below, then follow the [Raspberry Pi flashing instructions](installing-startos.md#raspberry-pi).
+> **Raspberry Pi cannot update over the air.** A Pi flash update uses the 0.4.0 Raspberry Pi microSD image rather than a USB installer. Complete [Prepare Your Server](#prepare-your-server) below, then follow the [Raspberry Pi flashing instructions](installing-startos.md#raspberry-pi).
 
 The preparation steps are **not optional**: complete [Prepare Your Server](#prepare-your-server) before updating.
 
@@ -71,53 +76,103 @@ With all services stopped, create a [full system backup](/0.3.5.x/user-manual/ba
 > [!WARNING]
 > Do **not** skip this step. Migration failures are possible, and without a backup your data could be lost permanently.
 
-## Update Over the Air
+## Install StartOS 0.4.0
 
-Once StartOS 0.4.0 is available for your server, it is offered under **System → Software Update**. If it is not offered yet, check again later. (Raspberry Pi is not offered the update — follow the [Raspberry Pi flashing instructions](installing-startos.md#raspberry-pi) instead.)
+> [!WARNING]
+> **Flash updating is the more reliable method, and the one we recommend.** If you can physically reach your server and boot it from a USB drive, update that way.
+>
+> The over-the-air update needs neither a USB drive nor physical access, but it is the more failure-prone of the two. If you take it, the backup from Step 6 is your fallback.
 
-### Step 7: Begin the Update
+### Step 7: Install 0.4.0
 
-Go to **System → Software Update**, review the release notes, and click **Begin Update**. The download (~3 GB) runs in the background while your server continues running.
+Pick your method below. Everything above applies to both.
 
-### Step 8: Restart to Apply
+{{#tabs}}
+{{#tab name="Flash Update (Recommended)"}}
 
-When the download completes, the System page shows **Update Complete. Restart to apply changes**. Restart your server through the StartOS UI.
+1. Flash the 0.4.0 installer to a USB drive from any computer, following the [Download](installing-startos.md#download) and [Flash](installing-startos.md#flash) sections of the install guide. Your server can keep running while you do this.
 
-### Step 9: Reach the 0.4.0 UI
+   > [!NOTE]
+   > On a Raspberry Pi, there is no USB installer — flash the 0.4.0 Raspberry Pi image to the Pi's microSD card instead. Follow the [Raspberry Pi flashing instructions](installing-startos.md#raspberry-pi) in place of the steps below, then continue with [After the Update](#after-the-update).
 
-Your server is genuinely offline for the first part of this restart while the disk layout is converted, so give it a few minutes before you start checking on it.
+1. Shut down your server through the StartOS UI.
 
-**Then check every few minutes by opening your server's address (`https://adjective-noun.local`) in a new private/incognito window — a fresh window each time.** Do not just reload the tab you already had open. Your browser has the 0.3.5.1 UI cached, and that cached page will keep showing you the old interface or a "cannot connect" error indefinitely, long after 0.4.0 is up and serving. A private window bypasses the cache, so it is the reliable way to see whether your server is actually back.
+1. Insert the flashed USB drive into your server and power it on. The installer should boot from the USB drive and become available at `http://start.local`.
 
-Once a private window loads, your normal window is still stale. Bring it up to date with either:
+   > [!TIP]
+   > If the installer fails to boot and instead your normal StartOS boots, it means you will need to attach a monitor and keyboard (Kiosk mode) in order to enter the BIOS settings to change the boot priorities. The Server Pure should always boot from USB if present. For the Server One, this is done by hitting the ESC key repeatedly at boot time until the BIOS appears. Arrow over to the boot tab, and change Boot Option #1 to your inserted USB thumb drive, then restart.
 
-- A hard refresh:
-  - Linux/Windows: `ctrl+shift+R`
-  - macOS Firefox: `cmd+shift+R`
-  - macOS Safari: `cmd+option+E`, then `cmd+R`
-- Clearing your browser's cache, then reloading.
+1. Select your language.
 
-If a hard refresh still shows you the old UI, fully quit and restart the browser — browsers cache connections more aggressively than page content.
+1. Select the **OS drive** and the **data drive**. These can be the same drive if your server only has one. Double-check that you have selected the correct drive for each.
 
-### Step 10: Wait
+   > [!WARNING]
+   > You must select the **same drive layout** you had on 0.3.5.1. If 0.3.5.1 (OS and data) lived on a single drive, select **that same drive for both** the OS drive and the data drive. If your 0.3.5.1 data was on a separate drive, select a different drive for the OS. Choosing a different layout than your existing install cannot preserve your data, and the installer will refuse rather than erase the drive.
 
-On this restart, StartOS converts your system to the 0.4.0 format and then migrates every installed service. Once StartOS 0.4.0 boots, an initialization screen at your server's address shows migration progress.
+1. When prompted, select **Preserve** to keep your existing data.
 
-The migration can take **hours**, depending on how much data you have. Be patient and do not power off or unplug your server.
+   > [!WARNING]
+   > If you do not select "Preserve", all data on the drive will be erased.
 
-When the migration completes, the login page becomes available at the same address. Continue with [After the Update](#after-the-update).
+1. Optionally set a new password, or skip to keep your current password.
+
+1. Wait. StartOS converts your system to the 0.4.0 format and then migrates every installed service. This can take **hours**, depending on how much data you have. Be patient and do not power off or unplug your server.
+
+   > [!TIP]
+   > Expect progress to sit at **85%** for a long time — potentially hours. This is when your installed packages are being migrated to the 0.4.0 format, and the time scales with how many packages you have and how much data each one contains. The installer is not stuck.
+
+1. When the update is complete, follow the on-screen instructions to remove the USB drive and reboot.
+
+1. Once your server has rebooted, go to your server's own address (`https://adjective-noun.local`) — the address you used on 0.3.5.1, not the installer's `start.local`.
+
+   **If you get the old 0.3.5.1 interface, a blank page, or a "cannot connect" error, your browser is serving you its cached copy of the old UI.** The server is fine; the page is stale. Any of these will get you the 0.4.0 UI:
+   - Open the address in a new private/incognito window.
+   - Hard refresh the page:
+     - Linux/Windows: `ctrl+shift+R`
+     - macOS Firefox: `cmd+shift+R`
+     - macOS Safari: `cmd+option+E`, then `cmd+R`
+   - Clear your browser's cache, then reload.
+
+   If a hard refresh still shows the old UI, fully quit and restart the browser — browsers cache connections more aggressively than page content.
+
+{{#endtab}}
+{{#tab name="Over the Air"}}
+
+Once StartOS 0.4.0 is available for your server, it is offered under **System → Software Update**. If it is not offered yet, check again later. (Raspberry Pi is never offered the update — use the flash update.)
+
+1. Go to **System → Software Update**, review the release notes, and click **Begin Update**. The download (~3 GB) runs in the background while your server continues running.
+
+1. When the download completes, the System page shows **Update Complete. Restart to apply changes**. Restart your server through the StartOS UI.
+
+1. On this restart, StartOS converts your system to the 0.4.0 format and then migrates every installed service. Your server is unreachable while the disk layout is converted; once StartOS 0.4.0 boots, an initialization screen at your server's address (`https://adjective-noun.local`) shows migration progress. The migration can take **hours**, depending on how much data you have. Be patient and do not power off or unplug your server.
+
+1. **Check on it every few minutes by opening your server's address in a new private/incognito window — a fresh window each time.** Do not just reload the tab you already had open. Your browser has the 0.3.5.1 UI cached for that address, and the cached page will keep showing you the old interface or a "cannot connect" error indefinitely, long after 0.4.0 is up and serving. A private window bypasses the cache, so it is the reliable way to see whether your server is actually back — first with the initialization screen, then with the 0.4.0 login page.
+
+   Once a private window loads, your normal window is still stale. Bring it up to date with either:
+   - A hard refresh:
+     - Linux/Windows: `ctrl+shift+R`
+     - macOS Firefox: `cmd+shift+R`
+     - macOS Safari: `cmd+option+E`, then `cmd+R`
+   - Clearing your browser's cache, then reloading.
+
+   If a hard refresh still shows you the old UI, fully quit and restart the browser — browsers cache connections more aggressively than page content.
+
+{{#endtab}}
+{{#endtabs}}
+
+When the migration completes and you can sign in, continue below.
 
 ## After the Update
 
-### Step 11: Update All Services
+### Step 8: Update All Services
 
 Every installed service will have an update available for the 0.4.0 marketplace. Update **all** of them — including Bitcoin (again, to the latest **minor** of your selected **major** version) — before doing anything else. The 0.4.0 versions are repackaged for the new system, even if the underlying software version is the same.
 
-### Step 12: Start All Services
+### Step 9: Start All Services
 
 Once all services are updated, you can start them. Wait for all services to fully start and confirm they are running correctly.
 
-### Step 13: Create a Backup!
+### Step 10: Create a Backup!
 
 Create a [full system backup](backup-create.md). Ideally this is to a separate drive (or network folder) than 0.3.5.
 

--- a/scripts/deploy-migration-payload.sh
+++ b/scripts/deploy-migration-payload.sh
@@ -142,8 +142,9 @@ HEADLINE="${HEADLINE:-StartOS $ADVERTISED}"
 # 0.3.5.1's OS-update modal renders these notes as markdown (marked + DOMPurify;
 # GitHub-style `> [!WARNING]` admonitions are NOT supported) directly above its
 # "Begin Update" button. The default carries the pre-update portion of the 0.4.0
-# migration guide (projects/start-os/docs/src/update-040.md), adapted to the OTA
-# path (no USB steps) — keep the two in sync.
+# migration guide (projects/start-os/docs/src/update-040.md) plus its "Over the
+# Air" tab's what-to-expect and browser-cache steps, with the guide's USB path
+# dropped — keep the two in sync.
 if [ -z "$NOTES" ]; then
     NOTES="$(cat <<'EOF'
 StartOS 0.4.0 is a completely new operating system. This update replaces StartOS in place: it downloads ~3 GB, reboots your server, and migrates your services and data to the new format. It requires StartOS 0.3.5.1.
@@ -183,7 +184,11 @@ With all services stopped, create a full system backup covering every service. *
 
 **What to expect**
 
-After you begin, the update downloads (~3 GB), your server reboots, and the migration runs. It can take **hours**, depending on how much data you have — be patient, and do not power off or unplug your server. When it completes: sign in, update **all** of your services from the marketplace before doing anything else (the 0.4.0 versions are repackaged for the new system even when the app version looks the same), start them, and create a fresh backup.
+After you begin, the update downloads (~3 GB), your server reboots, and the migration runs. It can take **hours**, depending on how much data you have — be patient, and do not power off or unplug your server.
+
+**Your browser will not show you 0.4.0 on its own.** Your server is unreachable for part of the restart, and your browser has this 0.3.5.1 interface cached — reloading this tab will keep showing you the old UI or a "cannot connect" error indefinitely, long after 0.4.0 is up and serving. So check on your server every few minutes by opening its address (the `.local` address you are using right now) in a **new private/incognito window** — a fresh window each time. That bypasses the cache, and is the reliable way to see whether your server is back: first an initialization screen with migration progress, then the 0.4.0 login page. Once a private window loads, bring your normal window over with a hard refresh (`ctrl+shift+R`; on macOS Firefox `cmd+shift+R`, on macOS Safari `cmd+option+E` then `cmd+R`) or by clearing your browser's cache.
+
+When the migration completes: sign in, update **all** of your services from the marketplace before doing anything else (the 0.4.0 versions are repackaged for the new system even when the app version looks the same), start them, and create a fresh backup.
 
 Full guide: https://docs.start9.com/start-os/update-040.html
 EOF


### PR DESCRIPTION
Follow-up to #3563. That PR added the browser-cache guidance as a shared step; this one makes flash updating the recommended path and moves the cache guidance into each path where it actually bites.

## Flash is the recommended method

The guide presented the over-the-air update as the only way to reach 0.4.0. It now names both methods in the intro, and the update section opens with a warning that flashing is the more reliable method and OTA the more failure-prone of the two, with the Step 6 backup as the fallback.

`Step 7: Install 0.4.0` is a tab group — **Flash Update (Recommended)** first, so it is the default selection. The flash instructions are the USB walkthrough this guide carried before 0.4.0 went stable (shut down, boot the installer at `start.local`, matching drive layout, **Preserve**, the 85% progress tip), restored and updated for the stable release. Raspberry Pi users are pointed at the microSD image from inside that tab.

## The cache guidance is per-path, deliberately duplicated

The two paths meet the stale-UI problem in different places, so each tab carries its own version rather than sharing a step:

- **Flash** — the install runs in the installer at `start.local`, where nothing is cached. The old UI is only hit at the very end, when the user moves to their own `.local` address, so that step says: if you see the old interface, a blank page, or an error, the page is stale, not the server — private window, hard refresh, clear cache, browser restart.
- **OTA** — the server is unreachable for part of the restart and a cached page never recovers on its own, so a fresh private window every few minutes is the only way to tell whether the server is back (first the initialization screen, then the login page).

Steps now run 1-10; `After the Update` is 8/9/10.

## Migration payload notes

`scripts/deploy-migration-payload.sh` renders its notes in 0.3.5.1's update modal directly above **Begin Update** and is kept in sync with this guide by hand. Users who start there hit the cached-UI problem first and are least likely to have read the guide, so the same guidance is now in the modal's "What to expect" section (plain markdown — that modal does not support admonitions). Its sync comment is updated to describe what the notes now mirror.

Verified with `mdbook build` (v0.5.2 + mdbook-tabs 0.3.4, matching CI): tabs render with Flash active and OTA hidden, admonitions nested in tab list items render, and every internal anchor resolves — including the removal of the link to the step this PR deletes. `bash -n` on the script.

Not changed: the warning asserts that flashing is more reliable without giving a mechanism, since I don't have one to state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)