### PR TITLE
fix(start-sdk): report which daemon failed, and why, when runUntilSuccess times out

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -4,10 +4,38 @@
 
 ### Fixed
 
+- **A `runUntilSuccess` timeout now says which daemon failed and why.** It
+  reported a bare list of ids, which cannot distinguish a daemon that is slow to
+  start from one that is crash-looping, and leaked the internal sentinel
+  daemon's id as if it were a component — a package whose Postgres died on every
+  start reported only this, after burning its full thirty-minute budget:
+
+  ```
+  Timed out waiting for postgres,upgrade,__RUN_UNTIL_SUCCESS
+  ```
+
+  The message now carries each un-ready daemon's health result and message, the
+  count and cause of any abnormal exits, and the budget that elapsed:
+
+  ```
+  Timed out after 1800000ms waiting for postgres (loading; 47 failed exit(s), last: docker-entrypoint.sh exited with code 1), upgrade (waiting; postgres)
+  ```
+
+  The sentinel is excluded — it depends on every other daemon, so it is never
+  ready when anything else isn't. A crash-looping daemon's exit error was
+  previously swallowed by the restart loop, so this is the only place it reaches
+  the caller: `Daemon` now retains it as `lastExitError` alongside a
+  `failedExits` count, and `HealthDaemon` appends the cause to its
+  `<id> daemon crashed` health message. Reporting the exit count next to the
+  current health matters because they disagree in exactly the case that hurts —
+  a `ready` check that returns `loading` on a failed probe keeps overwriting the
+  crash back to `loading` between restarts
+
 - **Package template cleanup.** Dropped the `alerts` manifest block, removed in
   2.0.0, that the template still scaffolded, and the `hello-world` guard job
   from `release.yml` / `tagAndRelease.yml`. Its workflows are now identical to
   a real package's
+
 - **`make install` no longer announces "Initializing StartOS developer
   environment…" on every run.** `check-init` guarded on
   `~/.startos/developer.key.pem`, which start-cli 1.1.0 renamed to

--- a/projects/start-sdk/docs/src/init.md
+++ b/projects/start-sdk/docs/src/init.md
@@ -250,6 +250,21 @@ await sdk.Daemons.of(effects)
 3. When the oneshot completes successfully, `runUntilSuccess` returns
 4. All processes are cleaned up automatically
 
+### When it times out
+
+If the timeout elapses before everything is ready, `runUntilSuccess` throws, which fails init: StartOS restores the package's volumes from the backup it took beforehand, then reverts an update to the previous version or removes a failed install. The error names every daemon that never became ready, with its current health result and message, and — for one whose process kept dying — how many times it exited and the error from the last exit:
+
+```
+Timed out after 120000ms waiting for server (loading; 12 failed exit(s), last: node exited with code 1), bootstrap (waiting)
+```
+
+Read it as: `server` never came up, and its process has been crash-looping rather than merely starting slowly; `bootstrap` never ran, because `waiting` means its `requires` are not all ready — here, `server`. A daemon reported as `loading` or `starting` with **no** failed exits is running but not passing its ready check — look at the check, not the process.
+
+A `waiting` daemon's message lists the `display` names of the dependencies still holding it up, which is why there is none above: the chain declares `display: null` on `server`. Give a daemon a `display` and its dependents name it.
+
+> [!TIP]
+> A `ready` function that returns `loading` on a failed probe (rather than `failure`) makes a dead process look identical to a slow one in the UI. The exit count above is what distinguishes them, but the daemon's own logs are still the place to find out why it died — a daemon's stdout and stderr go to the service logs.
+
 ### Making HTTP Calls Without curl
 
 Many slim Docker images do not have curl. Use the runtime's built-in HTTP capabilities instead.

--- a/projects/start-sdk/lib/mainFn/Daemon.ts
+++ b/projects/start-sdk/lib/mainFn/Daemon.ts
@@ -33,7 +33,9 @@ export class Daemon<
   private onExitFns: ((success: boolean) => void)[] = []
   private loop: { abort: AbortController; done: Promise<void> } | null = null
   private releaseSubcontainerHold: (() => Promise<void>) | null = null
