### PR TITLE
fix(core): start the tor service the 0.3.5.1 migration installs

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -36,6 +36,10 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **Updating from 0.3.5.1 starts the Tor service it installs.** Your existing
+  onion addresses come across with it and answer as soon as the update
+  finishes, with nothing to start by hand.
+
 - **The over-the-air update to 0.4.0 boots on the Server Pure.** The Server
   Pure's PureBoot firmware reads the boot configuration itself rather than
   running GRUB, and it takes the kernel and initramfs paths literally. The

--- a/projects/start-os/docs/src/update-040.md
+++ b/projects/start-os/docs/src/update-040.md
@@ -182,7 +182,7 @@ Depending on the speed of your drive, plan on 3-5 minutes per GB of backup data.
 
 ### Tor Cleanup
 
-During migration, the **Tor** service is automatically installed with all your existing onion addresses intact. However, Tor is rarely needed in StartOS 0.4.0 — most users will be better served by other networking options.
+During migration, the **Tor** service is automatically installed and started, with all your existing onion addresses intact and reachable as soon as the update finishes. However, Tor is rarely needed in StartOS 0.4.0 — most users will be better served by other networking options.
 
 You are encouraged to review your service interfaces and delete any Tor addresses you do not intend to use.
 

--- a/shared-libs/crates/start-core/src/version/v0_4_0_alpha_20.rs
+++ b/shared-libs/crates/start-core/src/version/v0_4_0_alpha_20.rs
@@ -285,11 +285,21 @@ impl VersionT for Version {
                     .await
                     .result?;
 
+                // The onion addresses it carries over only answer while tor runs.
+                crate::control::start(
+                    ctx.clone(),
+                    crate::control::StartParams {
+                        id: tor_id,
+                        force: false,
+                    },
+                )
+                .await?;
+
                 Ok::<_, Error>(())
             }
             .await
             {
-                tracing::error!("Error installing tor package: {e}");
+                tracing::error!("Error installing and starting tor package: {e}");
                 tracing::debug!("{e:?}");
             }
         }


### PR DESCRIPTION
The 0.4.0 migration (`v0_4_0_alpha_20::post_up`) sideloads the bundled tor s9pk and hands it the server's existing onion addresses via `onion-migration.json`. tor-startos imports them in `setupOnInit`, so they land in its torrc at install time — but a freshly installed package is written with `StatusInfo::default()`, i.e. `desired: Stopped`, and nothing in the install path ever flips it. The daemon that answers those addresses was never started, so every carried-over `.onion` stayed dark until the user found the Tor service and pressed Start.

This starts it, right after the registry URL is set:

```rust
crate::control::start(
    ctx.clone(),
    crate::control::StartParams { id: tor_id, force: false },
)
.await?;
```

### Why this shape

- **`control::start`, not a direct `statusInfo.desired` write.** It is the same call the Start button makes, and it keeps the critical-task guard (`control.rs:42-53`) that `Model<StatusInfo>::start()` skips — if tor's init ever declares a critical task, `Service::install` has just set `desired: Stopped` for that reason and we should not override it. tor-startos declares none today, so this is fail-safe, not inert.
- **No deadlock.** The `ServiceMap` entry write guard is taken inside await #1 and dropped inside await #3 (`service_map.rs:191`, `:408`); this runs after all three awaits, and `control::start` is a pure `db.mutate` that never touches `ServiceMap`.
- **It takes effect on this boot, not the next one.** There is no boot-time "start everything that was running" sweep — starting is reactive: each service's `ServiceActor` watches `/public/packageData/<id>/statusInfo` and turns `desired: Running` + `started: None` into a Starting transition (`service_actor.rs:104-114`). `cleanup_and_initialize` → `ServiceMap::init` runs *before* `version::post_init` (`context/rpc.rs:416`, `:419`), and the install itself creates the actor, so the write is picked up immediately. It also survives reboots: `statusInfo.init()` passes `Running` through untouched (`status/mod.rs:74-90`).
- **Fire-and-forget by design.** `post_up` is on the boot critical path; it returns once the desired state is committed rather than blocking boot on tor coming up. Failures surface in tor's own logs and `statusInfo.error`.
- The error message covers the added step, and a start refusal is swallowed and logged exactly like an install failure — it can't abort the migration.

### Interaction with `v0_4_0_beta_10::post_up`

Todos drain in ascending version order, so beta_10's post_up runs after this one and rewrites tor's hidden-service dir, torrc and `onion-migration.json` on disk — now potentially under a live daemon. It is a no-op on current master: since #3527, alpha_20 writes `start-os`/`admin` directly, so all three fixups find nothing to change, and the boxes those fixups were written for already drained the alpha.20 todo. Worth knowing before any future on-disk tor fixup is added to a later version.

### Open question — servers already on 0.4.0

This only reaches servers that have yet to run the alpha.20 migration. `start-os/v0.4.0` shipped on 2026-07-24; anyone who already took it has drained that todo, so their tor stays installed-and-stopped and this patch can never run for them.

Covering them needs a `post_up` on `v0_4_0_1::Version` — but nothing recorded in the DB distinguishes "stopped because the migration never started it" from "stopped because the user stopped it" (`update-040.md` actively tells people Tor is rarely needed in 0.4.0). I left that out rather than force-start tor for the second group. Happy to add it, or a notification instead — your call.

### Verification

- `cargo check -p start-core`, `cargo fmt --all --check`, `prettier --check` on the touched markdown: clean.
- `cargo test --features=test` in `start-core`: 546 + 52 passing, 0 failures.
- Not verified end to end: this needs a real 0.3.5.1 → 0.4.0.1 upgrade on hardware/VM with an OS image build. The check that matters there is that `/public/packageData/tor/statusInfo` ends with `desired: {"main":"running"}` **and** a non-null `started` (proof the actor actually drove the transition), and that a pre-existing `.onion` resolves afterward.
