### PR TITLE
fix(start-wrt): don't let a disabled outbound VPN be selected as a profile outbound or a chain target

### DIFF
--- a/projects/start-wrt/API_CONTRACT.md
+++ b/projects/start-wrt/API_CONTRACT.md
@@ -1045,6 +1045,14 @@ struct OutboundVpnCreateResponse {
 // OpenVPN configs (no INI headers) are rejected with an OpenVPN-specific
 // message. The web UI mirrors this with an async file-content check before
 // submit, but the backend is the authoritative gate.
+//
+// `target` must be "Internet" or an existing VPN's label (else InvalidValue),
+// must not close a chain cycle (VpnChainCycle), and must not name a VPN that
+// is disabled (VpnDisabled) — a disabled interface is never registered with
+// netifd, so the vcr_<iface> chain route is dropped and this VPN's endpoint
+// traffic silently falls back to the WAN. `vpn-client.set-enabled` holds the
+// other half of that invariant, refusing to disable a VPN that something
+// already chains through.
 ```
 
 ### `vpn-client.update`
@@ -1064,6 +1072,11 @@ struct OutboundVpnUpdateRequest {
 // Response: null
 // Backend: updates label+target metadata and the interface `mtu` option.
 // Bounces the WG interface only when the MTU actually changed.
+//
+// Validation: same `target` rules as vpn-client.create, except the disabled
+// check runs ONLY when `target` differs from the stored one — mirroring
+// guard_subnet_collision, so an unrelated edit (label, MTU) isn't blocked by a
+// broken chain already present in the config.
 ```
 
 ### `vpn-client.delete`

--- a/projects/start-wrt/API_CONTRACT.md
+++ b/projects/start-wrt/API_CONTRACT.md
@@ -1400,6 +1400,11 @@ struct ProfileCreateRequest {
 // Validation: gateway_ip must stay inside the LAN network block (see
 //   lan.ipv4-set). owns_lan profiles must be a valid RFC 1918 selection;
 //   others must share the admin LAN's first two octets, else InvalidRequest.
+//   outbound must be "wan" or an outbound VPN that vpn-client.list reports as
+//   enabled: an unknown interface (or one that is a VPN server rather than a
+//   client) is ErrorKind::NotFound, a disabled one ErrorKind::VpnDisabled.
+//   A disabled VPN's tunnel never comes up, so routing a profile through it
+//   would blackhole that profile.
 ```
 
 ### `profiles.set`
@@ -1417,7 +1422,7 @@ struct ProfileSetRequest {
     force: bool,
 }
 // Response: ProfileId
-// Validation: same gateway_ip block check as profiles.create.
+// Validation: same gateway_ip and outbound checks as profiles.create.
 ```
 
 ### `profiles.delete`

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Disabled outbound VPNs are no longer offered as a Security Profile's
+  outbound route.** The VPN picker on the profile's WAN / Internet tab listed
+  every VPN, including disabled ones — and picking one silently cut that
+  profile off the Internet, since a disabled VPN's tunnel never comes up. The
+  picker now lists only enabled VPNs.
+
 - **Enabling LAN IPv6 no longer silently fails when the Admin profile routes
   through an IPv4-only VPN.** Saving the LAN IPv6 settings reported success
   but immediately reverted to disabled: the save re-derived the admin LAN's

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -33,7 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outbound route.** The VPN picker on the profile's WAN / Internet tab listed
   every VPN, including disabled ones — and picking one silently cut that
   profile off the Internet, since a disabled VPN's tunnel never comes up. The
-  picker now lists only enabled VPNs.
+  picker now lists only enabled VPNs, and the router refuses a profile pointed
+  at a disabled — or nonexistent — VPN, so the command line can't create the
+  same dead end.
 
 - **Enabling LAN IPv6 no longer silently fails when the Admin profile routes
   through an IPv4-only VPN.** Saving the LAN IPv6 settings reported success

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   at a disabled — or nonexistent — VPN, so the command line can't create the
   same dead end.
 
+  The same applied to VPN chaining, where it was quieter and worse: a disabled
+  VPN could be picked as another VPN's **Connects to** target, and the chain
+  then silently collapsed to a single hop. The downstream VPN connected
+  normally — straight out your Internet connection instead of through the VPN
+  you chained it to — and every screen reported success. Disabled VPNs are no
+  longer offered as chain targets, and the router rejects one outright.
+
 - **Enabling LAN IPv6 no longer silently fails when the Admin profile routes
   through an IPv4-only VPN.** Saving the LAN IPv6 settings reported success
   but immediately reverted to disabled: the save re-derived the admin LAN's

--- a/projects/start-wrt/backend/ctrl/src/error.rs
+++ b/projects/start-wrt/backend/ctrl/src/error.rs
@@ -61,6 +61,7 @@ pub enum ErrorKind {
     DhcpStaticHostsInSubnet = 1023,
     SubnetCollision = 1024,
     PublishedPortsUseIpv6 = 1025,
+    VpnDisabled = 1026,
 }
 
 impl From<ErrorKind> for startos::ErrorKind {
@@ -122,6 +123,7 @@ impl ErrorKind {
             DhcpStaticHostsInSubnet => "DHCP Static Hosts in Subnet",
             SubnetCollision => "Subnet Collision",
             PublishedPortsUseIpv6 => "Published Ports Use IPv6",
+            VpnDisabled => "Outbound VPN Disabled",
         }
     }
 }

--- a/projects/start-wrt/backend/ctrl/src/profiles.rs
+++ b/projects/start-wrt/backend/ctrl/src/profiles.rs
@@ -1310,6 +1310,7 @@ fn set_config<C: CtrlContext>(
     profile: &Profile<ProfileIdOpt>,
 ) -> Result<(ProfileId, Option<OldProfileState>), Error> {
     validate_profile_block(cfgs, profile)?;
+    crate::vpn_client::guard_outbound_available(cfgs, &profile.outbound)?;
     let ipv6 = is_ipv6_enabled(cfgs) && outbound_supports_ipv6(cfgs, &profile.outbound);
     // Check fullname uniqueness before renaming
     if let Some(given_fullname) = &profile.id.fullname {
@@ -1590,6 +1591,7 @@ fn create_config(
     pre_allocated_interface: Option<String>,
 ) -> Result<ProfileId, Error> {
     validate_profile_block(cfgs, profile)?;
+    crate::vpn_client::guard_outbound_available(cfgs, &profile.outbound)?;
     // The new interface isn't in the config yet, so no self-exclusion is needed:
     // reject if the requested /24 already belongs to any existing profile.
     guard_subnet_collision(cfgs, profile.gateway_ip, None)?;
@@ -3561,6 +3563,11 @@ config profile guest
 \toption fullname 'Guest'
 \toption interface 'guest'
 \toption vlan_tag '101'
+
+config vpn_client
+\toption interface 'wg_test'
+\toption label 'Test VPN'
+\toption target 'Internet'
 ",
         )
         .unwrap();
@@ -3592,6 +3599,14 @@ config bridge-vlan
 config bridge-vlan
 \toption device 'br-lan'
 \toption vlan '101'
+
+config interface 'wg_test'
+\toption proto 'wireguard'
+\toption private_key 'aGkmAm6PEDDjyZx/Lwc8AfwlVWuJOaKB6E5Hp+JqgVc='
+\toption disabled '0'
+\toption defaultroute '0'
+\toption peerdns '0'
+\tlist addresses '10.1.0.2/32'
 ",
         )
         .unwrap();
@@ -4545,7 +4560,7 @@ config profile guest
                 vlan_tag: Some(101),
             },
             gateway_ip: Ipv4Addr::new(192, 168, 101, 1),
-            outbound: "wg0".into(),
+            outbound: "wg_test".into(),
             lan_access: LanAccess::SameProfile,
             wan_access: WanAccess::All,
             dns_override: Vec::new(),
@@ -4579,7 +4594,7 @@ config profile guest
         .unwrap();
 
         assert_eq!(
-            result.outbound, "wg0",
+            result.outbound, "wg_test",
             "outbound should persist through set_config"
         );
     }
