### PR TITLE
docs(start-os): clarify server returns to its old address after the 0.4.0 migration

### DIFF
--- a/projects/start-os/docs/src/update-040.md
+++ b/projects/start-os/docs/src/update-040.md
@@ -125,7 +125,7 @@ Once StartOS 0.4.0 is available for your server, it is offered under **System �
 
 1. When the download completes, the System page shows **Update Complete. Restart to apply changes**. Restart your server through the StartOS UI.
 
-1. **Your server does not come back at its old address on this restart.** Wait a few minutes for it to reboot, then go to `http://start.local` — the same address the USB installer uses. The migration begins — continue with [Step 8](#step-8-wait-for-the-migration).
+1. **Your server does not immediately come back at its old address on this restart.** Wait a few minutes for it to reboot, then go to `http://start.local` — the same address the USB installer uses. The migration begins — continue with [Step 8](#step-8-wait-for-the-migration).
 
 {{#endtab}}
 {{#endtabs}}


### PR DESCRIPTION
In the interests of being perfectly correct, technically the `adjective-noun.local` does come back, but only after the **entirety** of the migration takes place (potentially hours) with no indication of progress while the user waits. If someone left and came back the next day, they'd be fine. But if they wanted to see if working, and provide logs if anything went wrong, it's better to have them sit on `start.local` to observe.
