### PR TITLE
fix(migration): report why a service failed to convert from 0.3.5.1

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -40,6 +40,20 @@ file tracks notable changes since the move to the monorepo.
   onion addresses come across with it and answer as soon as the update
   finishes, with nothing to start by hand.
 
+- **A service that fails to convert while migrating from 0.3.5.1 reports the
+  reason.** The v1→v2 package conversion raises a notification against that
+  service carrying the error that stopped it, in the same form as an install
+  failure — alongside the summary notification listing every service to
+  re-install.
+
+- **A service that is renamed during migration is recorded as migrated.** Ghost,
+  Synapse, Monero, Nostr and Fedimint are installed under new ids on 0.4.0
+  (`ghost-legacy`, `synapse-legacy`, `monerod-legacy`, `nostr-rs-relay` and
+  `fedimint-guardian`), and the migration looks each one up under the id it was
+  installed as. These services complete their migration without appearing among
+  the failures, and the failure list names services by ids that exist in the
+  marketplace.
+
 - **The over-the-air update to 0.4.0 boots on the Server Pure.** The Server
   Pure's PureBoot firmware reads the boot configuration itself rather than
   running GRUB, and it takes the kernel and initramfs paths literally. The

--- a/projects/start-os/docs/src/update-040.md
+++ b/projects/start-os/docs/src/update-040.md
@@ -180,6 +180,12 @@ Depending on the speed of your drive, plan on 3-5 minutes per GB of backup data.
 
 ## Post-Migration Notes
 
+### If a Service Fails to Migrate
+
+Check your notifications. A service that fails to migrate raises a notification naming the service and the reason it failed, and a summary notification lists everything that needs re-installing.
+
+Your data is safe — it stays on disk where the service left it. Install the service again from the marketplace and it will pick that data back up.
+
 ### Tor Cleanup
 
 During migration, the **Tor** service is automatically installed and started, with all your existing onion addresses intact and reachable as soon as the update finishes. However, Tor is rarely needed in StartOS 0.4.0 — most users will be better served by other networking options.

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -1996,6 +1996,13 @@ migration.migrating-package:
   fr_FR: "Migration du paquet %{package}..."
   pl_PL: "Migracja pakietu %{package}..."
 
+migration.service-failed-title:
+  en_US: "Migration Failed"
+  de_DE: "Migration fehlgeschlagen"
+  es_ES: "Migración fallida"
+  fr_FR: "Échec de la migration"
+  pl_PL: "Migracja nie powiodła się"
+
 migration.services-failed-title:
   en_US: "Services Failed To Migrate"
   de_DE: "Dienste konnten nicht migriert werden"

--- a/shared-libs/crates/start-core/src/version/v0_3_6_alpha_0.rs
+++ b/shared-libs/crates/start-core/src/version/v0_3_6_alpha_0.rs
@@ -436,7 +436,8 @@ impl VersionT for Version {
             }
         }
 
-        let mut failures = BTreeMap::new();
+        // title, plus the error when nothing else has reported it
+        let mut failures: BTreeMap<PackageId, (String, Option<String>)> = BTreeMap::new();
 
         // Should be the name of the package
         let current_package: std::sync::Arc<tokio::sync::watch::Sender<Option<PackageId>>> =