@@ -5103,7 +5118,7 @@ config profile guest
                 vlan_tag: Some(101),
             },
             gateway_ip: Ipv4Addr::new(192, 168, 101, 1),
-            outbound: "wg_mullvad".into(),
+            outbound: "wg_test".into(),
             lan_access: LanAccess::SameProfile,
             wan_access: WanAccess::All,
             dns_override: Vec::new(),
@@ -5121,9 +5136,9 @@ config profile guest
             .sections
             .iter()
             .filter_map(|s| s.get::<FirewallZone>().ok())
-            .find(|z| z.name == "vpn_wg_mullvad")
-            .expect("vpn_wg_mullvad zone should exist");
-        assert_eq!(vpn_zone.network, vec!["wg_mullvad".to_string()]);
+            .find(|z| z.name == "vpn_wg_test")
+            .expect("vpn_wg_test zone should exist");
+        assert_eq!(vpn_zone.network, vec!["wg_test".to_string()]);
         assert_eq!(vpn_zone.masq, Some(true));
         assert_eq!(vpn_zone.masq6, Some(true));
 
@@ -5135,9 +5150,58 @@ config profile guest
             .find(|z| z.name == DEFAULT_WAN_ZONE)
             .expect("WAN zone should exist");
         assert!(
-            !wan_zone.network.contains(&"wg_mullvad".to_string()),
+            !wan_zone.network.contains(&"wg_test".to_string()),
             "VPN interface must not be in the WAN zone, got: {:?}",
             wan_zone.network
+        );
+    }
+
+    #[tokio::test]
+    async fn set_config_rejects_disabled_outbound_vpn() {
+        // A disabled VPN's WireGuard interface never comes up, so routing a
+        // profile through it blackholes the profile. The UI only offers enabled
+        // VPNs; the RPC/CLI must refuse the rest rather than write the config.
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+        setup_configs(dir.path());
+        let network = std::fs::read_to_string(dir.path().join("network"))
+            .unwrap()
+            .replace("\toption disabled '0'", "\toption disabled '1'");
+        std::fs::write(dir.path().join("network"), network).unwrap();
+
+        let arena = Arena::new();
+        let mut cfgs = parse_all(
+            ctx.uci_root(),
+            &arena,
+            &["startwrt", "network", "firewall", "dhcp"],
+        )
+        .await
+        .unwrap();
+
+        let profile = Profile {
+            id: ProfileIdOpt {
+                fullname: Some("Guest".into()),
+                interface: Some("guest".into()),
+                vlan_tag: Some(101),
+            },
+            gateway_ip: Ipv4Addr::new(192, 168, 101, 1),
+            outbound: "wg_test".into(),
+            lan_access: LanAccess::SameProfile,
+            wan_access: WanAccess::All,
+            dns_override: Vec::new(),
+            dns_source: String::new(),
+            access_to_new_profiles: false,
+            owns_lan: false,
+        };
+
+        let err = set_config(ctx, &mut cfgs, &profile).unwrap_err();
+        assert_eq!(err.kind, ErrorKind::VpnDisabled);
+        assert!(
+            !cfgs["network"]
+                .sections
+                .iter()
+                .any(|s| s.name().as_deref() == Some("prt_guest")),
+            "a rejected outbound must not leave policy routing behind"
         );
     }
 
