### PR TITLE
fix(sdk): clean up the package template

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- **Package template cleanup.** Dropped the `alerts` manifest block, removed in
+  2.0.0, that the template still scaffolded, and the `hello-world` guard job
+  from `release.yml` / `tagAndRelease.yml`. Its workflows are now identical to
+  a real package's
 - **`make install` no longer announces "Initializing StartOS developer
   environment…" on every run.** `check-init` guarded on
   `~/.startos/developer.key.pem`, which start-cli 1.1.0 renamed to

--- a/projects/start-sdk/docs/package-template/.github/workflows/build.yml
+++ b/projects/start-sdk/docs/package-template/.github/workflows/build.yml
@@ -14,7 +14,5 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     uses: Start9Labs/start-technologies/.github/workflows/build.yml@master
-    # with:
-    #   FREE_DISK_SPACE: true
     secrets:
       DEV_KEY: ${{ secrets.DEV_KEY }}

--- a/projects/start-sdk/docs/package-template/.github/workflows/release.yml
+++ b/projects/start-sdk/docs/package-template/.github/workflows/release.yml
@@ -6,23 +6,9 @@ on:
       - 'v*.*'
 
 jobs:
-  guard:
-    runs-on: ubuntu-latest
-    outputs:
-      id: ${{ steps.read.outputs.id }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: read
-        run: |
-          id="$(awk -F"'" '/id:/ {print $2; exit}' startos/manifest/index.ts)"
-          echo "id=$id" >> "$GITHUB_OUTPUT"
-
   release:
-    needs: guard
-    if: needs.guard.outputs.id != 'hello-world'
     uses: Start9Labs/start-technologies/.github/workflows/release.yml@master
     with:
-      # FREE_DISK_SPACE: true
       RELEASE_REGISTRY: ${{ vars.RELEASE_REGISTRY }}
       S3_S9PKS_BASE_URL: ${{ vars.S3_S9PKS_BASE_URL }}
     secrets:

--- a/projects/start-sdk/docs/package-template/.github/workflows/tagAndRelease.yml
+++ b/projects/start-sdk/docs/package-template/.github/workflows/tagAndRelease.yml
@@ -10,24 +10,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  guard:
-    runs-on: ubuntu-latest
-    outputs:
-      id: ${{ steps.read.outputs.id }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: read
-        run: |
-          id="$(awk -F"'" '/id:/ {print $2; exit}' startos/manifest/index.ts)"
-          echo "id=$id" >> "$GITHUB_OUTPUT"
-
   tag:
-    needs: guard
-    if: needs.guard.outputs.id != 'hello-world'
     uses: Start9Labs/start-technologies/.github/workflows/tagAndRelease.yml@master
     with:
       REFERENCE_REGISTRY: ${{ vars.REFERENCE_REGISTRY }}
-      # FREE_DISK_SPACE: true
       RELEASE_REGISTRY: ${{ vars.RELEASE_REGISTRY }}
       S3_S9PKS_BASE_URL: ${{ vars.S3_S9PKS_BASE_URL }}
     secrets:

--- a/projects/start-sdk/docs/package-template/startos/manifest/index.ts
+++ b/projects/start-sdk/docs/package-template/startos/manifest/index.ts
@@ -23,13 +23,5 @@ export const manifest = setupManifest({
       arch: ['x86_64', 'aarch64'],
     },
   },
-  alerts: {
-    install: null,
-    update: null,
-    uninstall: null,
-    restore: null,
-    start: null,
-    stop: null,
-  },
   dependencies: {},
 })


### PR DESCRIPTION
`s9pk init-package` copies `projects/start-sdk/docs/package-template/` verbatim, so anything stale in it ships into every new service package. Two things were.

## `alerts`

2.0.0 removed the manifest field with no compatibility alias, but the template kept scaffolding it:

```ts
alerts: { install: null, update: null, uninstall: null, restore: null, start: null, stop: null },
```

It survives `tsc` because `setupManifest` infers its parameter type from the argument rather than rejecting the key as an excess property — which is why it went unnoticed. Every package scaffolded since 2.0.0 carries a dead field, and a packager reading the scaffold has no way to tell it was removed.

## The `hello-world` guard job

`release.yml` and `tagAndRelease.yml` each opened with a job that read the package id out of `startos/manifest/index.ts` so the release could skip itself when that id was `hello-world`:

```yaml
guard:
  runs-on: ubuntu-latest
  outputs: { id: "${{ steps.read.outputs.id }}" }
  ...
release:
  needs: guard
  if: needs.guard.outputs.id != 'hello-world'
```

That only ever protected the template's own lineage from publishing under `hello-world`. In a real package the condition is always true, so it buys nothing and costs an extra checkout job on every release. hello-world itself dropped it in `ed0dca2`; the template didn't follow.

No package in either registry has it — **0 of 258** `release.yml` / `tagAndRelease.yml` files across `start9-registry`, `community-registry`, `needs-review` and `no-registry`, multi-branch worktrees included. It exists only here.

## Mirrors

Per the root `AGENTS.md` § Coupled changes, the template's workflows are one of three hand-maintained mirrors, alongside the reusable CI in `.github/workflows/` and the examples in `project-structure.md`. Both of those were already clean — the template was the only copy that had drifted — so this also drops the commented-out `FREE_DISK_SPACE` input it carried in all three. Its workflows are now byte-identical to `hello-world-startos`'s.

## Notes

- No SDK source change; `lib/` is untouched.
- `2.0.10` has no `start-sdk/v2.0.10` origin tag, so the changelog entry goes under the existing unreleased heading.
- Found while rebuilding `dojo-startos` on SDK 2.0 from a fresh scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)