### PR TITLE
fix(image-recipe): bump NVIDIA driver to 580.173.02 for kernel 7.1 and pin the module flavour

### DIFF
--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -256,7 +256,7 @@ if [ "${NVIDIA}" = "1" ]; then
     # install a specific NVIDIA driver version
 
     # ---------------- configuration ----------------
-    NVIDIA_DRIVER_VERSION="\${NVIDIA_DRIVER_VERSION:-580.159.03}"
+    NVIDIA_DRIVER_VERSION="\${NVIDIA_DRIVER_VERSION:-580.173.02}"
 
     BASE_URL="https://download.nvidia.com/XFree86/Linux-${QEMU_ARCH}"
 

--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -306,8 +306,10 @@ if [ "${NVIDIA}" = "1" ]; then
 
     echo "[nvidia-hook] Running NVIDIA installer for kernel \${KVER}" >&2
 
+    # Otherwise the installer picks the flavour from the build host's own GPUs.
     if ! sh "\${RUN_PATH}" \
         --silent \
+        --kernel-module-type=proprietary \
         --kernel-name="\${KVER}" \
         --no-x-check \
         --no-nouveau-check \


### PR DESCRIPTION
Unbreaks `Build Image (x86_64-nvidia)` and `Build Image (aarch64-nvidia)`, both failing since this morning ([run 30212752866](https://github.com/Start9Labs/start-technologies/actions/runs/30212752866)). Two commits: the driver bump that unbreaks CI, and an explicit module-flavour pin that locks in the behaviour we already ship.

## 1. What broke

Nothing in this repo. `build.sh` pins `linux-image-*`/`linux-headers-*` to the trixie-backports *release*, not a version, so the chroot kernel floats:

| | run | time (UTC) | kernel | driver |
|---|---|---|---|---|
| last good | [30182652588](https://github.com/Start9Labs/start-technologies/actions/runs/30182652588) `feac0516` | 2026-07-26 01:57 | `7.0.13+deb13-amd64` | 580.159.03 |
| first bad | [30208735770](https://github.com/Start9Labs/start-technologies/actions/runs/30208735770) `4001e68b` | 2026-07-26 16:13 | `7.1.3+deb13-amd64` | 580.159.03 |

`git diff feac0516..4001e68b -- projects/start-os/build .github/workflows build` is empty. Signed `linux-image-7.1.3+deb13-{amd64,arm64}` entered the archive at 2026-07-26T08:27:15Z, inside that gap — the kernel is the only variable.

Linux 7.1 deleted `include/linux/of_gpio.h` (`b6420bd5aa0c`, "gpio: remove of_get_named_gpio() and \<linux/of_gpio.h\>"; present at `v7.0`, absent at `v7.1`). 580.159.03's `kernel/common/inc/nv-linux.h:1747` includes it unconditionally, so every object file dies at preprocessing. Confirmed on disk: `linux-headers-7.1.3+deb13-common` has no `of_gpio.h`, while 7.0.13, 6.19.14 and trixie's own 6.12.94 all ship it.

Same failure class as #3226 (6.x → 7.0, May).

## 2. Why 580.173.02

580.173.02 guards the include behind `NV_LINUX_OF_GPIO_H_PRESENT` and provides an `of_get_named_gpio()` compat implementation on the `#else` path. Lowest version that fixes this and stays on the 580 branch.

Verified locally against the real CI kernel headers (`linux-headers-7.1.3+deb13-{common,amd64}` `7.1.3-1~bpo13+1`, host gcc 14.2.0-19 = the kernel's own `CONFIG_CC_VERSION_TEXT`):

- 580.159.03 → 24 × `nv-linux.h:1747:10: fatal error: linux/of_gpio.h: No such file or directory`, 0 modules, exit 2 — matches CI verbatim.
- 580.173.02 → 0 such errors, exit 0, all five modules built (`nvidia.ko`, `nvidia-uvm.ko`, `nvidia-modeset.ko`, `nvidia-drm.ko`, `nvidia-peermem.ko`). This was the `kernel/` (proprietary) tree, i.e. exactly what the pin below selects.

No GPU support change: both payloads' `supported-gpus.json` list an identical 2312 chips (0 dropped, 0 added). Both versions are published for `Linux-x86_64` and `Linux-aarch64`.

Caveats: built amd64 only (CI also builds arm64), and with `CONFIG_DEBUG_INFO_BTF_MODULES=` since module BTF needs the installed kernel image, which a headers-only host lacks — that step runs after all compilation and works in the CI chroot.

## 3. Why pin the module flavour

`nvidia-installer` chooses proprietary vs. open from the GPUs attached to the machine running it, so the flavour baked into the ISO is a property of the runner, not of the recipe. Verified on a GPU-less host: `nvidia-installer --print-recommended-kernel-module-type` prints `proprietary`, and both failing CI logs build in `.../NVIDIA-Linux-<arch>-580.159.03/kernel` with zero `kernel-open` references.

So every image we have ever shipped carries proprietary modules. `--kernel-module-type=proprietary` makes that explicit and stops a runner that happens to expose a Turing-or-later GPU from silently producing an image that drops Maxwell, Pascal and Volta — 303 device IDs / 142 product names in this driver, including Tesla P40, P100, P4, M40 and V100.

Note NVIDIA's README §45D describes the default as "if a pre-Turing GPU is detected → proprietary, otherwise → open", which reads as though a GPU-less builder would get open. The binary disagrees with the prose; the measurement above is what the recipe actually does.

## 4. Not addressed here

- The kernel still floats, so this re-arms on the next backports upload. Backports currently carries 21 ABIs from 6.16.3 to 7.0.13, so a version pin is available if we want the pair to move deliberately.
- `linux-kbuild-$KBUILD_VER` is built from `grep -oP '^\d+\.\d+'` → `linux-kbuild-7.1`, which is not a package (the real one is `linux-kbuild-7.1.3+deb13`). It installs only because apt falls back to POSIX-regex matching, where `.` matches any character.
