### PR TITLE
fix(start-os): unquote the migration grub.cfg paths so PureBoot can parse them

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -12,6 +12,12 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **The over-the-air update to 0.4.0 boots on the Server Pure.** The Server
+  Pure's PureBoot firmware reads the boot configuration itself rather than
+  running GRUB, and it takes the kernel and initramfs paths literally. The
+  update now writes those paths in the plain form PureBoot expects, so the
+  server boots into 0.4.0 on the restart that applies the update.
+
 - **Installing onto a pre-installed Raspberry Pi keeps the data pool you pick.**
   Selecting the data pool by partition path now preserves that choice through
   installation.

--- a/projects/start-os/build/lib/scripts/migration-update-grub
+++ b/projects/start-os/build/lib/scripts/migration-update-grub
@@ -35,6 +35,8 @@ fi
 # never runs. The rest matches 0.4.0's GRUB_CMDLINE_LINUX (debian/postinst).
 CMDLINE="$root boot=startos console=ttyS0,115200n8 console=tty0"
 
+# Paths stay unquoted: the Server Pure's PureBoot parses this file itself rather
+# than running GRUB, and takes the path verbatim, so a quote drops the entry.
 mkdir -p "$BOOT/grub"
 cat > "$BOOT/grub/grub.cfg" <<EOF
 set timeout=1
@@ -46,8 +48,8 @@ menuentry "StartOS" {
     insmod btrfs
     insmod ext2
     insmod fat
-    search --no-floppy --set=root --file "/$kernel"
-    linux "/$kernel" $CMDLINE
-    initrd "/$initrd"
+    search --no-floppy --set=root --file /$kernel
+    linux /$kernel $CMDLINE
+    initrd /$initrd
 }
 EOF


### PR DESCRIPTION
The 0.3.5.1 → 0.4.0 OTA leaves a **Server Pure with zero boot options**. The migration payload's hand-written `grub.cfg` quotes the kernel and initrd paths; PureBoot does not run GRUB, and its own parser does no quote removal.

## Mechanism

`migration-update-grub` writes the box's only boot entry:

```
    linux "/$kernel" $CMDLINE
    initrd "/$initrd"
```

PureBoot (Heads) parses that file itself and kexecs:

- `kexec-parse-boot` `grub_entry()`: `kernel=$(echo $trimcmd | sed "s/([^)]*)//g" | cut -d\  -f2)` → the token is `"/vmlinuz-…"`, **quote bytes included**.
- `fix_path()`: `[ "${path:0:1}" != "/" ]` — the first character is `"`, so the absolute path is reclassified as **relative** and prefixed with the config's directory → `/grub/"/vmlinuz-…"`.
- `check_path()` stats `/boot/grub/"/vmlinuz-…"`, fails, and `echo_entry()` returns without emitting anything. Same for the initrd.

One menuentry in, zero entries out. `basic-autoboot.sh` guards on `[ -s "$BOOT_MENU_OPTIONS" ]`, so `kexec-boot` is never called — no error, exit 0 — and the box lands on the PureBoot menu. The board has no serial console (`# CONFIG_SERIAL_8250_CONSOLE is not set`), so a headless server simply never comes back. The manual escape is dead too: the menu's Boot Options runs the same parser and dies with `Failed to parse any boot options`.

Not a brick — `usb-autoboot.sh` runs before `/boot` is mounted, so USB rescue still works, and with `CONFIG_BASIC=y` there is no hash or signature gate involved (`CONFIG_TPM=n`, `CONFIG_BOOT_REQ_HASH=n`). The parse is the only gate.

## Why it is PureBoot-only

Real GRUB's lexer strips `DQSTR`, so the quoted form is ordinary valid GRUB and every UEFI/BIOS box boots it — `grub-script-check` passes on both. 0.3.5.1 booted fine on the same hardware because its `grub.cfg` came from `grub-mkconfig`, which emits paths bare. This is the first hand-written `grub.cfg` in StartOS, so nothing had exercised the difference.

## Verification

PureBoot's own `kexec-parse-boot` (unmodified, from the release the field is on) run over the config this script generates:

| `grub.cfg` | entries |
|---|---|
| as shipped (quoted) | **0** |
| this patch (unquoted) | **1** — `StartOS\|elf\|kernel /vmlinuz-…\|initrd /initrd.img-…\|append root=UUID=… boot=startos console=ttyS0,115200n8 console=tty0` |
| stock 0.3.5.1 (pre-OTA, for reference) | 1 |

`grub-script-check` passes on the patched output. Quoting either path alone is equally fatal. Ground truth for the layout came from a real installed 0.3.5.1 disk: `/boot` is the 1 GiB vfat partition, 49 MiB used, paths relative to its root — so no ENOSPC and no path-prefix problem, just the quotes.

**Source-level and by re-executing PureBoot's scripts — not yet confirmed on hardware.** No Librem Mini v2 was available. One Server Pure should be taken through the full OTA before the payload is republished.

## This does not reach users by merging

The payload is a built artifact. After this lands it needs `make start-os-migration-squashfs` and `./scripts/deploy-migration-payload.sh --replace <registry-host> <payload>`.

**Pre-flight canary for any Server Pure that has applied the update but not yet rebooted** — it is still on 0.3.5.1 and still reachable over SSH:

```
grep -nE '^\s*(linux|initrd)' /boot/grub/grub.cfg
```

Quoted paths mean that box will not come back; deleting the quotes by hand saves it.

## Deliberately not in this PR

Found while diagnosing, happy to take any of them:

1. **`firmware.rs` reads the PureBoot ROM from the wrong path.** `firmware.rs:125` expects `/usr/lib/startos/firmware/<id>.rom.gz`, but `download-firmware.sh` writes `build/lib/firmware/$PLATFORM/` and `build.mk:87` copies `build/lib` wholesale, so it installs one directory deep at `firmware/x86_64/`. 0.3.5.1's `Makefile:140` flattened it; the flatten was dropped in 96ae53287 (#3085). The DMI match still fires (`firmware.json` itself lands correctly), so a Server Pure serves an "updating firmware" phase on every boot and then fails the hash check on a nonexistent file. Needs an image rebuild, not a payload rebuild — and re-arming an unattended whole-ROM `flashrom -w` on the first boot after a major migration deserves its own discussion, so I did not bundle it here. Filed as 3571.
2. **No fallback menuentry.** `sync_boot` uses `delete:false`, so the 0.3.5.1 kernel and initrd are still on `/boot`. A second entry would make this recoverable — but it must be emitted **after** the 0.4.0 one, since `basic-autoboot.sh` boots `head -1` and does not sort; first would silently revert every Server Pure to 0.3.5.1 and consume the upgrade sentinel.
3. **Fail before the point of no return.** Asserting the kernel and initrd are readable under `/boot` before truncating `grub.cfg` would abort `do_update` ahead of `swap_boot_label()`, turning an unbootable box into a visibly failed update.
4. **`startos-initramfs-module` uses `exit 1` where initramfs-tools uses `panic`.** `exit` from a sourced function kills PID 1, so a future initramfs failure is a bare kernel panic instead of an `(initramfs)` prompt.