@@ -5918,6 +5982,24 @@ config zone
     fn setup_configs_with_ipv6_vpn(dir: &std::path::Path) {
         setup_configs(dir);
 
+        // Register both tunnels as outbound VPN clients — a profile may only
+        // route through an interface that has vpn_client metadata.
+        let mut startwrt = std::fs::read_to_string(dir.join("startwrt")).unwrap();
+        startwrt.push_str(
+            "\n\
+config vpn_client
+\toption interface 'wg_v6'
+\toption label 'V6 VPN'
+\toption target 'Internet'
+
+config vpn_client
+\toption interface 'wg_v4'
+\toption label 'V4 VPN'
+\toption target 'Internet'
+",
+        );
+        std::fs::write(dir.join("startwrt"), startwrt).unwrap();
+
         // Append WG interfaces to network config
         let mut network = std::fs::read_to_string(dir.join("network")).unwrap();
         network.push_str(
@@ -6392,6 +6474,15 @@ config dhcp 'guest'
 ",
         );
         std::fs::write(dir.path().join("network"), network).unwrap();
+        let mut startwrt = std::fs::read_to_string(dir.path().join("startwrt")).unwrap();
+        startwrt.push_str(
+            "\nconfig vpn_client
+\toption interface 'wg_v6'
+\toption label 'V6 VPN'
+\toption target 'Internet'
+",
+        );
+        std::fs::write(dir.path().join("startwrt"), startwrt).unwrap();
 
         let arena = Arena::new();
         let mut cfgs = parse_all(

--- a/projects/start-wrt/backend/ctrl/src/vpn_client.rs
+++ b/projects/start-wrt/backend/ctrl/src/vpn_client.rs
@@ -179,6 +179,59 @@ fn get_vpn_server_interfaces(cfgs: &Configs) -> std::collections::BTreeSet<Strin
         .collect()
 }
 
+/// Reject a profile outbound that isn't a usable outbound VPN client.
+///
+/// `"wan"` (direct) always passes. Anything else must be an interface `list`
+/// reports as `enabled`, so the RPC/CLI can't select an outbound the UI never
+/// offers. Both failures blackhole the profile silently otherwise: an unknown
+/// interface still gets a `vpn_<X>` zone and a policy route pointing at
+/// nothing, and a disabled VPN's WireGuard interface never comes up.
+///
+/// A VPN server's interface fails the metadata lookup — servers carry
+/// `vpn_server`, not `vpn_client` — and `create` keeps the two namespaces
+/// disjoint via `InterfaceNameConflict`, so no separate check is needed.
+pub(crate) fn guard_outbound_available(cfgs: &Configs, outbound: &str) -> Result<(), Error> {
+    if outbound == crate::profiles::DEFAULT_WAN_ZONE {
+        return Ok(());
+    }
+
+    let meta = cfgs["startwrt"]
+        .sections
+        .iter()
+        .filter_map(|s| s.get::<UciVpnClient>().ok())
+        .find(|meta| meta.interface == outbound);
+    let Some(meta) = meta else {
+        return Err(Error::new(
+            eyre!("no outbound VPN client named {outbound}"),
+            ErrorKind::NotFound,
+        ));
+    };
+
+    let wg = cfgs["network"]
+        .sections
+        .iter()
+        .find(|s| s.name().as_deref() == Some(outbound))
+        .and_then(|s| s.get::<WgInterface>().ok())
+        .filter(|wg| wg.is_wireguard());
+    let Some(wg) = wg else {
+        return Err(Error::new(
+            eyre!("outbound VPN '{}' has no WireGuard interface", meta.label),
+            ErrorKind::NotFound,
+        ));
+    };
+    if wg.disabled() {
+        return Err(Error::new(
+            eyre!(
+                "outbound VPN '{}' is disabled — enable it before routing a profile through it",
+                meta.label
+            ),
+            ErrorKind::VpnDisabled,
+        ));
+    }
+
+    Ok(())
+}
+
 /// Compute which profiles use a given WireGuard interface as their outbound route.
 /// Reads UciProfile sections directly from startwrt config.
 fn get_used_by_profiles(cfgs: &Configs, wg_interface_name: &str) -> Vec<String> {
@@ -2207,6 +2260,59 @@ MIID...snip...
             used_by.is_empty(),
             "no profiles should reference wg_proton after reset"
         );
+    }
+
+    // === guard_outbound_available ===
+
+    #[tokio::test]
+    async fn test_guard_outbound_accepts_wan_and_enabled_vpn() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_with_vpn_client(dir.path());
+
+        let arena = Arena::new();
+        let cfgs = parse_all(dir.path(), &arena, &["network", "startwrt"])
+            .await
+            .unwrap();
+
+        guard_outbound_available(&cfgs, "wan").expect("direct WAN is always available");
+        guard_outbound_available(&cfgs, "wg_proton").expect("an enabled VPN client is available");
+    }
+
+    #[tokio::test]
+    async fn test_guard_outbound_rejects_disabled_vpn() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_with_vpn_client(dir.path());
+        let network = std::fs::read_to_string(dir.path().join("network"))
+            .unwrap()
+            .replace("\toption disabled '0'", "\toption disabled '1'");
+        std::fs::write(dir.path().join("network"), network).unwrap();
+
+        let arena = Arena::new();
+        let cfgs = parse_all(dir.path(), &arena, &["network", "startwrt"])
+            .await
+            .unwrap();
+
+        let err = guard_outbound_available(&cfgs, "wg_proton").unwrap_err();
+        assert_eq!(err.kind, ErrorKind::VpnDisabled);
+    }
+
+    #[tokio::test]
+    async fn test_guard_outbound_rejects_unknown_and_server_interfaces() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_with_vpn_client(dir.path());
+
+        let arena = Arena::new();
+        let cfgs = parse_all(dir.path(), &arena, &["network", "startwrt"])
+            .await
+            .unwrap();
+
+        let err = guard_outbound_available(&cfgs, "wg_nonexistent").unwrap_err();
+        assert_eq!(err.kind, ErrorKind::NotFound);
+
+        // wg_guest is a real WireGuard interface, but an inbound VPN server —
+        // it carries no vpn_client metadata, so it is not an egress path.
+        let err = guard_outbound_available(&cfgs, "wg_guest").unwrap_err();
+        assert_eq!(err.kind, ErrorKind::NotFound);
     }
 
     #[tokio::test]

