### PR TITLE
fix(ci): read release notes from en_US, not the never-matching en-US

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,7 +236,7 @@ jobs:
       - name: Generate changelog
         run: |
           FIRST_S9PK=$(ls *.s9pk | head -1)
-          RELEASE_NOTES=$(start-cli s9pk inspect "$FIRST_S9PK" manifest | jq -r '.releaseNotes | if type == "object" then (.["en-US"] // first(.[]) // "") else . end')
+          RELEASE_NOTES=$(start-cli s9pk inspect "$FIRST_S9PK" manifest | jq -r '.releaseNotes | if type == "object" then (.en_US // first(.[]) // "") else . end')
           {
             echo "## What's Changed"
             echo ""


### PR DESCRIPTION
## The bug

`.github/workflows/release.yml`'s **Generate changelog** step builds the GitHub-release body with:

```jq
.releaseNotes | if type == "object" then (.["en-US"] // first(.[]) // "") else . end
```

StartOS locale keys are **underscore**-separated. `LocaleString::localize_for` splits on `_` when prefix-matching, and every package, the SDK's i18n scaffold, and the package template key on `en_US`. Nothing in the fleet ever emits `en-US`, so that lookup never matches and the expression always falls through to `first(.[])` — whichever locale the packager happened to write first in `releaseNotes`.

That is a serialization-order accident, not a language choice. The manifest's map is insertion-ordered (`InOMap`), so today it works by convention — packages follow the template and write `en_US` first — and silently ships the wrong language the moment one doesn't:

```console
$ echo '{"releaseNotes":{"de_DE":"GERMAN","en_US":"ENGLISH"}}' \
  | jq -r '.releaseNotes | if type == "object" then (.["en-US"] // first(.[]) // "") else . end'
GERMAN

$ echo '{"releaseNotes":{"de_DE":"GERMAN","en_US":"ENGLISH"}}' \
  | jq -r '.releaseNotes | if type == "object" then (.en_US // first(.[]) // "") else . end'
ENGLISH
```

Multi-locale `releaseNotes` are now expected of every package — the community-review checklist requires `en_US`/`es_ES`/`de_DE`/`pl_PL`/`fr_FR` — so this is going from latent to reachable as packages get audited.

## The fix

One token: `.["en-US"]` → `.en_US`.

`first(.[])` stays as the fallback for a package with no `en_US` at all, and the `type == "object"` guard still passes a legacy plain-string `releaseNotes` through untouched. Both verified:

```console
$ echo '{"releaseNotes":"legacy string"}' | jq -r '<new expr>'
legacy string
$ echo '{"releaseNotes":{}}' | jq -r '<new expr>'          # empty, as before
```

## Scope

Single occurrence — `grep -rn 'en-US' .github/ projects/start-sdk/` returns only this line. The package-template copies under `projects/start-sdk/docs/package-template/.github/workflows/` are thin `workflow_call` callers and don't carry the expression, so the reusable-CI ↔ template ↔ docs mirror in `AGENTS.md` doesn't apply here. No changelog entry: the reusable service-package CI isn't a versioned product (same shape as #3568).

Found while auditing a community package with fully translated release notes.
