### PR TITLE
fix(auth): send the local authcookie to a non-loopback listen address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7729,7 +7729,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "start-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "start-core",
  "tracing",
@@ -7888,7 +7888,7 @@ dependencies = [
 
 [[package]]
 name = "start-registry"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "start-core",
 ]

--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -9,6 +9,22 @@ Because `start-cli` is a thin client over `start-core`, most user-visible CLI ch
 in `start-core`; record here anything that changes this crate's entrypoint, features, packaging,
 or the CLI's externally observable behavior.
 
+## [1.1.1]
+
+### Fixed
+
+- **The local authcookie now reaches a registry or tunnel daemon that listens on a
+  non-loopback address.** Run on the server itself, the CLI presents the daemon's local
+  authcookie as an `Authorization: Bearer` header — but it attached that header only when
+  the URL was literally loopback. With no `--registry`/`--tunnel` the CLI derives the URL
+  from the daemon's own `registry-listen`/`tunnel-listen`, which is commonly the wildcard
+  `0.0.0.0:5959`; that is not loopback, so the request went out unauthenticated and came
+  back `Unauthorized`. `start-cli registry admin list` on the registry host failed this way.
+  A wildcard listen address is now dialled over loopback — binding every interface is not a
+  destination — and an address derived from the daemon's own listen configuration counts as
+  naming this machine, so the token is attached. An explicit `--registry`/`--tunnel` target
+  is unchanged: the token still goes only to a loopback URL.
+
 ## [1.1.0]
 
 ### Changed

--- a/projects/start-cli/Cargo.toml
+++ b/projects/start-cli/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-cli"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "1.1.0"                                               # VERSION_BUMP
+version = "1.1.1"                                               # VERSION_BUMP
 
 [[bin]]
 name = "start-cli"

--- a/projects/start-cli/man/start-cli.1
+++ b/projects/start-cli/man/start-cli.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH start-cli 1  "start-cli 1.1.0" 
+.TH start-cli 1  "start-cli 1.1.1" 
 .SH NAME
 start\-cli
 .SH SYNOPSIS
@@ -120,4 +120,4 @@ Command for calculating the blake3 hash of a file
 start\-cli\-wifi(1)
 Commands related to wifi networks i.e. add, connect, delete
 .SH VERSION
-v1.1.0
+v1.1.1

--- a/projects/start-registry/CHANGELOG.md
+++ b/projects/start-registry/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `start-registry` (the Start Registry server) are documented here. This project is versioned **independently** (starting at `1.0.0`); its version lives in `Cargo.toml`. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.2]
+
+- **`start-registry` works on a registry host that listens on a non-loopback address.** With no
+  `--registry`, the CLI derives the registry's address from `registry-listen` and authenticates
+  with the local authcookie — but it only sent that token when the derived URL was literally
+  loopback. A registry reachable from anywhere but the host itself listens on `0.0.0.0:5959`, so
+  every local command went out unauthenticated and came back `Unauthorized`. A wildcard listen
+  address is now dialled over loopback, and an address derived from the registry's own listen
+  configuration counts as naming this machine. An explicit `--registry` URL is unchanged: the
+  token still goes only to a loopback URL.
+
 ## [1.0.1]
 
 - **Registry responses stay compatible with pre-beta.10 clients.** `package.get` re-adds a

--- a/projects/start-registry/Cargo.toml
+++ b/projects/start-registry/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-registry"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "1.0.1"                                               # VERSION_BUMP
+version = "1.0.2"                                               # VERSION_BUMP
 
 [[bin]]
 name = "registrybox"

--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`start-tunnel` reaches a daemon that listens on a wildcard address.** With no
+  `--tunnel`, the CLI derives the daemon's address from `tunnel-listen` and
+  authenticates with the local authcookie, which it sends only to a loopback
+  address. A tunnel server binds `0.0.0.0` by nature, so the derived address was
+  never loopback: the CLI skipped the token and then, having no local auth, fell
+  through to dialling `https://0.0.0.0` — a request that can't succeed. A wildcard
+  listen address is now dialled over loopback, since binding every interface is not
+  a destination.
+
 - **`subnet <SUBNET> set-wan` and `subnet <SUBNET> set-ipv6` take the subnet
   once, from the parent `subnet` command.** Both asked for it a second time
   after the subcommand name, and no invocation satisfied that — giving the

--- a/shared-libs/crates/start-core/src/middleware/auth/local.rs
+++ b/shared-libs/crates/start-core/src/middleware/auth/local.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
 use base64::Engine;
 use http::HeaderValue;
 use http::header::AUTHORIZATION;