-  private _detached = false
+  private detached = false
+  private _lastExitError: Error | null = null
+  private _failedExits = 0
   protected constructor(
     readonly subcontainer: C,
     private startCommand: () => Promise<CommandController<Manifest, C>>,
@@ -49,6 +51,24 @@ export class Daemon<
   /** Returns true if this daemon is a one-shot process (exits after success) */
   isOneshot(): this is Oneshot<Manifest> {
     return this.oneshot
+  }
+  /**
+   * The error from the most recent abnormal exit, or `null` if none has been
+   * recorded. An exit driven by {@link stop} or {@link term} is deliberate and
+   * does not set this; the restart loop otherwise logs the error and retries,
+   * retaining it here rather than reporting it to anyone.
+   */
+  get lastExitError(): Error | null {
+    return this._lastExitError
+  }
+  /**
+   * How many times the process has exited abnormally over this daemon's
+   * lifetime. Nothing resets it — neither a restart nor a
+   * {@link stop}/{@link start} cycle — so a non-zero count means the process
+   * has died at least once, not that it is dying now.
+   */
+  get failedExits(): number {
+    return this._failedExits
   }
   /**
    * Factory method to create a new Daemon.
@@ -69,7 +89,7 @@ export class Daemon<
         CommandController.of<Manifest, C>()(effects, subcontainer, exec)
       const res = new Daemon<Manifest, C>(subcontainer, startCommand)
       effects.onLeaveContext(() => {
-        if (res._detached) return
+        if (res.detached) return
         res.term().catch(e => logErrorOnce(asError(e)))
       })
       return res
@@ -93,7 +113,7 @@ export class Daemon<
    * Idempotent.
    */
   detach(): void {
-    this._detached = true
+    this.detached = true
   }
   /**
    * Start the daemon. If it is already running, this is a no-op.
@@ -133,7 +153,11 @@ export class Daemon<
           const success = await this.commandController.wait().then(
             _ => true,
             err => {
-              if (!signal.aborted) logErrorOnce(err)
+              if (!signal.aborted) {
+                logErrorOnce(err)
+                this._lastExitError = asError(err)
+                this._failedExits += 1
+              }
               return false
             },
           )

--- a/projects/start-sdk/lib/mainFn/Daemons.ts
+++ b/projects/start-sdk/lib/mainFn/Daemons.ts
@@ -29,6 +29,14 @@ export const cpExec = promisify(CP.exec)
 export const cpExecFile = promisify(CP.execFile)
 
 /**
+ * Id of the sentinel {@link Daemons.runUntilSuccess} appends to the chain: a
+ * oneshot depending on every user daemon, so it completes exactly when all of
+ * them are ready. Not a component of the service — it publishes no health, and
+ * the timeout message leaves it out.
+ */
+const RUN_UNTIL_SUCCESS_ID = '__RUN_UNTIL_SUCCESS'
+
+/**
  * Configuration for a daemon's health-check readiness probe.
  *
  * Every daemon and standalone health check requires a `Ready` configuration
@@ -614,15 +622,19 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    */
   async runUntilSuccess(timeout: number | null) {
     let resolve = (_: void) => {}
+    let timer: ReturnType<typeof setTimeout> | undefined
     const res = new Promise<void>((res, rej) => {
       resolve = res
       if (timeout) {
-        setTimeout(() => {
-          const notReady = (this.builtHealthDaemons ?? [])
-            .filter(d => !d.isReady)
-            .map(d => d.id)
-          rej(new Error(`Timed out waiting for ${notReady}`))
-        }, timeout)
+        timer = setTimeout(
+          () =>
+            rej(
+              new Error(
+                `Timed out after ${timeout}ms waiting for ${this.describeNotReady()}`,
+              ),
+            ),
+          timeout,
+        )
       }
     })
     // Build the user's chain through the normal path so onLeaveContext +
@@ -638,7 +650,7 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
     const sentinelHd = new HealthDaemon<Manifest>(
       sentinelDaemon,
       [...(this.builtHealthDaemons ?? [])],
-      '__RUN_UNTIL_SUCCESS',
+      RUN_UNTIL_SUCCESS_ID,
       EXIT_SUCCESS,
       this.effects,
     )
@@ -649,9 +661,44 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
       await sentinelHd.updateStatus()
       await res
     } finally {
+      clearTimeout(timer)
       await this.term()
     }
     return null
+  }
+
+  /**
+   * Human-readable account of every daemon that has not reached ready, each
+   * with its current health result and message, plus the count and last cause
+   * of any abnormal exits.
+   *
+   * The exit count sits alongside the current health rather than replacing it
+   * because the two disagree in the case that matters most: a `ready` check
+   * that returns `loading` on a failed probe overwrites the crash back to
+   * `loading` on its next poll, so health alone reads as "still starting" for
+   * a process that is dying every time.
+   *
+   * {@link RUN_UNTIL_SUCCESS_ID} is excluded — it depends on every other
+   * daemon, so it is never ready when anything else isn't.
+   */
+  private describeNotReady(): string {
+    const notReady = (this.builtHealthDaemons ?? []).filter(
+      d => !d.isReady && d.id !== RUN_UNTIL_SUCCESS_ID,
+    )
+    if (!notReady.length) return 'no daemons — every one became ready'
+    return notReady
+      .map(d => {
+        const detail: string[] = [d.health.result]
+        if (d.health.message) detail.push(d.health.message)
+        if (d.daemon?.failedExits)
+          detail.push(
+            `${d.daemon.failedExits} failed exit(s), last: ${
+              d.daemon.lastExitError?.message ?? 'cause unknown'
+            }`,
+          )
+        return `${d.id} (${detail.join('; ')})`
+      })
+      .join(', ')
   }
 
   /**

--- a/projects/start-sdk/lib/mainFn/HealthDaemon.ts
+++ b/projects/start-sdk/lib/mainFn/HealthDaemon.ts
@@ -140,9 +140,12 @@ export class HealthDaemon<Manifest extends SDKManifest> {
       if (success && this.ready === 'EXIT_SUCCESS') {
         this.setHealth({ result: 'success', message: null })
       } else if (!success) {
+        const cause = this.daemon?.lastExitError?.message
         this.setHealth({
           result: 'failure',
-          message: `${this.id} daemon crashed`,
+          message: cause
+            ? `${this.id} daemon crashed: ${cause}`
+            : `${this.id} daemon crashed`,
         })
       } else if (!this.daemon?.isOneshot()) {
         this.setHealth({

--- a/projects/start-sdk/lib/test/Daemons.test.ts
+++ b/projects/start-sdk/lib/test/Daemons.test.ts
@@ -1,4 +1,5 @@
 import { Daemons, DaemonsReconciler, configHash } from '../mainFn/Daemons'
+import { cooldownTrigger } from '../trigger'
 import { Daemon } from '../mainFn/Daemon'
 import { Mounts } from '../mainFn/Mounts'
 import { setupMain } from '../mainFn'
@@ -443,5 +444,76 @@ describe('setupMain composition', () => {
     )
     const built = await main({ effects: e } as any)
     expect(built).toBeInstanceOf(DaemonsReconciler)
+  })
+})
+
+describe('runUntilSuccess timeout diagnostics', () => {
+  /**
+   * A daemon that never becomes ready, whose ready check reports `loading` on
+   * every poll.
+   */
+  const stuckChain = (e: T.Effects) =>
+    Daemons.of<Manifest>({ effects: e }).addDaemon('stuck', {
+      subcontainer: null,
+      exec: {
+        // Runs until the chain's teardown aborts it, so the `finally`'s
+        // term() after the timeout doesn't sit out the sigterm budget.
+        fn: (_sub, abort) =>
+          new Promise<null>(resolve =>
+            abort.addEventListener('abort', () => resolve(null), {
+              once: true,
+            }),
+          ),
+      },
+      ready: {
+        display: null,
+        // Poll fast so the first result lands well inside the test's budget;
+        // defaultTrigger's 1s lead-in would leave health on `starting`.
+        trigger: cooldownTrigger(5),
+        fn: () => ({ result: 'loading' as const, message: 'still warming up' }),
+      },
+      requires: [],
+    })
+
+  it('names the un-ready daemon with its health result and message', async () => {
+    await expect(
+      stuckChain(fakeEffects()).runUntilSuccess(200),
+    ).rejects.toThrow(/stuck \(loading; still warming up\)/)
+  })
+
+  it('omits the internal sentinel from the message', async () => {
+    await expect(stuckChain(fakeEffects()).runUntilSuccess(50)).rejects.toThrow(
+      expect.objectContaining({
+        message: expect.not.stringContaining('__RUN_UNTIL_SUCCESS'),
+      }),
+    )
+  })
+
+  it('reports the elapsed budget', async () => {
+    await expect(stuckChain(fakeEffects()).runUntilSuccess(50)).rejects.toThrow(
+      /Timed out after 50ms/,
+    )
+  })
+
+  it('surfaces the exit cause of a crash-looping daemon', async () => {
+    // The Nextcloud shape: the process dies on every start, but the ready
+    // check reports `loading` on a failed probe and so keeps overwriting the
+    // crash back to `loading`. Current health alone therefore says nothing —
+    // only the retained exit error identifies the fault.
+    const chain = Daemons.of<Manifest>({
+      effects: fakeEffects(),
+    }).addDaemon('crasher', {
+      subcontainer: null,
+      exec: { fn: async () => Promise.reject(new Error('exited with code 1')) },
+      ready: {
+        display: null,
+        trigger: cooldownTrigger(5),
+        fn: () => ({ result: 'loading' as const, message: null }),
+      },
+      requires: [],
+    })
+    await expect(chain.runUntilSuccess(200)).rejects.toThrow(
+      /crasher \(loading; \d+ failed exit\(s\), last: exited with code 1\)/,
+    )
   })
 })


