### PR TITLE
fix(start-sdk): drop check-init's stale key-file guard

### DIFF
--- a/projects/start-sdk/AGENTS.md
+++ b/projects/start-sdk/AGENTS.md
@@ -52,8 +52,12 @@ This symlinks the built `dist/` into your global `node_modules`, so the package 
 
 The SDK is a first-class project of the monorepo-wide release tool, [`scripts/manage-release.sh`](../../scripts/manage-release.sh) (the `npm` kind). The version is read from `package.json`; the git tag / GitHub release is `start-sdk/v<version>`. Only `dist/` ships to npm (compiled JavaScript, declarations, bundled dependencies, package metadata).
 
-1. Bump `package.json`, add the matching `CHANGELOG.md` entry (`pre-check` requires it), and run `make sync-template` to move the [package template](docs/package-template)'s `@start9labs/start-sdk` pin to the new version (`pre-check` enforces the match). Land that on `master`.
-2. Cut the release from the repo root (needs `gh` and an npm login with publish rights):
+1. Bump `package.json` and add the matching `CHANGELOG.md` entry (`pre-check` requires it). Land that on `master`.
+2. Run `make sync-template` to move the [package template](docs/package-template)'s `@start9labs/start-sdk` pin to the version being cut, and land it. `pre-check` enforces the match, so a stale pin fails the release before anything is tagged or published.
+
+   **Sync the pin with the release, not with the bump.** `s9pk init-package` scaffolds from the checkout's template rather than from npm, so a pin ahead of what npm has breaks `npm install` for anyone scaffolding a package in the meantime. When the bump and the release happen in one sitting, steps 1 and 2 collapse into one commit and the distinction doesn't matter. When a version accumulates on `master` first, it does.
+
+3. Cut the release from the repo root (needs `gh` and an npm login with publish rights):
 
    ```bash
    ./scripts/manage-release.sh release start-sdk

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.0.10 — StartOS 0.4.0-beta.10
+
+### Fixed
+
+- **`make install` no longer announces "Initializing StartOS developer
+  environment…" on every run.** `check-init` guarded on
+  `~/.startos/developer.key.pem`, which start-cli 1.1.0 renamed to
+  `id.key.pem`, so the guard stopped matching and ran `start-cli init-key`
+  unconditionally. The condition is removed rather than repointed at the new
+  name: `init-key` already checks for an existing key and prints that it found
+  one, so the guard only duplicated that check while giving the filename a
+  second place to go stale. Cosmetic — no build ever failed over it
+
 ## 2.0.9 — StartOS 0.4.0-beta.10 (2026-07-25)
 
 ### Fixed

--- a/projects/start-sdk/package-lock.json
+++ b/projects/start-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@start9labs/start-sdk",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "bundleDependencies": [
         "@start9labs/start-core",
         "eslint",

--- a/projects/start-sdk/package.json
+++ b/projects/start-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@start9labs/start-sdk",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "Software development kit to facilitate packaging services for StartOS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/projects/start-sdk/s9pk.mk
+++ b/projects/start-sdk/s9pk.mk
@@ -115,10 +115,7 @@ check-deps:
 		(echo "Error: jq not found. Install jq. See https://docs.start9.com/packaging/environment-setup.html" && exit 1)
 
 check-init:
-	@if [ ! -f ~/.startos/developer.key.pem ]; then \
-		echo "Initializing StartOS developer environment..."; \
-		start-cli init-key; \
-	fi
+	@start-cli init-key
 
 javascript/index.js: $(shell find startos -type f) tsconfig.json node_modules
 	npm run check


### PR DESCRIPTION
`s9pk.mk`'s `check-init` guarded on `~/.startos/developer.key.pem`:

```make
check-init:
	@if [ ! -f ~/.startos/developer.key.pem ]; then \
		echo "Initializing StartOS developer environment..."; \
		start-cli init-key; \
	fi
```

start-cli 1.1.0 renamed that file to `id.key.pem`, so the guard stopped matching and `init-key` ran unconditionally — printing the "Initializing StartOS developer environment…" banner on every `make install`, immediately followed by start-cli reporting the key already exists.

**Nothing was broken.** `init-key` is idempotent (`developer/mod.rs:81-97` checks for the key and no-ops), and `check-init` is an order-only prerequisite of `install` alone — the `.s9pk` targets depend on `check-deps` only. The entire symptom is one misleading log line.

## Why remove the condition instead of repointing it

`start-cli init-key` already does the existence check and reports the result. Repointing the guard at `id.key.pem` would reimplement that check in Make, hardcode a path start-cli resolves itself (it also honors `/run/startos/id.key.pem` and a configured `id-key-path`), and leave a second copy of the filename to go stale the next time one moves — which is exactly how this got here.

## Versioning

Cuts `2.0.10`, since `start-sdk/v2.0.9` is tagged and released.

**The package template's pin deliberately stays at 2.0.9.** `AGENTS.md` § Cutting a release folds `make sync-template` into the same step as the bump, which is right when the release follows immediately (as it did for 2.0.9). This change is meant to sit on `master` and ship with whatever else accumulates into 2.0.10, and `s9pk init-package` scaffolds from the *checkout's* template (`init.rs:235`), not from npm — so pinning 2.0.10 now would break `npm install` for anyone scaffolding a package before it publishes. `pre-check` compares the pin against the version being released (`manage-release.sh:427`) and fails if they differ, so `sync-template` at release time is both sufficient and enforced.

The changelog heading carries no date for the same reason — whoever cuts the release should add it.