--- a/projects/start-wrt/backend/ctrl/src/vpn_client.rs
+++ b/projects/start-wrt/backend/ctrl/src/vpn_client.rs
@@ -179,6 +179,16 @@ fn get_vpn_server_interfaces(cfgs: &Configs) -> std::collections::BTreeSet<Strin
         .collect()
 }
 
+/// The WireGuard interface section named `name`, if it exists and is one.
+fn wg_interface(cfgs: &Configs, name: &str) -> Option<WgInterface> {
+    cfgs["network"]
+        .sections
+        .iter()
+        .find(|s| s.name().as_deref() == Some(name))
+        .and_then(|s| s.get::<WgInterface>().ok())
+        .filter(|wg| wg.is_wireguard())
+}
+
 /// Reject a profile outbound that isn't a usable outbound VPN client.
 ///
 /// `"wan"` (direct) always passes. Anything else must be an interface `list`
@@ -190,6 +200,10 @@ fn get_vpn_server_interfaces(cfgs: &Configs) -> std::collections::BTreeSet<Strin
 /// A VPN server's interface fails the metadata lookup — servers carry
 /// `vpn_server`, not `vpn_client` — and `create` keeps the two namespaces
 /// disjoint via `InterfaceNameConflict`, so no separate check is needed.
+///
+/// Only the immediate hop is checked. `guard_target_enabled` and `set_enabled`
+/// between them keep every link of a chain enabled, so an enabled interface
+/// implies an enabled chain behind it — no walk needed here.
 pub(crate) fn guard_outbound_available(cfgs: &Configs, outbound: &str) -> Result<(), Error> {
     if outbound == crate::profiles::DEFAULT_WAN_ZONE {
         return Ok(());
@@ -207,13 +221,7 @@ pub(crate) fn guard_outbound_available(cfgs: &Configs, outbound: &str) -> Result
         ));
     };
 
