### PR TITLE
docs(packaging): stop telling packagers to document dependency version constraints

### DIFF
--- a/projects/start-sdk/docs/src/writing-readmes.md
+++ b/projects/start-sdk/docs/src/writing-readmes.md
@@ -70,7 +70,7 @@ Write for two audiences:
 
 ## Dependencies
 
-[Required and optional dependencies — version constraints, health checks, mounted volumes, purpose]
+[Required and optional dependencies — health checks, mounted volumes, purpose]
 
 ## Limitations and Differences
 
@@ -191,10 +191,11 @@ For each interface:
 For each dependency, document:
 
 - **Service name** and whether it is required or optional
-- **Version constraint** (e.g. `>= 28.3`)
 - **Health checks** that must pass before this service starts
 - **Mounted volumes** — if a dependency volume is mounted, note the mount point and whether it is read-only
 - **Purpose** — why this dependency is needed (e.g. "blockchain data via RPC", "Electrum lookups")
+
+Do **not** restate the version range. `setupDependencies()` declares it, and a copy in the README goes stale the first time you raise the floor — point the reader at that code if the minimum is worth mentioning at all.
 
 If the service has no dependencies, state "None" explicitly.
 


### PR DESCRIPTION
`writing-readmes.md` contradicted itself on dependency version constraints:

- **Says don't** — the AI-quick-reference admonition ("Do not include `upstream_version`, image tags, or dependency version constraints in the YAML block **or anywhere else in the README**") and the pre-publish checklist ("No specific version numbers anywhere … dep version constraints — all stale the moment you bump").
- **Says do** — the recommended-structure outline (`## Dependencies` → "version constraints, health checks, mounted volumes, purpose") and § Dependencies ("**Version constraint** (e.g. `>= 28.3`)").

The instructions won, because they sit in the sections a packager actually writes from while the prohibitions sit under the YAML block and the checklist. And the constraints went stale exactly as predicted:

- `monerod-startos` listed Tor at `>= 0.4.9.5` against the `>=0.4.9.11:4` declared in `startos/dependencies.ts` — Start9-Community/monerod-startos#13.
- All four of `open-webui-startos`' backend minimums had drifted from `startos/backends.ts` (Ollama `>=0.21.0:0` vs `>=0.31.2:2`, vLLM `>=0.16.0:0.1` vs `>=0.23.1-rc.0:13`, llama.cpp `>=1.0.9544:0` vs `>=1.0.9994:1`, Maple Proxy `>=0.1.8:1` vs `>=0.1.11:1`) — Start9Labs/open-webui-startos#28.

Both READMEs dropped the column rather than syncing it. This removes the instruction that produced it, and adds the prohibition to § Dependencies itself so it's visible where the mistake gets made. `setupDependencies()` stays the single source of truth for a version range.

No SDK version bump or `CHANGELOG.md` entry — docs-only, matching the precedent for `docs(packaging):` / `docs(start-sdk):` guide changes. `mdbook build` of the packaging book passes; `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