@@ -462,6 +463,7 @@ impl VersionT for Version {
             let Ok(id) = path.file_name().to_string_lossy().parse::<PackageId>() else {
                 continue;
             };
+            let new_id = migrated_id(&id)?;
             let path = path.path();
             if !path.is_dir() {
                 continue;
@@ -509,7 +511,7 @@ impl VersionT for Version {
                     // DB stores versions in emver format (e.g. `0.21.1.0`),
                     // but callers parse `.version` as `exver::ExtendedVersion`
                     // (e.g. `0.21.1:0`), so convert before writing — and also
-                    // apply the same package-specific flavor/prerelease/id
+                    // apply the same package-specific flavor/prerelease
                     // rewrites that the v1→v2 s9pk conversion in
                     // `s9pk::v2::compat` applies, so the on-disk version and
                     // volume path match what the install will look up.
@@ -542,17 +544,9 @@ impl VersionT for Version {
                             // The rename pass at the top of post_up has
                             // already moved the volume dirs to their new
                             // names, so we must write under the new id.
-                            let new_package_id: &str = match &*id {
-                                "nostr" => "nostr-rs-relay",
-                                "ghost" => "ghost-legacy",
-                                "synapse" => "synapse-legacy",
-                                "monerod" => "monerod-legacy",
-                                "fedimintd" => "fedimint-guardian",
-                                other => other,
-                            };
                             let version_path = Path::new(DATA_DIR)
                                 .join(PKG_VOLUME_DIR)
-                                .join(new_package_id)
+                                .join(&*new_id)
                                 .join("data")
                                 .join(".version");
                             write_file_atomic(&version_path, version.to_string().as_bytes())
@@ -560,15 +554,37 @@ impl VersionT for Version {
                         }
                     }
 
-                    if let Err(e) = async {
+                    let title = installed_manifest
+                        .and_then(|m| m.get("title"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(&new_id)
+                        .to_owned();
+
+                    // `install` raises its own per-package notification, but only
+                    // once its reload guard is armed — the v1→v2 conversion ahead
+                    // of that, and this bookkeeping after it, report themselves.
+                    let converted = async {
                         let package_s9pk = tokio::fs::File::open(path).await?;
                         let file = MultiCursorFile::open(&package_s9pk).await?;
-
                         let key = ctx.db.peek().await.into_private().into_developer_key();
+                        crate::s9pk::load(file, || Ok(key.de()?.0), None).await
+                    }
+                    .await;
+                    let s9pk = match converted {
+                        Ok(s9pk) => s9pk,
+                        Err(e) => {
+                            tracing::error!("Error converting {id}: {e}");
+                            tracing::debug!("{e:?}");
+                            failures.insert(new_id.clone(), (title, Some(e.to_string())));
+                            continue;
+                        }
+                    };
+
+                    if let Err(e) = async {
                         ctx.services
                             .install(
                                 ctx.clone(),
-                                || crate::s9pk::load(file.clone(), || Ok(key.de()?.0), None),
+                                move || async move { Ok(s9pk) },
                                 None,
                                 None::<crate::util::Never>,
                                 None,
@@ -576,39 +592,42 @@ impl VersionT for Version {
                             .await?
                             .await?
                             .await?;
-
-                        ctx.db
-                            .mutate(|db| {
-                                let package = db
-                                    .as_public_mut()
-                                    .as_package_data_mut()
-                                    .as_idx_mut(&id)
-                                    .or_not_found(&id)?;
-                                if configured {
-                                    package
-                                        .as_tasks_mut()
-                                        .remove(&ReplayId::from("needs-config"))?;
-                                }
-                                Ok(())
-                            })
-                            .await
-                            .result?;
-
                         Ok::<_, Error>(())
                     }
                     .await
                     {
-                        failures.insert(
-                            id.clone(),
-                            input
-                                .get(&*id)
-                                .and_then(|pde| pde.get("installed"))
-                                .and_then(|i| i.get("manifest"))
-                                .and_then(|m| m.get("title"))
-                                .and_then(|v| v.as_str()),
-                        );
                         tracing::error!("Error reinstalling {id}: {e}");
                         tracing::debug!("{e:?}");
+                        failures.insert(new_id.clone(), (title, None));
+                        continue;
+                    }
+
+                    match ctx
+                        .db
+                        .mutate(|db| {
+                            let package = db
+                                .as_public_mut()
+                                .as_package_data_mut()
+                                .as_idx_mut(&new_id)
+                                .or_not_found(&new_id)?;
+                            if configured {
+                                package
+                                    .as_tasks_mut()
+                                    .remove(&ReplayId::from("needs-config"))?;
+                            }
+                            Ok(())
+                        })
+                        .await
+                        .result
+                    {
+                        Ok(()) => {
+                            failures.remove(&new_id);
+                        }
+                        Err(e) => {
+                            tracing::error!("Error recording {new_id} as migrated: {e}");
+                            tracing::debug!("{e:?}");
+                            failures.insert(new_id.clone(), (title, Some(e.to_string())));
+                        }
                     }
                 }
             }
@@ -617,10 +636,20 @@ impl VersionT for Version {
         if !failures.is_empty() {
             ctx.db
                 .mutate(|db| {
-                    let services = failures
+                    for (id, error) in failures
                         .iter()
-                        .map(|(id, title)| title.as_ref().copied().unwrap_or(id))
-                        .join(", ");
+                        .filter_map(|(id, (_, error))| Some((id, error.as_ref()?)))
+                    {
+                        notify(
+                            db,
+                            Some(id.clone()),
+                            NotificationLevel::Error,
+                            t!("migration.service-failed-title").to_string(),
+                            error.clone(),
+                            (),
+                        )?;
+                    }
+                    let services = failures.values().map(|(title, _)| title).join(", ");
                     notify(
                         db,
                         None,
@@ -637,6 +666,20 @@ impl VersionT for Version {
         progress_logger.abort();
         Ok(())
     }
+}
+
+/// Mirrors the id rewrites `s9pk::v2::compat` applies during the v1→v2
+/// conversion — the installed package lands under the new id, not the one the
+/// 0.3.5.1 archive directory is named after.
+fn migrated_id(id: &PackageId) -> Result<PackageId, Error> {
+    Ok(match &**id {
+        "nostr" => "nostr-rs-relay".parse()?,
+        "ghost" => "ghost-legacy".parse()?,
+        "synapse" => "synapse-legacy".parse()?,
+        "monerod" => "monerod-legacy".parse()?,
+        "fedimintd" => "fedimint-guardian".parse()?,
+        _ => id.clone(),
+    })
 }
 
 #[tracing::instrument(skip_all)]


### PR DESCRIPTION
The 0.3.5.1 → 0.4.0 migration collected every per-package failure into one
aggregate notification listing service names, and threw the error itself away to
the logs (`tracing::error!("Error reinstalling {id}: {e}")`).

## Why the install machinery didn't already cover it

`ServiceMap::install` does emit a per-package failure notification, but only
through `ServiceRefReloadCancelGuard`, which is not constructed until
`service_map.rs:209`. `notify(` appears exactly once in that file (`:584`, inside
`ServiceRefReloadInfo::reload`), reachable only via `handle`/`handle_last`/`Drop`
— so the whole prologue is silent by construction.

Of the 25 error-return points in `install` (lines 150–418), 5 are unguarded, all
in that prologue: `:167` `s9pk().await?`, `:169` `validate_and_filter`, `:171`
`commitment()`, `:180-188` the reserved-id return, `:189` `icon_data_url()`. For
the migration, `:167` **is** the docker-driven v1→v2 s9pk conversion — the step
most likely to fail — so the most common migration failure reported nothing.

Two more silent steps sit outside `install` entirely: the `File::open` /
`MultiCursorFile::open` ahead of it, and the post-install `db.mutate` after it
(`handle_last` disarms the guard on success, so nothing covers that one).

## What this changes

Hoist the s9pk load out of the closure passed to `install` and notify against the
package when the conversion fails, matching the shape of an install failure:
`package_id: Some(id)`, localized title, the error as the body, subtype `()`. The
post-install bookkeeping mutate reports itself the same way.

Failures *inside* `install` deliberately do **not** get a notification from here —
they already raise their own "Installing Failed" — so nothing is duplicated. The
`failures` map carries the error only when nothing else has reported it; the
aggregate summary still lists every failure either way.

Deliberately **out of scope** (agreed on-thread): `install`'s remaining prologue
holes (`validate_and_filter` / `commitment()` / `icon_data_url()`). Covering those
means wrapping them in `reload_guard.handle(...)` — merely arming the guard
earlier is not enough, because `Drop` passes `None` and `reload` only notifies on
`Some(error)`. It also changes failed-*update* behaviour: with a packageData entry
present, `load(…, Undo)` takes the `Installed` arm and bounces the running
service. That belongs in its own change.

## Renamed packages were always reported as failed

`s9pk::v2::compat` rewrites five ids during the conversion (`nostr` →
`nostr-rs-relay`, `ghost`/`synapse`/`monerod` → `*-legacy`, `fedimintd` →
`fedimint-guardian`), and `install` inserts into `packageData` under
`manifest.id`. The post-install lookup used the old archive-directory id, and
`up()` resets `packageData` to `{}` — so `or_not_found` always missed and those
five landed in `failures` even when they migrated fine, telling users to
re-install them under ids the marketplace no longer has. The rename map already
existed inline a few lines above for the `.version` write; it is now a shared
helper used by both.

Also: clear a package from `failures` once it succeeds. The archive is walked per
version directory with no dedup by id, so a package with a stale version dir
alongside the current one can be installed twice and would otherwise stay marked
failed after a later attempt worked.

## Verification

`cargo check -p start-core`, `make start-core-format-check`, and prettier over the
changed markdown all pass. The notification path itself is not exercised by any
existing test and I have not run a 0.3.5.1 → 0.4.0 migration on a VM, so the
runtime behaviour is reasoned from the source, not observed.
