### PR TITLE
docs(sdk): correct what tagAndRelease checks, and that it re-releases

### DIFF
--- a/projects/start-sdk/docs/src/project-structure.md
+++ b/projects/start-sdk/docs/src/project-structure.md
@@ -98,7 +98,7 @@ jobs:
       DEV_KEY: ${{ secrets.DEV_KEY }}
 ```
 
-**tagAndRelease.yml** -- on merge to master, checks the version against the production registry. If the version already exists, the workflow exits gracefully without building. Otherwise, creates a release tag, then builds and publishes to the test registry. If a new commit arrives while a previous run is still in progress, the old run is cancelled:
+**tagAndRelease.yml** -- on merge to master, checks the version against the registry named by `REFERENCE_REGISTRY`. That is whichever registry the track treats as already-shipped — it is configured per repo/org and is not necessarily production. If that registry already serves the version, the workflow exits gracefully without building. Otherwise it force-moves the release tag onto the new commit, then builds and publishes to the test registry, replacing the release's same-named assets. If a new commit arrives while a previous run is still in progress, the old run is cancelled:
 
 ```yaml
 name: Tag and Release


### PR DESCRIPTION
`project-structure.md` got two things wrong about `tagAndRelease.yml`, and I hit both while working on a package.

**It called `REFERENCE_REGISTRY` "the production registry."** It isn't. It's a per-repo/org Actions variable naming whichever registry that track treats as already-shipped — **beta** on the Start9 track, community-prod on the community one. Nothing in the workflow ties it to production; its own input description just says *"Registry where published versions are permanent."*

**It said the workflow "exits gracefully without building" if the version already exists**, which reads as though a tagged and released version is thereafter frozen. When the reference registry doesn't serve the version, the Tag job force-pushes the existing tag onto the new commit:

```bash
git tag -f "${TAG}"
git push origin -f "refs/tags/${TAG}"
```

and the release is updated in place with same-named assets replaced. So a push to `master` can re-release the *same* version with different bits — which is useful (a fix that has only reached the test registry doesn't need a downstream bump), but it also means the tag isn't a stable record of what was built.

## Verified

`Start9-Community/dojo-startos` at `1.29.2:2` — a push to `master` produced:

```
REFERENCE_REGISTRY resolved to  https://community-registry.start9.com
version not found                → skip=false
refs/tags/v1.29.2_2              d50512d → 0f31dda
dojo_x86_64.s9pk                 asset replaced (15:10 → 15:55)
dojo_aarch64.s9pk                asset replaced (15:10 → 15:55)
```

## Notes

- One paragraph, docs only; no behaviour change, so no `CHANGELOG.md` entry.
- Only copy of the claim — `publishing.md` doesn't describe the workflow.
- Related: #3597 drops the per-package `hello-world` guard job from the template. Reading this workflow confirms why it's redundant — the reusable one skips `hello-world` by package id itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)