### PR DESCRIPTION
## Problem

A `runUntilSuccess` timeout reported only a list of ids:

```
Timed out waiting for postgres,upgrade,__RUN_UNTIL_SUCCESS
```

Three things wrong with it:

1. **It leaks the internal sentinel.** `__RUN_UNTIL_SUCCESS` is the oneshot `runUntilSuccess` appends to detect that every user daemon is ready. It depends on all of them, so it is never ready when anything else isn't — it can only ever add noise to a message a user reads.
2. **It cannot distinguish slow from dead.** "postgres never became ready" is the same sentence whether the process is still starting or has exited 47 times.
3. **The error that says which is discarded.** `Daemon.runLoop` catches the exit error, logs it, and retries forever on a backoff. Nothing retains it, so it never reaches the caller.

Together these make a crash-looping daemon indistinguishable from a slow one for the entire timeout. A user hit this updating Nextcloud: the Postgres entrypoint exited 1 on every start, the chain retried for the full 30 minutes, and the only surfaced output was the line above. The real cause — `Database is uninitialized and superuser password is not specified` — was in the service logs the whole time, but nothing in the failure pointed there.

## Change

- `Daemon` retains `lastExitError` and a `failedExits` count.
- `HealthDaemon` appends the cause to its `<id> daemon crashed` health message.
- The timeout message reports, per un-ready daemon, its health result and message plus the exit count and last exit error, and states the budget that elapsed. The sentinel is filtered out, and its id is now a named constant rather than a literal in two places.
- `clearTimeout` on success, which otherwise left a pending long-duration timer alive after the chain finished.

