### PR TITLE
fix(start-os): use a private temp file for the login banner's db snapshot

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -8,6 +8,17 @@ Full per-release notes are published on the
 [GitHub releases page](https://github.com/Start9Labs/start-technologies/releases). This
 file tracks notable changes since the move to the monorepo.
 
+## [0.4.0.2]
+
+### Fixed
+
+- **The login banner reports system status for every user, not just the first
+  one to log in.** It staged its database snapshot at a fixed path in `/tmp`,
+  which `pam_motd` created as root at login — so any subsequent non-root run
+  could not write it and the banner fell back to `Services: Unknown`,
+  `WAN: N/A` and `NTP: Unknown`. It now uses a private temporary file and
+  removes it on every exit path.
+
 ## [0.4.0.1]
 
 ### Changed

--- a/projects/start-os/build/lib/motd
+++ b/projects/start-os/build/lib/motd
@@ -1,11 +1,21 @@
 #!/bin/sh
 
 parse_essential_db_info() {
-    DB_DUMP="/tmp/startos_db.json"
+    # A fixed path in /tmp does not survive being run by more than one user:
+    # pam_motd runs this as root at login, so the file ends up root-owned and
+    # every later non-root run fails to write it — the banner then silently
+    # degrades to "Unknown" for exactly the fields this function fills. It is
+    # also a predictable path in a world-writable directory. Use a private
+    # temp file instead, and clean it up on every exit path.
+    DB_DUMP=$(mktemp "${TMPDIR:-/tmp}/startos_db.XXXXXXXX") || return 1
 
     if command -v start-cli >/dev/null 2>&1; then
-        timeout 30 start-cli db dump > "$DB_DUMP" 2>/dev/null || return 1
+        timeout 30 start-cli db dump > "$DB_DUMP" 2>/dev/null || {
+            rm -f "$DB_DUMP"
+            return 1
+        }
     else
+        rm -f "$DB_DUMP"
         return 1
     fi
 


### PR DESCRIPTION
## Problem

`projects/start-os/build/lib/motd` staged its `start-cli db dump` output at a fixed path:

```sh
DB_DUMP="/tmp/startos_db.json"
```

`pam_motd` runs the script as root at login, so that file is created root-owned. Every later non-root invocation then fails to write it, and the banner silently degrades to `Services: Unknown`, `WAN: N/A`, `NTP: Unknown` — the exact fields `parse_essential_db_info` exists to fill.

Reproduced on a 0.4.0.1 box as the `start9` user:

```
start9@orion:~$ /usr/lib/startos/motd
/usr/lib/startos/motd: 7: cannot create /tmp/startos_db.json: Permission denied
    │ Services: Unknown                WAN:     N/A                     │
    │ Local:    192.168.50.204         NTP:     Unknown                 │
```

It is also a predictable path in a world-writable directory.

## Fix

Use `mktemp`, and remove the file on every exit path. The previous code also leaked the snapshot when `start-cli` was absent or the dump failed — both of those returned without cleanup.

## Verification

Ran the script against a live 0.4.0.1 server with the blocking `/tmp/startos_db.json` still in place:

- **Before:** `Services: Unknown`, `WAN: N/A`, `NTP: Unknown`
- **After:** `Services: 5/5 running`, `WAN: 65.78.82.12`, `NTP: Synced`

Also exercised the two failure paths — server unreachable, and `start-cli` not on `PATH`. Both degrade to the same banner as before and leave zero temp files behind. `sh -n` clean.

## Two things for a maintainer to confirm

1. **Base branch.** `CONTRIBUTING.md` says to target a `next/*` branch when the latest release is not a pre-release, and `start-os/v0.4.0.1` is tagged. But `next/patch` still has the pre-monorepo layout (no `projects/`), so this is based on `master` instead. Happy to retarget.

2. **Changelog heading.** `## [0.4.0.1]` is a cut origin tag, so per the root `AGENTS.md` this entry goes under a new heading — `## [0.4.0.2]`. I did **not** bump the manifests that heading is coupled to, because per `VERSION_BUMP.md` an OS revision bump also requires a new `version/v0_4_0_2.rs` migration module and a `Current` change, which is a release action rather than part of a bug fix. Say the word if you'd rather this land under a different heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wQBSdkk5GYtD3LAvCnaGJ