### PR TITLE
fix(start-os): install the PureBoot ROM where firmware.rs reads it

### DIFF
--- a/.github/workflows/startos-iso.yaml
+++ b/.github/workflows/startos-iso.yaml
@@ -190,7 +190,7 @@ jobs:
           files="$(gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
             --jq '.[].filename')"
-          matched="$(printf '%s\n' "$files" | grep -E '^(build/|debian/|apt/|projects/start-os/build/|projects/start-os/debian/|projects/start-os/[^/]+\.(service|slice)$|\.github/workflows/startos-iso\.yaml$|\.github/actions/setup-build/)' || true)"
+          matched="$(printf '%s\n' "$files" | grep -E '^(build/|debian/|apt/|projects/start-os/build/|projects/start-os/build\.mk$|projects/start-os/debian/|projects/start-os/[^/]+\.(service|slice)$|\.github/workflows/startos-iso\.yaml$|\.github/actions/setup-build/)' || true)"
           if [ -n "$matched" ]; then
             echo "Image-affecting files changed:"; printf '  %s\n' "$matched"
             echo "image=true" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ secrets.db
 /dpkg-workdir
 /compiled.tar
 /compiled-*.tar
+/projects/start-os/build/firmware
 /projects/start-os/build/lib/firmware
 tmp
 /.i18n-checked

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -18,6 +18,10 @@ file tracks notable changes since the move to the monorepo.
   update now writes those paths in the plain form PureBoot expects, so the
   server boots into 0.4.0 on the restart that applies the update.
 
+- **A Server Pure applies its PureBoot firmware update.** StartOS installs the
+  firmware image at the path it reads it from, so a Server Pure on an older
+  PureBoot release updates its firmware on the next start.
+
 - **Installing onto a pre-installed Raspberry Pi keeps the data pool you pick.**
   Selecting the data pool by partition path now preserves that choice through
   installation.

--- a/projects/start-os/build.mk
+++ b/projects/start-os/build.mk
@@ -2,7 +2,7 @@
 # of .github/workflows/startos-iso.yaml (see root AGENTS.md "Coupled changes").
 
 IMAGE_TYPE=$(shell if [ "$(PLATFORM)" = raspberrypi ]; then echo img; else echo iso; fi)
-FIRMWARE_ROMS := projects/start-os/build/lib/firmware/$(PLATFORM) $(shell jq --raw-output '.[] | select(.platform[] | contains("$(PLATFORM)")) | "./projects/start-os/build/lib/firmware/$(PLATFORM)/" + .id + ".rom.gz"' projects/start-os/build/lib/firmware.json)
+FIRMWARE_ROMS := projects/start-os/build/firmware/$(PLATFORM) $(shell jq --raw-output '.[] | select(.platform[] | contains("$(PLATFORM)")) | "./projects/start-os/build/firmware/$(PLATFORM)/" + .id + ".rom.gz"' projects/start-os/build/lib/firmware.json)
 BUILD_SRC := $(call ls-files, projects/start-os/build/lib) build/lib/scripts/forward-port build/lib/scripts/forward-port6 projects/start-os/build/lib/depends projects/start-os/build/lib/conflicts $(FIRMWARE_ROMS) projects/start-os/build/lib/migration-images/.done
 IMAGE_RECIPE_SRC := $(call ls-files, projects/start-os/build/image-recipe/)
 STARTD_SRC := projects/start-os/startd.service projects/start-os/services.slice projects/start-os/startos-shutdown.service projects/start-os/startos-restart.service $(BUILD_SRC)
@@ -85,6 +85,7 @@ start-os-install: $(STARTOS_TARGETS)
 	$(call mkdir,$(DESTDIR)/usr/lib)
 	$(call rm,$(DESTDIR)/usr/lib/startos)
 	$(call cp,projects/start-os/build/lib,$(DESTDIR)/usr/lib/startos)
+	$(call cp,projects/start-os/build/firmware/$(PLATFORM),$(DESTDIR)/usr/lib/startos/firmware)
 	$(call cp,build/lib/scripts/forward-port,$(DESTDIR)/usr/lib/startos/scripts/forward-port)
 	$(call cp,build/lib/scripts/forward-port6,$(DESTDIR)/usr/lib/startos/scripts/forward-port6)
 	$(call mkdir,$(DESTDIR)/usr/lib/startos/container-runtime)