Same failure now reads:

```
Timed out after 1800000ms waiting for postgres (loading; 47 failed exit(s), last: docker-entrypoint.sh exited with code 1), upgrade (waiting; postgres)
```

The exit count is reported *alongside* current health rather than instead of it, because the two disagree in exactly the case that matters: a `ready` check that returns `loading` on a failed probe — the common shape, and what Nextcloud does — overwrites the crash back to `loading` between restarts, so health alone always reads "still starting".

## Not changed

Timeout semantics. A crash-looping daemon still runs out the full budget rather than failing fast. Failing early on N consecutive crashes would be a behavior change for packages whose daemons legitimately crash a few times before coming up, so it is left as a separate decision. This PR is scoped to making the existing failure legible.

## Tests

Four new cases in `lib/test/Daemons.test.ts`, driving `runUntilSuccess` against JS-fn daemons so no container is needed:

- names the un-ready daemon with its health result and message
- omits the sentinel from the message
- reports the elapsed budget
- surfaces the exit cause and count of a crash-looping daemon (the Nextcloud shape: process dies every start, ready check reports `loading`)

`make test` 84 passed, `make check` clean, root `prettier --check` clean on all changed files.

## Docs

`docs/src/init.md` gains a "When it times out" section under the `runUntilSuccess` pattern: how to read the new message, and the distinction between a daemon with failed exits (process is dying — read the service logs) and one without (running, but not passing its ready check).