### PR TITLE
test(bins): check every CLI tree for arguments a subcommand shares with an ancestor

### DIFF
--- a/shared-libs/crates/start-core/src/bins/container_cli.rs
+++ b/shared-libs/crates/start-core/src/bins/container_cli.rs
@@ -43,6 +43,11 @@ pub fn main(args: impl IntoIterator<Item = OsString>) {
 }
 
 #[test]
+fn no_shadowed_args_start_container() {
+    super::assert_no_shadowed_args(app().into_command());
+}
+
+#[test]
 fn export_manpage_start_container() {
     // start-container is part of the start-os product; anchored to start-core's crate dir.
     let dir = concat!(

--- a/shared-libs/crates/start-core/src/bins/mod.rs
+++ b/shared-libs/crates/start-core/src/bins/mod.rs
@@ -235,3 +235,60 @@ impl MultiExecutable {
         std::process::exit(1);
     }
 }
+
+/// Assert that no subcommand of `root` redeclares an argument an ancestor owns.
+///
+/// `ParentHandler<_, P>` renders `P` as the parent command's arguments and each
+/// subcommand's own `Params` beneath it, then merges the two serialized objects
+/// with `combine`, which rejects a duplicate key. A subcommand that redeclares
+/// one is therefore uninvokable both ways: pass the value once and the ancestor
+/// consumes it, leaving the subcommand's copy missing; pass it twice and the
+/// merge fails. Clap sees two separate commands, so nothing catches it until the
+/// command is run. Inherit with `.with_inherited(...)` and take the ancestor's
+/// params as the handler's last argument instead.
+#[cfg(test)]
+pub(crate) fn assert_no_shadowed_args(root: clap::Command) {
+    use std::collections::BTreeSet;
+
+    fn declared(cmd: &clap::Command) -> BTreeSet<String> {
+        cmd.get_arguments()
+            .filter(|a| !a.is_global_set())
+            .map(|a| a.get_id().to_string())
+            .filter(|id| id != "help" && id != "version")
+            .collect()
+    }
+
+    fn walk(
+        cmd: &clap::Command,
+        path: &str,
+        ancestors: &BTreeSet<String>,
+        found: &mut Vec<String>,
+    ) {
+        let own = declared(cmd);
+        for id in own.intersection(ancestors) {
+            found.push(format!("{path} <{id}>"));
+        }
+        let ancestors: BTreeSet<String> = ancestors.union(&own).cloned().collect();
+        for sub in cmd.get_subcommands() {
+            walk(
+                sub,
+                &format!("{path} {}", sub.get_name()),
+                &ancestors,
+                found,
+            );
+        }
+    }
+
+    // The root's own arguments are the CLI's config (`--host`, `--config`, …),
+    // which is parsed separately and never merged into params, so the walk
+    // starts fresh at each top-level subcommand.
+    let mut found = Vec::new();
+    for sub in root.get_subcommands() {
+        walk(sub, sub.get_name(), &BTreeSet::new(), &mut found);
+    }
+    assert!(
+        found.is_empty(),
+        "these subcommands redeclare an ancestor's argument and cannot be invoked:\n  {}",
+        found.join("\n  ")
+    );
+}

--- a/shared-libs/crates/start-core/src/bins/registry.rs
+++ b/shared-libs/crates/start-core/src/bins/registry.rs
@@ -125,6 +125,11 @@ pub fn cli(args: impl IntoIterator<Item = OsString>) {
 }
 
 #[test]
+fn no_shadowed_args_start_registry() {
+    super::assert_no_shadowed_args(app().into_command());
+}
+
+#[test]
 fn export_manpage_start_registry() {
     // Pages live with the start-registry product; anchored to start-core's crate dir.
     let dir = concat!(

--- a/shared-libs/crates/start-core/src/bins/start_cli.rs
+++ b/shared-libs/crates/start-core/src/bins/start_cli.rs
@@ -39,6 +39,11 @@ pub fn main(args: impl IntoIterator<Item = OsString>) {
 }
 
 #[test]
+fn no_shadowed_args_start_cli() {
+    super::assert_no_shadowed_args(app().into_command());
+}
+
+#[test]
 fn export_manpage_start_cli() {
     // Pages live with the start-cli product; anchored to start-core's crate dir.
     let dir = concat!(

--- a/shared-libs/crates/start-core/src/bins/tunnel.rs
+++ b/shared-libs/crates/start-core/src/bins/tunnel.rs
@@ -241,6 +241,21 @@ pub fn cli(args: impl IntoIterator<Item = OsString>) {
     }
 }
 
+/// A subnet subcommand that declares its own `<SUBNET>` instead of inheriting the
+/// parent's is uninvokable: one subnet fails clap, two fail the params merge.
+#[test]
+fn subnet_subcommands_inherit_the_subnet_argument() {
+    let command = app().into_command();
+    let subnet = command.find_subcommand("subnet").unwrap();
+    for sub in subnet.get_subcommands() {
+        assert!(
+            !sub.get_positionals().any(|a| a.get_id() == "subnet"),
+            "`subnet {}` redeclares the parent's <SUBNET> positional",
+            sub.get_name()
+        );
+    }
+}
+
 #[test]
 fn export_manpage_start_tunnel() {
     // Pages live with the start-tunnel product; anchored to start-core's crate dir.

--- a/shared-libs/crates/start-core/src/bins/tunnel.rs
+++ b/shared-libs/crates/start-core/src/bins/tunnel.rs
@@ -241,19 +241,9 @@ pub fn cli(args: impl IntoIterator<Item = OsString>) {
     }
 }
 
-/// A subnet subcommand that declares its own `<SUBNET>` instead of inheriting the
-/// parent's is uninvokable: one subnet fails clap, two fail the params merge.
 #[test]
-fn subnet_subcommands_inherit_the_subnet_argument() {
-    let command = app().into_command();
-    let subnet = command.find_subcommand("subnet").unwrap();
-    for sub in subnet.get_subcommands() {
-        assert!(
-            !sub.get_positionals().any(|a| a.get_id() == "subnet"),
-            "`subnet {}` redeclares the parent's <SUBNET> positional",
-            sub.get_name()
-        );
-    }
+fn no_shadowed_args_start_tunnel() {
+    super::assert_no_shadowed_args(app().into_command());
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #3570, which landed while this was being written.

#3570 fixed `subnet set-wan`/`set-ipv6` re-declaring the parent's `<SUBNET>` positional (#3565). Nothing would have caught that: there is no test over the CLI surface, and the one artifact that showed the doubled positional — the generated man page — is regenerated from the same code, so a future refactor would regenerate the bug along with its evidence.

Per review, this checks the whole class rather than that one command. `assert_no_shadowed_args` walks a product CLI's clap tree and rejects any subcommand whose argument ids intersect an ancestor's, and every product CLI runs it: `start-tunnel`, `start-cli`, `start-registry`, `start-container`.

## Why an intersection is always a bug

`ParentHandler<_, P>::cli_command` uses `P::command()` as the base and attaches each child's own command beneath it (`rpc-toolkit/src/handler/parent.rs:352-366`), so the two argument sets live on separate clap `Command`s and clap never objects. At parse time `cli_parse` merges the two serialized param objects with `combine` (`parent.rs:389` → `util.rs:31-48`), which errors on any duplicate key. So a shared id is uninvokable in both directions — pass the value once and the ancestor consumes it, leaving the child's copy missing; pass it twice and the merge fails — and the failure only appears when the command is run.

The walk starts fresh at each top-level subcommand: the root's own arguments are the CLI's config (`--host`, `--config`, …), which `CliApp` parses into `Config` separately and never merges into params (`rpc-toolkit/src/cli.rs:57-78`). Global args and clap's own `help`/`version` are excluded for the same reason.

## Result

All four trees pass as-is, so `subnet set-wan` and `set-ipv6` were the only instances in the repo.

Verified the check actually catches the original bug rather than just being green — reverting `set-ipv6`'s `.with_inherited`:

```
these subcommands redeclare an ancestor's argument and cannot be invoked:
  tunnel subnet set-ipv6 <subnet>

failures:
    bins::start_cli::no_shadowed_args_start_cli
    bins::tunnel::no_shadowed_args_start_tunnel
```

Note it fires in the `start-cli` tree too, which the first (subnet-specific) version of this test missed entirely.

## Known limit

The check reads clap arguments, so it cannot see a field that is `#[arg(skip)]` but still serialized — `ShowConfigParams::local_addr` is the one such field today. Catching those would mean comparing serialized param keys, which no trait currently exposes.

Test-only, so no changelog entry and no version bump — 1.2.2 is already open for the fix itself.
