### PR TITLE
fix(update): create and heal current.rootfs across migration, boot, and prune

### DIFF
--- a/projects/start-os/build/lib/scripts/prune-images
+++ b/projects/start-os/build/lib/scripts/prune-images
@@ -32,6 +32,16 @@ fi
 MARGIN=${MARGIN:-1073741824}
 target=$((needed + MARGIN))
 
+# A missing pointer means the box booted the newest image via the initramfs
+# fallback (0.4.0's migration never created one), so relinking it is safe.
+if ! [ -h /media/startos/config/current.rootfs ] || ! [ -e /media/startos/config/current.rootfs ]; then
+    newest="$(ls -t1 /media/startos/images/*.rootfs 2> /dev/null | head -n1)"
+    if [ -f "$newest" ]; then
+        echo "Recreating missing current.rootfs -> $newest"
+        ln -rsf "$newest" /media/startos/config/current.rootfs
+    fi
+fi
+
 if [ -h /media/startos/config/current.rootfs ] && [ -e /media/startos/config/current.rootfs ]; then
     echo 'Pruning...'
     current="$(readlink -f /media/startos/config/current.rootfs)"

--- a/projects/start-os/build/lib/scripts/startos-initramfs-module
+++ b/projects/start-os/build/lib/scripts/startos-initramfs-module
@@ -47,6 +47,11 @@ local_mount_root()
 			image=$(readlink -f /startos/config/current.rootfs)
 		else
 			image="$(ls -t1 /startos/images/*.rootfs | head -n1)"
+			# Repair the pointer for boxes whose 0.4.0 migration never created it
+			if [ -f "$image" ]; then
+				mkdir -p /startos/config
+				ln -sf "../images/$(basename "$image")" /startos/config/current.rootfs
+			fi
 		fi
 		if ! [ -f "$image" ]; then
 			>&2 echo "image $image not available to boot"
@@ -83,7 +88,8 @@ local_mount_root()
 			>&2 echo 'migration payload missing 0.4.0 base image'
 			exit 1
 		fi
-		ln -rsf "$image" /startos/config/current.rootfs
+		# busybox ln has no -r; write the relative target explicitly
+		ln -sf "../images/$(basename "$image")" /startos/config/current.rootfs
 
 		rm -rf /startos/next /startos/current /startos/prev /startos/config/upgrade
 	fi


### PR DESCRIPTION
## Root cause

The 0.4.0 initramfs's 0.3.5.1→0.4.0 migration created `config/current.rootfs` with `ln -rsf`, but the initramfs's `ln` is **BusyBox, which has no `-r` flag** (verified against the shipped `initrd.img-7.0.13+deb13-amd64`: BusyBox 1.37.0, `ln: invalid option -- 'r'`). The failure is non-fatal (`/init` has no `set -e`), so:

1. every over-the-air 0.3.5.1→0.4.0 migration boots **without** `current.rootfs` (the boot silently falls back to the newest `images/*.rootfs`, which never recreates the pointer), and
2. every subsequent OTA update dies at its first step — `prune-images` refuses to run without a valid pointer ("No current.rootfs, not safe to prune").

Fresh installs and USB flash updates are unaffected (`build.sh` and `os_install` create the symlink with full coreutils).

## Fix (three layers)

- **Migration** writes the relative symlink target explicitly (`ln -sf "../images/$(basename …)"`) — BusyBox-compatible.
- **Boot fallback** recreates the pointer when missing or dangling, so any box that boots a fixed initramfs self-heals.
- **`prune-images`** rebuilds a missing/dangling pointer from the newest installed image instead of hard-failing — safe because a missing pointer means the box booted that image via the fallback. It still refuses when no image exists at all.

## No version bump — this builds the replacement 0.4.0.1 migration image

Deliberately carries **no version bump or changelog entry**: a build from this branch produces a **0.4.0.1-labeled** migration payload that replaces the live 0.3.5.1→0.4.0.1 OTA image 1:1 (`deploy-migration-payload.sh --replace`). The changelog entry and version bump ride the next release.

## Already-affected servers: handled via support

A box that already migrated OTA to 0.4.0 **cannot reach this fix by updating** (the failing `prune-images` runs from the installed 0.4.0 rootfs before any downloaded code executes). Support playbook: one SSH command —

```sh
ln -rsf "$(ls -t1 /media/startos/images/*.rootfs | head -n1)" /media/startos/config/current.rootfs
```

— or reinstall from a current installer with **Preserve**.

## Testing

- Migration symlink creation simulated under the actual BusyBox 1.37.0 binary extracted from the shipped 0.4.0 initramfs — symlink created, resolves, `-h && -e` pass.
- `prune-images` heal exercised with paths redirected: missing pointer → recreated and prune proceeds; dangling pointer → recreated; empty `images/` → still fails safe with the original error.
- `bash -n` clean; shellcheck shows no new warnings.
- Not run: full OS image build / end-to-end migration on hardware (needs the image pipeline — the dispatched build produces the deployable payloads).