@@ -224,7 +225,7 @@ start-os-clean:
 	rm -rf projects/start-os/web/dist projects/start-os/docs/book
 	rm -rf projects/start-os/container-runtime/dist projects/start-os/container-runtime/node_modules
 	rm -f projects/start-os/container-runtime/*.squashfs
-	rm -rf projects/start-os/build/lib/firmware projects/start-os/build/lib/migration-images
+	rm -rf projects/start-os/build/firmware projects/start-os/build/lib/firmware projects/start-os/build/lib/migration-images
 	rm -rf projects/start-os/build/image-recipe/deb
 
 # The ui/setup-wizard web apps and the container-runtime are formatted by

--- a/projects/start-os/build/download-firmware.sh
+++ b/projects/start-os/build/download-firmware.sh
@@ -11,13 +11,13 @@ if [ -z "$PLATFORM" ]; then
 	exit 1
 fi
 
-rm -rf ./lib/firmware/$PLATFORM
-mkdir -p ./lib/firmware/$PLATFORM
+rm -rf ./firmware/$PLATFORM
+mkdir -p ./firmware/$PLATFORM
 
-cd ./lib/firmware/$PLATFORM
+cd ./firmware/$PLATFORM
 
 firmwares=()
-while IFS= read -r line; do firmwares+=("$line"); done < <(jq -c ".[] | select(.platform[] | contains(\"$PLATFORM\"))" ../../firmware.json)
+while IFS= read -r line; do firmwares+=("$line"); done < <(jq -c ".[] | select(.platform[] | contains(\"$PLATFORM\"))" ../../lib/firmware.json)
 for firmware in "${firmwares[@]}"; do
 	if [ -n "$firmware" ]; then
 		id=$(echo "$firmware" | jq --raw-output '.id')


### PR DESCRIPTION
Closes #3571.

`firmware.rs:125-127` reads `/usr/lib/startos/firmware/<id>.rom.gz`. `download-firmware.sh` downloaded into `projects/start-os/build/lib/firmware/$PLATFORM/`, and `build.mk` copies `build/lib` wholesale — so the ROM installed one directory deeper, at `firmware/x86_64/<id>.rom.gz`. 0.3.5.1 flattened it (`Makefile:140`); the flatten was dropped in 96ae53287 (#3085) when the download directory moved under `build/lib`.

`firmware.json` itself lands correctly (it sits directly in `build/lib`), so the DMI match still fires: a Server Pure serves an "updating firmware" phase on every boot, fails `sha256sum -c` on a file that isn't there, logs a warning and continues. `start-cli server update-firmware` is broken the same way.

## The fix

Download the ROMs to `projects/start-os/build/firmware/$PLATFORM/` instead of under `lib`. `lib` then holds only checked-in files, the wholesale copy stays untouched, and `start-os-install` copies exactly the platform's ROMs to the flat path `firmware.rs` reads — no `rm`, no fix-up copy. The download keeps its per-platform subdirectory so a tree that builds multiple platforms keeps both caches.

## Verification

Ran `download-firmware.sh` for real (sha256 check passes), then simulated `start-os-install` with `build/common.mk`'s exact macros in both flavors — local (`cp = cp -r $1 $2`) and REMOTE (the tar `--transform` pipeline):

| | result |
|---|---|
| unpatched | `firmware/x86_64/<id>.rom.gz` |
| this patch, both flavors | `firmware/<id>.rom.gz`, `firmware.json` untouched |
| this patch, platform with no matching ROM (raspberrypi) | installs an empty `firmware/`, as before |

`make -n start-os-install` resolves the new paths and fires the download rule as expected.

## Why the CI change rides along

`projects/start-os/build.mk` was not in the `changes`-job regex in `startos-iso.yaml` (`projects/start-os/build/` needs the trailing slash), so a PR touching only `build.mk` skips the entire image matrix — and `compile` can't cover this, since the patched lines are in `start-os-install`, reachable only through the deb. Root `AGENTS.md` requires the regex to mirror what feeds the image target. Side effect: any `build.mk` edit now triggers the full matrix.

## Read this before merging

**This re-arms an unattended whole-chip SPI write on first boot.**

- `start_init.rs:25` calls `check_for_firmware_update()` as the first statement of `setup_or_init`. On a match it flashes at `:48-49` with no dialog, no confirmation, no opt-out. The only consented path is `start-cli server update-firmware`.
- The write is `flashrom -p internal -w-` of a full 16 MiB image covering flash descriptor + ME + BIOS, no A/B slot; flashrom erases before writing. A power cut mid-write needs an external SPI programmer.
- Failure is swallowed — `start_init.rs:49-57` warns and boots normally, nothing reaches `init_ctx.error` or a notification. If the flash fails but the box still boots on the old version, it retries every boot. (It does reach the persistent journal: `debian/postinst:178` sets `Storage=persistent` and `init.rs:269-273` replays the init log.)
- The init UI is served during the flash, but the phase sits at 0% with no "do not power off" warning.
- Timing: this would ride 0.4.0.1, so for many Server Pures the first boot after the 0.3.5.1 → 0.4.x migration is also the flash boot.

Counterweight: **this is restored behavior, not new.** `v0.3.5.1:core/startos/src/bins/start_init.rs` has the byte-identical swallow-and-continue, on a release where the ROM was where the code read it. Blast radius is one SKU (`librem_mini_v2` + `PureBoot-Release-` `<29` + `x86_64`) and it fires once — after the flash the box reports `Release-29`, which fails `<29`. Today the feature is 100% dead.

Say the word if you'd rather have a consent gate land first; I'll hold this.

## Scope notes

- **Only Server Pures on the Slim `x86_64` image are reached.** The runtime gate is exact set membership (`firmware.platform.contains(&*PLATFORM)`, `platform` is a `BTreeSet`) against `["x86_64"]`, and the build-time jq `select(.platform[] | contains("$PLATFORM"))` selects nothing for `x86_64-nonfree` — so a Pure installed from the Standard ISO has no ROM in its image and no runtime match, silently. Pre-existing, and the documented install for a Pure is the Slim ISO (`update-040.md` before 66c33c6e4: "Server Pure — download the x86_64 (AMD64) Slim (FOSS-only) ISO"; `manage-release.sh:147` labels plain `x86_64` "AMD64-slim (FOSS-only)"). Closing that gap means adding `x86_64-nonfree` to `firmware.json` **and** switching both jq predicates to `any(.platform[]; contains($p))` — the current form emits the object once per matching element, which would duplicate the target in `build.mk` and make GNU Make warn on every build. Happy to do it as its own PR if you want Standard-image Pures covered.
- `migration-images` is still downloaded under `lib` (`save-migration-images.sh` → `build/lib/migration-images`) — same shape as the old firmware layout. Left alone here; say the word if you want it moved out of `lib` too.
