### PR TITLE
docs(start-sdk): correct sigtermTimeout default to 60s

### DIFF
--- a/projects/start-sdk/lib/mainFn/Daemons.ts
+++ b/projects/start-sdk/lib/mainFn/Daemons.ts
@@ -109,7 +109,7 @@ export type ExecCommandOptions = {
    * How long (ms) to wait for the process to exit after sending SIGTERM
    * before force-killing it.
    *
-   * @default 30_000
+   * @default 60_000
    */
   sigtermTimeout?: number
   /** Run the command as PID 1 inside the container (init process) */
@@ -139,7 +139,7 @@ export type ExecFnOptions<
     subcontainer: C,
     abort: AbortSignal,
   ) => Promise<C extends null ? null : ExecCommandOptions | null>
-  // Defaults to the DEFAULT_SIGTERM_TIMEOUT = 30_000ms
+  // Defaults to the DEFAULT_SIGTERM_TIMEOUT = 60_000ms
   sigtermTimeout?: number
 }
 


### PR DESCRIPTION
## Problem

Both places documenting `ExecCommandOptions.sigtermTimeout` / `ExecFnOptions.sigtermTimeout` claim a `30_000`ms default:

- `lib/mainFn/Daemons.ts:112` — `@default 30_000`
- `lib/mainFn/Daemons.ts:142` — `// Defaults to the DEFAULT_SIGTERM_TIMEOUT = 30_000ms`

`DEFAULT_SIGTERM_TIMEOUT` is `60_000` (`lib/mainFn/index.ts:6`), and that is what `CommandController`'s constructor default parameter actually applies when `exec.sigtermTimeout` is `undefined`. The docs have been half the real value — presumably the constant was bumped and the type docs weren't.

These are TSDoc, so they ship in `dist/` declarations and are what packagers read at the call site.

## Why it matters

Found while diagnosing `lnd-startos`, where LND was being SIGKILLed exactly 60s into shutdown on every Bitcoin Core restart. Reading the type surface to decide whether the timeout was the problem gave the wrong number.

(The underlying bug was elsewhere — a `.const()` file watch firing on cookie *deletion* — and the timeout turned out to be blameless. But sizing a timeout off a doc that is 2× wrong is the failure mode this invites.)

## Not changed

- `lib/mainFn/Daemon.ts:195,239` refer to `DEFAULT_SIGTERM_TIMEOUT` symbolically — no number to rot, left alone.
- `Daemons.ts:827`'s `sigtermTimeout: e.sigtermTimeout ?? null` looks like it would defeat the constructor default (a default parameter applies to `undefined`, not `null`), but it is inside `normalizeExec`, a hashing helper for config-change detection, not the runtime path. Correct as-is.
- **No version bump or CHANGELOG entry.** 2.0.9 is a cut origin tag, and this alters no behaviour — there is nothing for an entry to describe. It rides the next bump. Happy to add one if you'd rather.

## Test plan

Comment-only; `npx prettier lib/mainFn/Daemons.ts --check` passes. No behavioural change to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)