@@ -50,9 +52,24 @@ pub fn is_loopback(url: &Url) -> bool {
     }
 }
 
+/// Where to reach a daemon bound to `listen`. The unspecified address means
+/// "every interface on this host", which is not a destination — dial loopback.
+pub fn dial_addr(listen: SocketAddr) -> SocketAddr {
+    if listen.ip().is_unspecified() {
+        let loopback = match listen.ip() {
+            IpAddr::V4(_) => IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(_) => IpAddr::V6(Ipv6Addr::LOCALHOST),
+        };
+        SocketAddr::new(loopback, listen.port())
+    } else {
+        listen
+    }
+}
+
 /// `Authorization: Bearer` header carrying the server's local auth token, if
 /// this process can read it (i.e. it runs on the server itself). Only attach
-/// this to requests bound for a loopback address ([`is_loopback`]).
+/// this to requests bound for the local machine — a loopback URL
+/// ([`is_loopback`]), or one derived from the daemon's own listen address.
 pub async fn local_auth_header<C: LocalAuthContext>() -> Option<HeaderValue> {
     let token = read_file_to_string(C::LOCAL_AUTH_COOKIE_PATH).await.ok()?;
     let mut header = HeaderValue::from_str(&format!("Bearer {token}")).ok()?;
@@ -112,5 +129,34 @@ impl<C: LocalAuthContext> Middleware<C> for LocalAuth {
         check_from_header::<C>(self.authorization.as_ref())
             .await
             .map_err(|e| RpcResponse::from(RpcError::from(e)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wildcard_listen_dials_loopback() {
+        for (listen, expected) in [
+            ("0.0.0.0:5959", "127.0.0.1:5959"),
+            ("[::]:5959", "[::1]:5959"),
+            ("127.0.0.1:5959", "127.0.0.1:5959"),
+            ("192.168.1.5:5959", "192.168.1.5:5959"),
+        ] {
+            assert_eq!(
+                dial_addr(listen.parse().unwrap()),
+                expected.parse::<SocketAddr>().unwrap(),
+                "{listen}"
+            );
+        }
+    }
+
+    #[test]
+    fn dialed_wildcard_is_loopback() {
+        let url: Url = format!("http://{}", dial_addr("0.0.0.0:5959".parse().unwrap()))
+            .parse()
+            .unwrap();
+        assert!(is_loopback(&url));
     }
 }

--- a/shared-libs/crates/start-core/src/registry/context.rs
+++ b/shared-libs/crates/start-core/src/registry/context.rs
@@ -25,7 +25,7 @@ use url::Url;
 use crate::context::config::{CONFIG_PATH, ContextConfig};
 use crate::context::{CliContext, RpcContext};
 use crate::middleware::auth::DbContext;
-use crate::middleware::auth::local::{LocalAuthContext, is_loopback, local_auth_header};
+use crate::middleware::auth::local::{LocalAuthContext, dial_addr, is_loopback, local_auth_header};
 use crate::middleware::auth::signature::{NonceCache, SignatureAuthContext};
 use crate::prelude::*;
 use crate::registry::RegistryDatabase;
@@ -205,12 +205,13 @@ impl CallRemote<RegistryContext> for CliContext {
     ) -> Result<Value, RpcError> {
         let local_auth = local_auth_header::<RegistryContext>().await;
 
-        let url = if let Some(url) = self.registry_url.clone() {
-            url
+        let (url, is_local) = if let Some(url) = self.registry_url.clone() {
+            let is_local = is_loopback(&url);
+            (url, is_local)
         } else if local_auth.is_some() || !self.registry_hostname.is_empty() {
             let mut url: Url = format!(
                 "http://{}",
-                self.registry_listen.unwrap_or(DEFAULT_REGISTRY_LISTEN)
+                dial_addr(self.registry_listen.unwrap_or(DEFAULT_REGISTRY_LISTEN))
             )
             .parse()
             .map_err(Error::from)?;
@@ -219,7 +220,9 @@ impl CallRemote<RegistryContext> for CliContext {
                 .with_kind(crate::ErrorKind::ParseUrl)?
                 .push("rpc")
                 .push("v0");
-            url
+            // Derived from the registry's own listen address, so it names this
+            // machine even when that address isn't loopback.
+            (url, true)
         } else {
             return Err(Error::new(
                 eyre!("{}", t!("registry.context.registry-required")),
@@ -229,7 +232,7 @@ impl CallRemote<RegistryContext> for CliContext {
         };
 
         let mut headers = HeaderMap::new();
-        if is_loopback(&url) {
+        if is_local {
             if let Some(auth) = local_auth {
                 headers.insert(AUTHORIZATION, auth);
             }

--- a/shared-libs/crates/start-core/src/tunnel/context.rs
+++ b/shared-libs/crates/start-core/src/tunnel/context.rs
@@ -26,7 +26,7 @@ use crate::context::config::ContextConfig;
 use crate::context::{CliContext, RpcContext};
 use crate::db::model::public::{NetworkInterfaceInfo, NetworkInterfaceType};
 use crate::middleware::auth::Auth;
-use crate::middleware::auth::local::{LocalAuthContext, local_auth_header};
+use crate::middleware::auth::local::{LocalAuthContext, dial_addr, local_auth_header};
 use crate::middleware::auth::signature::{NonceCache, url_host_str};
 use crate::middleware::cors::Cors;
 use crate::net::dns_update::rfc2136::{DnsInjector, InjectedRecord};
@@ -827,7 +827,7 @@ impl CallRemote<TunnelContext> for CliContext {
         let (tunnel_addr, addr_from_config) = if let Some(addr) = self.tunnel_addr {
             (addr, true)
         } else if let Some(addr) = self.tunnel_listen {
-            (addr, true)
+            (dial_addr(addr), true)
         } else {
             (TUNNEL_DEFAULT_LISTEN, false)
         };


### PR DESCRIPTION
Follow-up to the `startos-registry` setup-action failure ([startos-registry-startos#13](https://github.com/Start9Labs/startos-registry-startos/pull/13)); this is the start-core half.

## The bug

Run on the server itself, the CLI presents the daemon's local authcookie as an `Authorization: Bearer` header, gated on the target URL being loopback (`registry/context.rs`, added in #3526). With no `--registry` the CLI *derives* that URL from the daemon's own `registry-listen` — commonly the wildcard `0.0.0.0:5959`, which is not loopback. So the header was dropped and the call came back `Unauthorized`:

```
$ start-cli package attach startos-registry -n startos-registry-sub -- start-registry admin list
Unauthorized: Unauthorized

$ ... -- start-registry --registry http://127.0.0.1:5959 admin list      # works
```

That is the debugging path `projects/start-registry/AGENTS.md` documents, and it hits any bare-metal registry host that listens anywhere but loopback. The reason it went unnoticed is that the reachable-from-elsewhere config (`0.0.0.0`) is exactly the one that breaks, while a dev's `--listen 127.0.0.1:5959` is fine.

The tunnel has the same defect and worse consequences: a tunnel server binds a public address by nature, so `tunnel_listen` is essentially never loopback — and with no local auth the CLI falls through to dialling `https://0.0.0.0/rpc/v0`, which cannot succeed.

## The change

**`dial_addr(listen)`** maps a wildcard bind address to loopback. Binding every interface is not a destination; loopback is where that daemon answers. Applied to both derivations.

**The registry CLI attaches the token when the URL came from the registry's own listen configuration**, not only when it is literally loopback. Such an address names this machine by construction, so this is the invariant the loopback check was approximating, not a relaxation of it:

- The token only exists for a process that can read `/run/startos/registry.authcookie` — mode `0640`, owner `root:root`. If you can read it you are root on that box.
- `registry_listen` is `#[arg(skip)]`: config-file only, and it describes where the *local* daemon binds.
- An explicit `--registry`/`-r` URL keeps the loopback-only rule unchanged.

The tunnel gets the wildcard normalization only — its `-t/--tunnel` flag (a user-supplied remote address) and `tunnel_listen` land in the same variable, so "derived from local config" isn't distinguishable there without a wider refactor. Happy to do that separately if you'd rather have both halves consistent.

## Verification

`cargo check -p start-core` clean; two new unit tests in `middleware/auth/local.rs` cover `dial_addr` (v4/v6 wildcard, loopback and LAN pass-through) and that a dialled wildcard satisfies `is_loopback`.

On the wire, `start-cli` built from each side against a probe listener, with `registry-listen: 0.0.0.0:5959` and a readable authcookie:

| build | result |
| --- | --- |
| `origin/master` | `AUTHORIZATION=None` → server answers `Unauthorized` |
| this branch | `AUTHORIZATION='Bearer <token>'` |

Both dial loopback on Linux (connecting to `0.0.0.0` lands there), so the observable regression was the missing header; the normalization is what makes the derived URL honest, and portable.

## Versions

`start-cli` 1.1.0 → 1.1.1 and `start-registry` 1.0.1 → 1.0.2 — both top changelog headings are cut origin tags, so each gets a new heading and a manifest bump (`Cargo.lock` updated in the same commit). `start-tunnel` 1.2.2 is untagged, so its entry goes under the existing heading.