### PR TITLE
fix(service): send the attach exit code, not the raw wait status

### DIFF
--- a/shared-libs/crates/start-core/src/service/mod.rs
+++ b/shared-libs/crates/start-core/src/service/mod.rs
@@ -1163,14 +1163,18 @@ pub async fn attach(
         }
 
         let exit = child.wait().await?;
+        // Send the exit code, not `into_raw()`'s wait status: the client hands this
+        // straight to `std::process::exit`, which keeps only the low byte, and a
+        // normal exit encodes as `code << 8` — so every code would arrive as 0.
+        let code = exit
+            .code()
+            .unwrap_or_else(|| 128 + exit.signal().unwrap_or_default());
         ws.send(Message::Text("exit".into()))
             .await
             .with_kind(ErrorKind::Network)?;
-        ws.send(Message::Binary(
-            i32::to_be_bytes(exit.into_raw()).to_vec().into(),
-        ))
-        .await
-        .with_kind(ErrorKind::Network)?;
+        ws.send(Message::Binary(i32::to_be_bytes(code).to_vec().into()))
+            .await
+            .with_kind(ErrorKind::Network)?;
 
         Ok(())
     }


### PR DESCRIPTION
`start-cli package attach` always exits 0, whatever the command it ran did:

```console
$ start-cli package attach <pkg> -n <sub> -- sh -c 'exit 7'; echo $?
0
$ start-cli package attach <pkg> -n <sub> -- false; echo $?
0
```

This makes `attach` unusable in any conditional — scripts and agents that test a
condition inside a service container silently take the success branch every time.
It was found while packaging a service, where an `until attach … test -f <file>; do`
loop exited on its first iteration regardless of whether the file existed.

### Cause

The protocol is fine — the server sends an `"exit"` frame and `cli_attach` hands
the value to `std::process::exit`. The bug is the value:

```rust
i32::to_be_bytes(exit.into_raw())
```

`ExitStatus::into_raw()` is the raw `wait(2)` status, not the exit code. A normal
exit encodes as `code << 8`, and `std::process::exit` keeps only the low byte —
which for `code << 8` is always zero. So every exit code arrives as 0.

`strace` on the client confirms the frame is received and the path taken, rather
than the loop falling through to `Ok(())`:

```
exit_group(1792)     # 1792 == 7 << 8, from an inner `exit 7`
```

Signal deaths collapse for the same reason rather than surviving in the low bits:
the command runs under `lxc-attach` → `start-container subcontainer exec`, so by
the time the status is taken the wrappers have already converted a signal into an
ordinary `128+N` exit.

### Fix

Send `ExitStatus::code()`, falling back to `128 + signal` for the case where the
waited-on process itself dies by a signal.

Backward compatible in the useful direction: every client already forwards this
value straight to `exit`, so an old client talking to a fixed server gets the
correct code too. Nothing else reads the `"exit"` frame.

### Not included: the changelog entry

Deliberately left out, because it needs a decision rather than a line of text.

`projects/start-os/CHANGELOG.md`'s top heading is `## [0.4.0.1]`, and
`start-os/v0.4.0.1` is a cut origin tag — so per the root `AGENTS.md` rule this
entry cannot go under it, and needs `0.4.0.2` opened. Per `VERSION_BUMP.md` that
means a new `version/v0_4_0_2.rs` migration module, the root `package.json` +
`package-lock.json`, the `Cargo.toml` label, and a `Cargo.lock` refresh — a new
node in the migration graph, which is a release-management call and not something
to fold into a one-line bug fix.

Happy to add it here if you'd rather 0.4.0.2 be opened now; otherwise the next OS
bump can absorb it.

### Verification

The fix itself is not compiled locally — `cargo check -p start-core` builds the
whole backend from cold on this machine, so CI is the first compile. `make
start-core-format-check` passes. The diagnosis above was made against a running
0.4.0.1 box with `strace` and the installed `start-cli` (`5d2d4a4`), which
already contains the client-side `"exit"` handling, so this is not a
client/server version skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
