### PR TITLE
docs(start-sdk): document outbound network access and the container DNS rule

### DIFF
--- a/projects/start-sdk/docs/src/SUMMARY.md
+++ b/projects/start-sdk/docs/src/SUMMARY.md
@@ -88,6 +88,7 @@
 - [Initialization](init.md)
 - [Interfaces](interfaces.md)
 - [Service-to-Service Networking](service-to-service.md)
+- [Outbound Network Access](outbound-networking.md)
 - [Actions](actions.md)
 - [Tasks](tasks.md)
 - [Notifications](notifications.md)

--- a/projects/start-sdk/docs/src/outbound-networking.md
+++ b/projects/start-sdk/docs/src/outbound-networking.md
@@ -1,0 +1,43 @@
+# Outbound Network Access
+
+[Interfaces](interfaces.md) covers traffic **inbound** to your service. [Service-to-Service Networking](service-to-service.md) covers reaching **another package**. This page covers the third direction: your service reaching the **internet**.
+
+Outbound connections work by default. A service container can open a TCP or UDP connection to any external host — an upstream API, a package registry, a block explorer, an SMTP relay — with no manifest flag and no SDK call.
+
+Three things are blocked, and one of them is the reason most packages that "can't reach the internet" actually fail.
+
+## DNS must go through the container's own resolver
+
+Every service container ships an `/etc/resolv.conf` containing exactly:
+
+```
+nameserver 10.0.3.1
+```
+
+That is the OS itself, on the bridge gateway, running a recursive resolver on UDP and TCP port 53. It answers `.startos` and private names locally and forwards everything else to whatever upstream resolvers the box is configured with, preserving the query type — so `TXT`, `SRV` and `MX` lookups all work.
+
+Use it. Any library that reads `/etc/resolv.conf` — `getaddrinfo`, Go's resolver, `httpx`, `requests`, `reqwest`, Node's `dns` — is already correct and needs no configuration.
+
+> [!IMPORTANT]
+> A DNS query sent from a container **straight at a public resolver or the LAN gateway** — `1.1.1.1:53`, `8.8.8.8:53`, `192.168.1.1:53` — is dropped. Not rejected: dropped. The caller sees no error, only a timeout, once per configured nameserver.
+
+This bites when an upstream application hardcodes a resolver rather than reading the system one. The tell is distinctive: HTTPS to the same domain works fine, but a direct DNS lookup hangs for the client's full timeout and then reports a timeout rather than `NXDOMAIN` or "no nameservers". If a service resolves nothing while its other network calls succeed, check for a hardcoded nameserver list before anything else.
+
+The fix belongs in the application: drop the override and let the resolver library read `/etc/resolv.conf`. If the upstream needs to keep a configurable nameserver for other platforms, have it default to the system resolver and treat an explicit list as an opt-in override — that is correct on StartOS and on every other runtime.
+
+Verify inside a running container with:
+
+```
+start-cli package attach <id> -- cat /etc/resolv.conf
+```
+
+> [!NOTE]
+> The OS resolver forwards queries but does not currently pass DNSSEC records through — responses carry no `RRSIG` and no `AD` flag. A package that must validate DNSSEC itself (BIP 353 payment instructions, for example) cannot do so through it today.
+
+## Port mapping is reserved to the OS
+
+NAT-PMP/PCP (`udp/5351`) and UPnP SSDP (`udp/1900`) are dropped from containers. Only StartOS may open ports on the user's router, and it does so on the user's behalf when they enable clearnet access for an interface. A package must never try to map its own port — declare the binding in [interfaces.ts](interfaces.md) and let the OS decide how it is reached.
+
+## Don't assume how you are reached
+
+Outbound access says nothing about inbound. Whether your service has a Tor address, a clearnet domain, or LAN only is the user's choice at runtime, and your package cannot know it — see the note in [Interfaces](interfaces.md). If the service needs to know its own public URL, use [Set a Primary URL](recipe-primary-url.md).