-    let wg = cfgs["network"]
-        .sections
-        .iter()
-        .find(|s| s.name().as_deref() == Some(outbound))
-        .and_then(|s| s.get::<WgInterface>().ok())
-        .filter(|wg| wg.is_wireguard());
-    let Some(wg) = wg else {
+    let Some(wg) = wg_interface(cfgs, outbound) else {
         return Err(Error::new(
             eyre!("outbound VPN '{}' has no WireGuard interface", meta.label),
             ErrorKind::NotFound,
@@ -643,12 +651,61 @@ fn validate_target(cfgs: &Configs, target: &str, self_label: &str) -> Result<(),
         if current == "Internet" {
             return Ok(());
         }
+        // Bound the walk. Reaching `self_label` is the cycle this call is
+        // guarding against, but a cycle among *other* labels would spin here
+        // forever. Every edge is written through this function, so that can
+        // only come from a hand-edited /etc/config/startwrt — which must not
+        // hang the RPC thread.
+        if visited.iter().any(|v| v == current) {
+            return Err(Error::new(
+                eyre!("VPN chain cycle detected at '{}': {:?}", current, visited),
+                ErrorKind::VpnChainCycle,
+            ));
+        }
         visited.push(current.to_string());
         match label_to_target.get(current) {
             Some(next) => current = next,
             None => return Ok(()), // target chain ends at unknown label
         }
     }
+}
+
+/// Reject chaining onto a VPN that is disabled.
+///
+/// `"Internet"` always passes; an unknown label falls through to
+/// `validate_target`'s `InvalidValue`. A disabled interface is never registered
+/// with netifd, so the `vcr_<iface>` chain route pinning this VPN's endpoint
+/// through its target is dropped at config-parse time and the endpoint traffic
+/// silently falls back to the WAN — a single-hop connection where the user
+/// asked for two, with every surface still reporting success.
+///
+/// `set_enabled` holds the other half of this invariant, refusing to disable a
+/// VPN that something already chains through. Together they let
+/// `guard_outbound_available` check only the profile's immediate hop.
+fn guard_target_enabled(cfgs: &Configs, target: &str) -> Result<(), Error> {
+    if target == "Internet" {
+        return Ok(());
+    }
+
+    let target_iface = cfgs["startwrt"]
+        .sections
+        .iter()
+        .filter_map(|s| s.get::<UciVpnClient>().ok())
+        .find(|meta| meta.label == target)
+        .map(|meta| meta.interface);
+
+    let Some(target_iface) = target_iface else {
+        return Ok(());
+    };
+
+    if wg_interface(cfgs, &target_iface).is_some_and(|wg| wg.disabled()) {
+        return Err(Error::new(
+            eyre!("target VPN '{target}' is disabled — enable it before chaining through it"),
+            ErrorKind::VpnDisabled,
+        ));
+    }
+
+    Ok(())
 }
 
 /// List all outbound VPN clients
@@ -740,6 +797,7 @@ pub async fn create(
         }
 
         validate_target(&cfgs, &req.target, &req.label)?;
+        guard_target_enabled(&cfgs, &req.target)?;
 
         // Create the WireGuard interface section
         create_wg_client_interface(&mut cfgs, &interface_name, &parsed, &arena)?;
@@ -817,9 +875,11 @@ pub async fn update(
             ));
         }
 
-        // Find and update metadata, capturing old label for cascade
+        // Find and update metadata, capturing old label for cascade and old
+        // target so the disabled-target guard fires only on an actual retarget
         let mut found = false;
         let mut old_label = String::new();
