### PR TITLE
fix(ui): put the mobile notification checkbox in the title line

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/portal/routes/notifications/item.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/notifications/item.component.ts
@@ -16,10 +16,10 @@ import { DataModel } from 'src/app/services/patch-db/data-model'
   template: `
     @if (notificationItem(); as item) {
       <td>
-        <ng-content />
         {{ item.createdAt | date: 'MMM d, y, h:mm a' }}
       </td>
       <td class="title" [style.color]="color()">
+        <ng-content />
         <tui-icon [icon]="icon()" />
         {{ item.title }}
       </td>
@@ -69,12 +69,19 @@ import { DataModel } from 'src/app/services/patch-db/data-model'
     '[class._new]': '!notificationItem()?.seen',
   },
   styles: `
+    :host {
+      position: relative;
+    }
+
     :host._new td {
       font-weight: bold;
       color: var(--tui-text-primary);
     }
 
+    /* the checkbox is projected in here but paints in the date column on desktop,
+       so its containing block has to be the row rather than this cell */
     .title {
+      position: static;
       width: 13rem;
     }
 
@@ -145,7 +152,7 @@ import { DataModel } from 'src/app/services/patch-db/data-model'
       }
 
       :host-context(table:has(:checked)) tui-icon {
-        opacity: 0;
+        display: none;
       }
     }
   `,

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/notifications/table.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/notifications/table.component.ts
@@ -89,7 +89,7 @@ import { NotificationItemComponent } from './item.component'
     </table>
   `,
   styles: `
-    input {
+    :host-context(tui-root:not(._mobile)) input {
       position: absolute;
       top: 50%;
       left: 0.75rem;
@@ -98,15 +98,11 @@ import { NotificationItemComponent } from './item.component'
 
     :host-context(tui-root._mobile) {
       input {
-        position: absolute;
-        top: 2.875rem;
-        left: 0;
-        z-index: 1;
         pointer-events: none;
       }
 
       :host:not(:has(:checked)) input {
-        opacity: 0;
+        display: none;
       }
     }
   `,


### PR DESCRIPTION
## Summary

On a phone, selecting notifications draws the checkboxes over the message text instead of in the notification icon's place on the title line.

`840019c60` reordered the mobile row grid in `item.component.ts` — title from grid row 2 to row 1, message to row 2, date to row 3 — and pinned `.service` to row 1. `table.component.ts` kept the checkbox's hard-coded `top: 2.875rem`, an offset tuned to the title sitting on row 2, so the checkbox now lands 22–24px low, on the first line of the message, while the icon it stands in for blanks out at the top of the card. It shipped in 0.4.0 and is still in 0.4.0.1; 0.4.0-beta.9 was the last release without it.

Rather than retune the constant, the checkbox now lives in the title line:

- `<ng-content />` moves from the date cell into `.title`, ahead of `<tui-icon>`. On mobile it becomes an in-flow flex item, so `.title`'s existing `align-items: center` places it — the same rule that places the icon.
- Icon and checkbox swap via `display` rather than `opacity`. Both are 1rem behind the same 0.375rem gap, so nothing on the card moves as selection turns on.
- Absolute positioning is scoped to desktop (`:host-context(tui-root:not(._mobile))`) and anchored to the row rather than the date cell the checkbox no longer sits in, so mobile has nothing to undo.

No offset constant survives, so a future change to the row layout can't reintroduce this. That matters here beyond tidiness: because `.service` is now pinned to grid row 1, a service avatar makes the title row 32px against 27.4px without one, so no single offset would have been correct for both kinds of notification.

Verified against a static harness reproducing the component's DOM and Taiga's metrics: checkbox and icon land at identical coordinates both with an avatar (y=16.0) and without (y=13.7), and the title text starts at the same x whether or not selection is active. Desktop is unchanged apart from a 0.5px horizontal shift — the collapsed-border half-pixel from anchoring to the row rather than the cell. `npm run check:ui` and prettier are clean.

## Credit

@BeeJoe found and reported this regression and proposed a fix in #3616. This supersedes that PR with a different approach, but the diagnosis there is what pointed at these two files.

## Deliberately not included

No 0.4.0.2 bump and no changelog entry. #3616 and #3617 each already add their own `shared-libs/crates/start-core/src/version/v0_4_0_2.rs` and bump the manifest, so those two conflict with each other as things stand — whichever lands first should carry the plumbing for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)