### PR TITLE
fix(ci): unbreak package builds on fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,26 +78,27 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Find or create developer signing key
+      # Fork PRs get no secrets, so this falls through to `init-key` — which
+      # writes the same path, keeping the next step's copy source uniform.
+      - name: Find or create identity signing key
         run: |
           if [ -n "${{ secrets.DEV_KEY }}" ]; then
             mkdir -p ~/.startos
-            printf '%s' "${{ secrets.DEV_KEY }}" > ~/.startos/developer.key.pem
+            printf '%s' "${{ secrets.DEV_KEY }}" > ~/.startos/id.key.pem
           else
             start-cli init-key
           fi
         shell: bash
 
-      # start-cli 0.4.0-beta.10's `s9pk pack` requires a packaging workspace: a
-      # `.startos/` dir holding a `build-key` signing key. A bare CI checkout has
-      # none, and `s9pk init-workspace` would clone the guide repo. Provision the
-      # minimum instead — reuse the developer key as the workspace build key,
-      # which restores the pre-beta.10 signing identity (s9pks were signed by the
-      # developer key before the build-key split).
+      # `s9pk pack` requires a packaging workspace: a `.startos/` dir holding a
+      # `build.key.pem` signing key. A bare CI checkout has none, and
+      # `s9pk init-workspace` would clone the guide repo. Provision the minimum
+      # instead — reuse the identity key as the workspace build key, which keeps
+      # the signing identity s9pks had before the build-key split.
       - name: Provision workspace build key
         run: |
           mkdir -p .startos
-          cp ~/.startos/developer.key.pem .startos/build-key
+          cp ~/.startos/id.key.pem .startos/build.key.pem
         shell: bash
 
       # SDK 2.0+ packages `include node_modules/@start9labs/start-sdk/s9pk.mk`,


### PR DESCRIPTION
Fork PRs against `*-startos` package repos currently fail their build check before compiling anything.

## What happens

`build.yml` provisions the identity key one of two ways — from the `DEV_KEY` secret, or by generating one with `start-cli init-key` when there is no secret. Fork PRs get no secrets, so they take the second path.

start-cli 1.1.0 renamed `developer.key.pem` → `id.key.pem` (and `.startos/build-key` → `.startos/build.key.pem`). `init-key` writes the new name; the next step still copied the old one:

```
cp: cannot stat '/home/runner/.startos/developer.key.pem': No such file or directory
Error: Process completed with exit code 1
```

The secret path kept working because start-cli renames a legacy key file the first time it loads one (`migrate_legacy_key_file`, called from `CliContext::id_key` and `CliContext::build_key`) — but that only helps when the legacy file exists in the first place, which on the `init-key` path it never does.

Observed on [Start9-Community/wisp-startos#11](https://github.com/Start9-Community/wisp-startos/pull/11): both arches red on `Provision workspace build key`, while same-repo PRs on the identical workflow passed. It reproduces for any fork PR to any package repo.

## The fix

Use the current names in that step — write the secret to `id.key.pem`, and provision the workspace key as `.startos/build.key.pem`, the name `s9pk init-workspace` creates and `s9pk pack` looks for.

## Scope

Deliberately limited to the one broken step. `release.yml`, `start-wrt.yaml`, `startos-iso.yaml`, and `projects/start-sdk/s9pk.mk` still use the pre-1.1.0 names — they work today via the legacy-rename shim, and moving them off it belongs with whoever removes the shim (`developer/mod.rs` carries a `TODO` to). Worth knowing that `s9pk.mk`'s `check-init` guards on a file that no longer exists, so it re-runs `init-key` on every build; harmless, since `init-key` is idempotent, but the guard is dead and fixing it needs an SDK version bump.

No change to the reusable-workflow surface — inputs, action names, and file layout are untouched, so the package-template copies and `project-structure.md` need no corresponding edit.

## Verification

The x86 and arm builds on this repo's own package CI exercise the secret path. The fork path is what the change is for; the failing run is linked above.