+        let mut old_target = String::new();
         for section in &mut cfgs["startwrt"].sections {
             let Ok(mut meta) = section.get::<UciVpnClient>() else {
                 continue;
@@ -829,6 +889,7 @@ pub async fn update(
             }
 
             old_label = meta.label.clone();
+            old_target = meta.target.clone();
             meta.label = req.label.clone();
             meta.target = req.target.clone();
             section.set(&meta)?;
@@ -844,6 +905,13 @@ pub async fn update(
         }
 
         validate_target(&cfgs, &req.target, &req.label)?;
+        // Only on an actual retarget, mirroring guard_subnet_collision: a
+        // no-op edit (label, MTU) must not be blocked by a broken chain that
+        // already exists in the stored config — otherwise a router that
+        // already chains onto a disabled VPN becomes uneditable.
+        if req.target != old_target {
+            guard_target_enabled(&cfgs, &req.target)?;
+        }
 
         // Cascade label rename: update any VPN clients targeting the old label
         if old_label != req.label {
@@ -3696,6 +3764,79 @@ config wireguard_wg_c 'c_peer0'
         let arena = Arena::new();
         let cfgs = parse_all(dir.path(), &arena, &["startwrt"]).await.unwrap();
         assert!(validate_target(&cfgs, "A", "C").is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_target_terminates_on_foreign_cycle() {
+        // A→B→A is a cycle that never reaches "C", the label being validated.
+        // The walk used to terminate only on self_label or "Internet", so this
+        // config spun forever. Only a hand-edited /etc/config/startwrt can
+        // produce it — every edge written through validate_target is acyclic.
+        //
+        // NOTE: if the walk's bound regresses, this test HANGS rather than
+        // failing an assertion.
+        let dir = tempfile::tempdir().unwrap();
+        setup_vpn_chain_configs(dir.path(), &[("wg_a", "A", "B"), ("wg_b", "B", "A")]);
+        let arena = Arena::new();
+        let cfgs = parse_all(dir.path(), &arena, &["startwrt"]).await.unwrap();
+
+        let err = validate_target(&cfgs, "A", "C").unwrap_err();
+        assert_eq!(err.kind, ErrorKind::VpnChainCycle);
+    }
+
+    // === guard_target_enabled tests ===
+
+    #[tokio::test]
+    async fn test_guard_target_enabled_accepts_internet_and_enabled_target() {
+        let dir = tempfile::tempdir().unwrap();
+        setup_with_vpn_client(dir.path());
+
+        let arena = Arena::new();
+        let cfgs = parse_all(dir.path(), &arena, &["network", "startwrt"])
+            .await
+            .unwrap();
+
+        guard_target_enabled(&cfgs, "Internet").expect("Internet is always chainable");
+        guard_target_enabled(&cfgs, "Proton VPN").expect("an enabled VPN is chainable");
+    }
+
+    #[tokio::test]
+    async fn test_guard_target_enabled_rejects_disabled_target() {
+        // Chaining onto a disabled VPN drops the vcr_ route at netifd
+        // config-parse time, silently degrading a two-hop chain to one hop.
+        let dir = tempfile::tempdir().unwrap();
+        setup_with_vpn_client(dir.path());
+        // wg_proton is the only interface carrying `disabled`, so this hits it.
+        let network = std::fs::read_to_string(dir.path().join("network"))
+            .unwrap()
+            .replace("\toption disabled '0'", "\toption disabled '1'");
+        std::fs::write(dir.path().join("network"), network).unwrap();
+
+        let arena = Arena::new();
+        let cfgs = parse_all(dir.path(), &arena, &["network", "startwrt"])
+            .await
+            .unwrap();
+
+        let err = guard_target_enabled(&cfgs, "Proton VPN").unwrap_err();
+        assert_eq!(err.kind, ErrorKind::VpnDisabled);
+    }
+
+    #[tokio::test]
+    async fn test_guard_target_enabled_defers_unknown_label() {
+        // Division of labor: existence is validate_target's error to report,
+        // so this guard passes an unknown label through rather than shadowing
+        // InvalidValue with a less accurate VpnDisabled.
+        let dir = tempfile::tempdir().unwrap();
+        setup_with_vpn_client(dir.path());
+
+        let arena = Arena::new();
+        let cfgs = parse_all(dir.path(), &arena, &["network", "startwrt"])
+            .await
+            .unwrap();
+
+        guard_target_enabled(&cfgs, "DoesNotExist").expect("unknown labels defer");
+        let err = validate_target(&cfgs, "DoesNotExist", "Self").unwrap_err();
+        assert_eq!(err.kind, ErrorKind::InvalidValue);
     }
 
     // === IPv6 chain endpoint tests ===

--- a/projects/start-wrt/docs/src/outbound-vpn.md
+++ b/projects/start-wrt/docs/src/outbound-vpn.md
@@ -64,7 +64,7 @@ To delete a VPN, click "Delete" on its detail page. If any Security Profiles rou
 
 ## Enabling and Disabling
 
-Each VPN has an enable/disable toggle in the table view. When a VPN is disabled, profiles that route through it will fall back to the WAN (direct Internet). A disabled VPN is not offered when choosing a [Security Profile's](security-profiles.md) outbound routing — re-enable it first.
+Each VPN has an enable/disable toggle in the table view. When a VPN is disabled, profiles that route through it will fall back to the WAN (direct Internet). A disabled VPN is not offered when choosing a [Security Profile's](security-profiles.md) outbound routing, nor as another VPN's **Connects to** target — re-enable it first.
 
 > [!NOTE]
 > You cannot disable a VPN if other VPNs use it as a target. Change their target first.

--- a/projects/start-wrt/docs/src/outbound-vpn.md
+++ b/projects/start-wrt/docs/src/outbound-vpn.md
@@ -64,7 +64,7 @@ To delete a VPN, click "Delete" on its detail page. If any Security Profiles rou
 
 ## Enabling and Disabling
 
-Each VPN has an enable/disable toggle in the table view. When a VPN is disabled, profiles that route through it will fall back to the WAN (direct Internet).
+Each VPN has an enable/disable toggle in the table view. When a VPN is disabled, profiles that route through it will fall back to the WAN (direct Internet). A disabled VPN is not offered when choosing a [Security Profile's](security-profiles.md) outbound routing — re-enable it first.
 
 > [!NOTE]
 > You cannot disable a VPN if other VPNs use it as a target. Change their target first.

--- a/projects/start-wrt/docs/src/security-profiles.md
+++ b/projects/start-wrt/docs/src/security-profiles.md
@@ -42,7 +42,7 @@ One SSID, multiple passwords. One router, multiple isolated networks. The profil
    - **Auto whitelist new profiles** — A checkbox shown in Whitelist mode. When checked, newly created profiles are automatically added to this profile's whitelist. Useful for admin profiles that should maintain access to all network segments.
 
 1. On the **WAN / Internet** tab, configure Internet access:
-   - **Outbound Routing** — Choose how traffic from this profile reaches the Internet. Select **Direct** for direct Internet access, or **VPN** to route all traffic through an outbound VPN. The VPN option cannot be selected if you have no [Outbound VPN](outbound-vpn.md) clients; choosing VPN reveals a VPN client picker.
+   - **Outbound Routing** — Choose how traffic from this profile reaches the Internet. Select **Direct** for direct Internet access, or **VPN** to route all traffic through an outbound VPN. The VPN option cannot be selected if you have no enabled [Outbound VPN](outbound-vpn.md) clients; choosing VPN reveals a picker listing your enabled VPNs (a disabled VPN's tunnel is down, so routing a profile through it would cut that profile off).
 
    - **WAN Access** — Controls Internet access for devices on this profile:
      - **All** — Unrestricted Internet access.

--- a/projects/start-wrt/web/src/app/routes/outbound/routes/table/index.ts
+++ b/projects/start-wrt/web/src/app/routes/outbound/routes/table/index.ts
@@ -166,7 +166,13 @@ export default class OutboundTable {
   protected add() {
     const existing = this.service.data() ?? []
     const data = {
-      targets: ['Internet', ...existing.map(v => v.label)],
+      // Only enabled VPNs are chainable — see getSafeTargets. existingLabels
+      // stays unfiltered: a disabled VPN's label is still taken, and that list
+      // drives duplicate-name validation.
+      targets: [
+        'Internet',
+        ...existing.filter(v => v.enabled).map(v => v.label),
+      ],
       existingLabels: existing.map(v => v.label),
     }
 

--- a/projects/start-wrt/web/src/app/routes/outbound/utils.ts
+++ b/projects/start-wrt/web/src/app/routes/outbound/utils.ts
@@ -125,7 +125,11 @@ export type AddOutboundVpnForm = FormRawValue<
 
 /**
  * Compute which VPN labels are safe targets for a given VPN.
- * A target T is unsafe if following T's chain eventually reaches selfLabel (cycle).
+ * A target T is unsafe if it is disabled, or if following T's chain eventually
+ * reaches selfLabel (cycle). A disabled target's interface is never registered
+ * with netifd, so the chain route through it is dropped and this VPN's traffic
+ * silently falls back to the WAN — one hop where the user asked for two.
+ * Note the cycle walk still traverses the full unfiltered graph.
  */
 export function getSafeTargets(
   selfLabel: string,
@@ -135,6 +139,7 @@ export function getSafeTargets(
     'Internet',
     ...allVpns
       .filter(v => v.label !== selfLabel)
+      .filter(v => v.enabled)
       .filter(v => {
         const visited = new Set<string>([selfLabel])
         let current: OutboundVpn | undefined = v

--- a/projects/start-wrt/web/src/app/routes/profiles/dialog.ts
+++ b/projects/start-wrt/web/src/app/routes/profiles/dialog.ts
@@ -587,15 +587,20 @@ class AddProfile {
     return 1
   }
 
-  private getOutboundType(): 'direct' | 'vpn' {
+  /** The profile's current VPN outbound, if it is still one we can offer. */
+  private get existingVpn(): string | undefined {
     const outbound = this.existing?.outbound
-    return outbound && outbound !== 'wan' ? 'vpn' : 'direct'
+    return outbound && this.outboundVpns.some(v => v.interface === outbound)
+      ? outbound
+      : undefined
+  }
+
+  private getOutboundType(): 'direct' | 'vpn' {
+    return this.existingVpn ? 'vpn' : 'direct'
   }
 
   private getOutboundVpn(): string {
-    const outbound = this.existing?.outbound
-    if (outbound && outbound !== 'wan') return outbound
-    return this.outboundVpns[0]?.interface ?? ''
+    return this.existingVpn ?? this.outboundVpns[0]?.interface ?? ''
   }
 
   private parseDnsOverride(): {

--- a/projects/start-wrt/web/src/app/routes/profiles/index.ts
+++ b/projects/start-wrt/web/src/app/routes/profiles/index.ts
@@ -243,10 +243,15 @@ class Profiles {
       parseInt(p.gateway_ip.split('.')[2], 10),
     )
     const vpns = this.outboundService.data() || []
-    const outboundVpns = vpns.map(v => ({
-      interface: v.id,
-      label: v.label,
-    }))
+    // A disabled VPN's tunnel never comes up, so routing a profile through it
+    // would blackhole the profile — only offer the enabled ones (the backend
+    // rejects the rest).
+    const outboundVpns = vpns
+      .filter(v => v.enabled)
+      .map(v => ({
+        interface: v.id,
+        label: v.label,
+      }))
     const subnet = this.lanSubnet()
 
     // Check if editing a profile that has static IPs in its subnet, and collect

--- a/projects/start-wrt/web/src/app/services/api/mock-api.service.ts
+++ b/projects/start-wrt/web/src/app/services/api/mock-api.service.ts
@@ -1393,7 +1393,11 @@ export class MockApiService extends ApiService {
       id: 'wg_mullvad',
       label: 'Mullvad',
       target: 'Proton',
-      enabled: true,
+      // Disabled by default so the mock exercises the enabled-only filters on
+      // the profile outbound picker and both chain-target pickers. Nothing
+      // targets Mullvad and no mock profile routes through it, so this is a
+      // consistent state.
+      enabled: false,
       used_by: [],
       supports_ipv6: false,
       mtu: 1280,


### PR DESCRIPTION
### A disabled VPN could be selected as a profile's outbound

The outbound picker on a Security Profile listed every VPN, disabled ones included. A disabled VPN's interface is never registered with netifd, so a profile pointed at one has its traffic blackholed. Disabling a VPN already resets every profile using it back to WAN, so the picker was the only way in.

Behind it sat a wider hole: profiles.set/create never validated outbound at all. Any string was accepted and written — ensure_vpn_outbound_zone would build a real vpn_<X> firewall zone and rewrite_routing a policy route via an interface that didn't exist. outbound_supports_ipv6 returns true for an unfindable interface by design, so nothing downstream caught it either.

Fixed by filtering the picker to VPNs vpn-client.list reports as enabled, and opening a profile whose stored outbound is no longer offered as Direct rather than carrying an unusable value. New guard_outbound_available gates both backend write paths: an outbound must be "wan" or an enabled VPN client — NotFound for an unknown interface (a VPN server's included, since those carry vpn_server rather than vpn_client metadata) and a new VpnDisabled error kind for a disabled one.

### A disabled VPN could be selected as another VPN's chain target

The same shape one level up, but quieter and worse. rewrite_vpn_chain_routes pins a chained VPN's peer endpoint through its target's tunnel with config route 'vcr_<B>' / option interface '<A>', from a label→interface map with no enabled filter. netifd never registers a disabled interface (config.c:147) and drops any route naming an unregistered one (interface-ip.c:415-424), so vcr_B is never installed. B's handshake falls back to the main table's default — WAN's, since client interfaces are created defaultroute '0' — and leaves via the wan zone's ACCEPT output policy. B connects, healthy, single-hop, with every screen reporting success. Reachable straight from the UI: disable A while nothing targets it, then pick A from "Connects to".

Fixed by filtering both target pickers (getSafeTargets and the add-VPN dialog) to enabled VPNs, and gating vpn-client.create/update with a new guard_target_enabled. Together with set_enabled's existing refusal to disable a depended-on VPN, this makes an enabled interface imply an enabled chain behind it — which is why guard_outbound_available checks only the profile's immediate hop and needs no walk of its own.

### validate_target's chain walk was unbounded

It terminated only on reaching self_label or "Internet", so a cycle among other labels spun forever. Unreachable through the API — every edge is written through this same check — but a hand-edited /etc/config/startwrt would hang the RPC thread.

Fixed with a visited-containment check inside the loop, returning VpnChainCycle.

### Deliberate decisions

On update the disabled-target check fires only when the target actually changes, mirroring guard_subnet_collision — otherwise a router that already chains onto a disabled VPN could not have its label or MTU edited. The add-VPN dialog's existingLabels stays unfiltered, since a disabled VPN's label is still taken for duplicate-name validation.

### Testing

477 → 481 backend tests. The profile fixtures also gain a real wg_test VPN client; they had been routing through outbound names that existed nowhere in the fixture config, precisely the state the new guard rejects.

No hardware testing: this is config-layer validation over parsed Configs with no netifd or kernel surface. The netifd behavior above is read out of the pinned sources in openwrt/build_dir rather than
observed on a router — the fix makes that state unreachable either way.

### Docs

Changelog rides in the existing unreleased 1.0.2 entry (latest origin tag is start-wres in one bullet rather than split — to a user it is one fix. docs/src/outbound-vpn.md and docs/src/security-profiles.md updated; API_CONTRACT.md records the new validation on profiles.create/set and vpn-client.create/update.