--- a/projects/start-sdk/docs/src/service-to-service.md
+++ b/projects/start-sdk/docs/src/service-to-service.md
@@ -1,6 +1,6 @@
 # Service-to-Service Networking
 
-[Interfaces](interfaces.md) covers how your service exposes ports **inbound**. This page covers the reverse: how your service reaches **another** service at runtime — a wallet dialing Bitcoin's RPC, an indexer dialing Bitcoin's P2P port, anything dialing Tor's SOCKS proxy.
+[Interfaces](interfaces.md) covers how your service exposes ports **inbound**. This page covers the reverse: how your service reaches **another** service at runtime — a wallet dialing Bitcoin's RPC, an indexer dialing Bitcoin's P2P port, anything dialing Tor's SOCKS proxy. For reaching the internet rather than a sibling package, see [Outbound Network Access](outbound-networking.md).
 
 There is exactly one supported way to do this, and three once-common patterns that are now forbidden.
 


### PR DESCRIPTION
## What

Adds a packaging-docs reference page, **Outbound Network Access**, covering what a service container may and may not send outbound.

The load-bearing part is DNS. Since #3418 the egress guard drops tcp/udp `53` forwarded off `lxcbr0`:

```
add rule inet startos_egress_guard forward iifname "lxcbr0" meta l4proto { tcp, udp } th dport 53 drop
```

That is correct and intentional, but until now it was written down only in the `.nft` file's own comment and one line of the 0.4.0 changelog. `grep -rniE 'resolv\.conf|nameserver|10\.0\.3\.1:53' projects/start-sdk/docs/src/` returned nothing — a package author had no way to learn the rule from the packaging guide.

## Why now

Start9-Community/bolt12-pay-startos#32. The upstream app sets `resolver.nameservers = ["1.1.1.1", "8.8.8.8"]` and speaks plain UDP/53 to them. On 0.4.0 those packets are dropped, so every BIP353 and Lightning Address lookup fails with a ~10s hang and a 504 "DNS lookup timed out" — while HTTPS to the same domain keeps working, which sends you looking in the wrong place. The package author reasonably concluded StartOS had broken his app.

The page names that exact symptom (resolution fails, other network calls succeed → look for a hardcoded nameserver list) so the next person greps and lands on it.

## Verified on released 0.4.0

Fresh install from `startos-0.4.0-514af0c_x86_64.iso`, from inside a real service container:

```
# nslookup alex71btc.com                 -> resolves via 10.0.3.1
# nslookup alex71btc.com 1.1.1.1         -> ;; connection timed out; no servers could be reached
# nslookup -type=TXT phoenix.user._bitcoin-payment.alex71btc.com
                                         -> "bitcoin:?lno=lno1zrxq8pjw..."
# cat /etc/resolv.conf                   -> nameserver 10.0.3.1
```

Also confirms the DNSSEC note in the page — same name, same box:

| resolver | flags | RRSIG |
| --- | --- | --- |
| `10.0.3.1` | `qr rd ra` | absent |
| `1.1.1.1` | `qr rd ra ad` | present |

`./build.sh` in `projects/start-docs/` is clean (mdBook validates intra-book links).

## Two things this PR deliberately does not do

Raising them here rather than acting unilaterally, since both are net behaviour:

1. **`drop` vs `reject` vs redirect.** A terminal drop gives the caller a silent timeout and no diagnostic. A `reject` would fail fast and legibly; a DNAT of container→`:53` to `10.0.3.1:53` would preserve the security intent while fixing every app that hardcodes a resolver, present and future. Hardcoded public resolvers are common in upstream software, so bolt12-pay is unlikely to be the last.
2. **DNSSEC pass-through.** The forwarder strips `RRSIG` and never sets `AD`, so a package that must validate DNSSEC itself cannot. BIP 353 requires exactly that of payment-instruction lookups, so no compliant implementation can run on StartOS today. Documented as a limitation here; happy to open an issue if it's worth tracking.
