### PR TITLE
docs(start-sdk): correct getBridgeAddress docstring on http bindings

### DIFF
--- a/shared-libs/ts-modules/start-core/lib/util/GetHostInfo.ts
+++ b/shared-libs/ts-modules/start-core/lib/util/GetHostInfo.ts
@@ -93,18 +93,24 @@ export function getHost<Mapped>(
  * binding is reachable at from another container.
  *
  * Resolves the binding's own derived address rather than `net.assignedPort` /
- * `net.assignedSslPort`: only one of those is ever populated, and which one is
- * a property of how the *dependency* bound the port — a binding with `addSsl`
- * and `secure.ssl` carries only `assignedSslPort`, a passthrough binding only
- * `assignedPort`. Reading either directly asserts how a dependency terminates
- * TLS and resolves `null` the day that changes.
+ * `net.assignedSslPort`: which of those are populated is a property of how the
+ * *dependency* bound the port — a binding with `addSsl` and `secure.ssl`
+ * carries only `assignedSslPort`, a passthrough binding only `assignedPort`,
+ * and an `http`/`ws` binding (`secure: null` plus a generated `addSsl`) carries
+ * *both*. Reading either directly asserts how a dependency terminates TLS and
+ * resolves `null` the day that changes.
  *
  * Works for a binding with no exported interface, so it also resolves
  * bridge-only ports such as tor's SOCKS proxy.
  *
- * @param opts.ssl - Only for a binding that publishes both a plaintext and a
- * TLS address (`protocol: 'http'`/`'ws'`, or `secure: null` with `addSsl`);
- * omit it otherwise, where it would select nothing.
+ * @param opts.ssl - Required for a binding that publishes both a plaintext and
+ * a TLS address (`protocol: 'http'`/`'ws'`, or `secure: null` with `addSsl`).
+ * The filter is a no-op when omitted, so the lookup takes whichever leg sorts
+ * first rather than the one you meant. Omit it for a single-leg binding, where
+ * passing the wrong value resolves `null` — note that a TLS-passthrough binding
+ * (`secure: {ssl: true}` with `addSsl: null`, e.g. LND's gRPC) publishes its one
+ * address on `assignedPort` yet flagged `ssl: true`, so `ssl: false` there
+ * resolves nothing.
  * @param opts.fallbackPort - Resolve to `<osIp>:<fallbackPort>` instead of
  * `null` while the dependency is absent. Only for a flag that should be passed
  * unconditionally against an allocator-guaranteed port, such as tor's 9050.


### PR DESCRIPTION
The `getBridgeAddress` docstring asserts something false, and contradicts itself eight lines later.

## The claim

`shared-libs/ts-modules/start-core/lib/util/GetHostInfo.ts`:

> Resolves the binding's own derived address rather than `net.assignedPort` / `net.assignedSslPort`: **only one of those is ever populated** …

But the `@param opts.ssl` immediately below says the discriminator is for a binding that **publishes both** a plaintext and a TLS address (`protocol: 'http'`/`'ws'`, or `secure: null` with `addSsl`). Both cannot be true.

## Which one is wrong

The prose. For `protocol: 'http'`, `knownProtocols.http` is `{ secure: null, withSsl: 'https' }`, so in `bindPortForKnown` `getSslProto` returns `'https'` and `addSsl` is non-null while `secure` stays `null`. Then in `BindInfo::new` (`start-core/src/net/host/binding.rs`):

- `add_ssl.is_some()` → `assigned_ssl_port` is allocated;
- `options.secure.map_or(true, |s| !(s.ssl && options.add_ssl.is_some()))` is `true` under `secure: None` → `assigned_port` is allocated too.

Both are populated. `update_addresses` then emits the plaintext leg (gated on `opt.secure.map_or(gateway_secure, …)`, and `lxcbr0` is intrinsically secure) alongside the TLS leg.

## Why it is worth fixing rather than leaving

That sentence is the one a packager reasons from, and it implies an undiscriminated lookup is safe. It is not: the filter is `ssl === undefined || a.ssl === ssl` followed by `hostnames[0]`, so omitting the discriminator on a two-leg binding takes whichever leg sorts first. That resolves plaintext today only incidentally — `HostnameInfo` derives `Ord` with `ssl` first, so `false` sorts before `true`. Reorder the fields or change the derive and every undiscriminated lookup silently moves to the TLS leg.

This has already cost a bug: `canary-startos#11` omitted the discriminator on electrum and needed `#12` to fix. Package `AGENTS.md` files across both registries had paraphrased the wrong rule verbatim; those copies are corrected, but new packages keep inheriting it from here.

## What changed

Two paragraphs of the docstring, no code:

- states that an `http`/`ws` binding carries **both** ports, alongside the two single-leg cases that were already described correctly;
- rewrites `@param opts.ssl` to say the discriminator is *required* on a two-leg binding (omitting is a no-op filter, not a selection), and to name the trap on the other side — a TLS-passthrough binding (`secure: {ssl: true}`, `addSsl: null`, e.g. LND's gRPC) publishes its single address on `assignedPort` yet flagged `ssl: true`, so `ssl: false` there resolves `null`.

Comment-only, in hand-written TS under `lib/` (not `osBindings/`), so no generated bindings are affected and no regen is required. Prettier clean.