### PR TITLE
fix(net/dns): retry upstream over TCP, and select upstreams by address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7880,7 +7880,7 @@ dependencies = [
 
 [[package]]
 name = "start-os"
-version = "0.4.0-rev.1"
+version = "0.4.0-rev.2"
 dependencies = [
  "include_dir",
  "start-core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0.1",
+  "version": "0.4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "startos-ui",
-      "version": "0.4.0.1",
+      "version": "0.4.0.2",
       "license": "MIT",
       "dependencies": {
         "@angular/cdk": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "startos-ui",
-  "version": "0.4.0.1",
+  "version": "0.4.0.2",
   "author": "Start9 Labs, Inc",
   "homepage": "https://start9.com/",
   "license": "MIT",

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -8,6 +8,21 @@ Full per-release notes are published on the
 [GitHub releases page](https://github.com/Start9Labs/start-technologies/releases). This
 file tracks notable changes since the move to the monorepo.
 
+## [0.4.0.2]
+
+### Fixed
+
+- **DNS answers too large for a single UDP reply no longer fail.** StartOS's
+  resolver returned SERVFAIL for any answer an upstream would not hand back over
+  UDP, because it never retried the query over TCP. Large `TXT` record sets and
+  multi-kilobyte `SRV` responses were the casualties — most visibly, a freshly
+  installed Lightning node could not resolve the seed records it discovers its
+  first peers from, so it sat at zero peers indefinitely. Whether a given answer
+  needs TCP depends on the upstream resolver, so this affected some networks and
+  not others. StartOS now retries over TCP, and selects its upstream resolvers
+  by address rather than by position in `resolv.conf` — the latter had been
+  silently discarding upstreams.
+
 ## [0.4.0.1]
 
 ### Changed

--- a/projects/start-os/Cargo.toml
+++ b/projects/start-os/Cargo.toml
@@ -5,7 +5,7 @@ name = "start-os"
 repository = "https://github.com/Start9Labs/start-technologies"
 # Label only: SemVer has no 4th segment, so the OS version 0.4.0.1 is spelled 0.4.0-rev.1
 # here. Root package.json is the source of truth — see build/env/version.sh.
-version = "0.4.0-rev.1" # VERSION_BUMP
+version = "0.4.0-rev.2" # VERSION_BUMP
 
 [[bin]]
 name = "startbox"

--- a/projects/start-os/docs/src/installing-startos.md
+++ b/projects/start-os/docs/src/installing-startos.md
@@ -8,7 +8,7 @@ This guide is for flashing StartOS to a USB drive, then installing it onto a des
 
 ## Download
 
-1.  Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.1) to find the latest version of StartOS.
+1.  Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.2) to find the latest version of StartOS.
 
 1.  Under "ISO Downloads", select the ISO for your architecture. StartOS is available in x86_64 (AMD64), aarch64 (ARM64), and RISC-V (RVA23). For x86_64 and aarch64, two variants are available:
     - **Standard**: Includes proprietary firmware and drivers for broader hardware compatibility, including display and wireless. Recommended for most users.
@@ -74,7 +74,7 @@ This guide is for flashing StartOS to a USB drive, then installing it onto a des
 
 A Raspberry Pi does not use the USB installer above. Instead, you flash the StartOS image directly to the Pi's microSD card. This is also how a Raspberry Pi is updated to a new major version of StartOS — it cannot update over the air. If you are updating an existing 0.3.5.1 server, complete the [preparation steps in the update guide](update-040.md#prepare-your-server) before flashing.
 
-1. Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.1) and, from the downloads list, download the **Raspberry Pi `.img.gz`** file.
+1. Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.2) and, from the downloads list, download the **Raspberry Pi `.img.gz`** file.
 
 1. Verify the SHA256 checksum against the one listed on GitHub (optional but recommended) — see [Download](#download) for the command for your computer. The release lists checksums for both the compressed `.img.gz` you downloaded and the `.img` inside it.
 

--- a/shared-libs/crates/start-core/src/net/dns.rs
+++ b/shared-libs/crates/start-core/src/net/dns.rs
@@ -266,6 +266,24 @@ pub(crate) fn name_server_socket_addr(ns: &NameServerConfig) -> SocketAddr {
     SocketAddr::new(ns.ip, ns.connections.first().map_or(53, |c| c.port))
 }
 
+/// The upstream nameservers resolv.conf lists, minus loopback — those point back
+/// at this server, so forwarding to one is a query loop.
+///
+/// Selecting by address rather than by position matters: hickory yields one
+/// `NameServerConfig` per nameserver, not one per nameserver-and-protocol, so
+/// anything counting entries drops whole upstreams. Callers pair this with
+/// [`forward_name_server`] so each upstream keeps a TCP connection alongside UDP
+/// — without it, any answer too large for a UDP datagram fails instead of
+/// retrying over TCP.
+fn upstream_name_servers(config: &ResolverConfig) -> impl Iterator<Item = SocketAddr> + '_ {
+    config
+        .name_servers()
+        .iter()
+        .map(name_server_socket_addr)
+        .filter(|addr| !addr.ip().is_loopback())
+        .dedup()
+}
+
 /// Parse systemd-resolved's resolv.conf. hickory 0.26 only exposes
 /// `system_conf::parse_resolv_conf` on non-apple unix; this path only runs on
 /// the (Linux) server, so non-Linux targets just need a stub to compile.
@@ -347,6 +365,16 @@ fn spawn_forwarder(
                             // resolvers give up around 5s, so a longer forward
                             // serves nobody; keep the default retry count.
                             opts.timeout = Duration::from_secs(5);
+                            // Retry over TCP when a UDP query fails — hickory
+                            // leaves this off, which turns any answer an
+                            // upstream won't hand back over UDP into a
+                            // SERVFAIL. That covers large TXT sets and the
+                            // multi-KB SRV responses Lightning nodes bootstrap
+                            // from, and it is not a property of the answer
+                            // alone: whether a given upstream needs TCP for it
+                            // varies by resolver, so the box's behavior changes
+                            // with the network it is on.
+                            opts.try_tcp_on_error = true;
                             last_config = Some((config, opts));
                             true
                         }
@@ -380,15 +408,7 @@ fn spawn_forwarder(
                                 .as_network_mut()
                                 .as_dns_mut()
                                 .as_dhcp_servers_mut()
-                                .ser(
-                                    &config
-                                        .name_servers()
-                                        .iter()
-                                        .map(name_server_socket_addr)
-                                        .dedup()
-                                        .skip(2)
-                                        .collect(),
-                                )
+                                .ser(&upstream_name_servers(config).collect())
                         })
                         .await
                         .result?;
@@ -400,7 +420,9 @@ fn spawn_forwarder(
                                 .map(|addr| forward_name_server(*addr))
                                 .collect()
                         } else {
-                            config.name_servers().iter().skip(2).cloned().collect()
+                            upstream_name_servers(config)
+                                .map(forward_name_server)
+                                .collect()
                         };
                     let auth: Vec<Arc<dyn ZoneHandler>> = vec![Arc::new(
                         ForwardZoneHandler::builder_tokio(ForwardConfig {

--- a/shared-libs/crates/start-core/src/version/mod.rs
+++ b/shared-libs/crates/start-core/src/version/mod.rs
@@ -40,6 +40,7 @@ mod v0_3_6_alpha_18;
 
 mod v0_4_0;
 mod v0_4_0_1;
+mod v0_4_0_2;
 mod v0_4_0_alpha_0;
 mod v0_4_0_alpha_1;
 mod v0_4_0_alpha_2;
@@ -77,7 +78,7 @@ mod v0_4_0_beta_7;
 mod v0_4_0_beta_8;
 mod v0_4_0_beta_9;
 
-pub type Current = v0_4_0_1::Version; // VERSION_BUMP
+pub type Current = v0_4_0_2::Version; // VERSION_BUMP
 
 impl Current {
     #[instrument(skip(self, db))]
@@ -221,7 +222,8 @@ enum Version {
     V0_4_0_beta_9(Wrapper<v0_4_0_beta_9::Version>),
     V0_4_0_beta_10(Wrapper<v0_4_0_beta_10::Version>),
     V0_4_0(Wrapper<v0_4_0::Version>),
-    V0_4_0_1(Wrapper<v0_4_0_1::Version>), // VERSION_BUMP
+    V0_4_0_1(Wrapper<v0_4_0_1::Version>),
+    V0_4_0_2(Wrapper<v0_4_0_2::Version>), // VERSION_BUMP
     Other(exver::Version),
 }
 
@@ -300,7 +302,8 @@ impl Version {
             Self::V0_4_0_beta_9(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0_beta_10(v) => DynVersion(Box::new(v.0)),
             Self::V0_4_0(v) => DynVersion(Box::new(v.0)),
-            Self::V0_4_0_1(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
+            Self::V0_4_0_1(v) => DynVersion(Box::new(v.0)),
+            Self::V0_4_0_2(v) => DynVersion(Box::new(v.0)), // VERSION_BUMP
             Self::Other(v) => {
                 return Err(Error::new(
                     eyre!("unknown version {v}"),
@@ -371,7 +374,8 @@ impl Version {
             Version::V0_4_0_beta_9(Wrapper(x)) => x.semver(),
             Version::V0_4_0_beta_10(Wrapper(x)) => x.semver(),
             Version::V0_4_0(Wrapper(x)) => x.semver(),
-            Version::V0_4_0_1(Wrapper(x)) => x.semver(), // VERSION_BUMP
+            Version::V0_4_0_1(Wrapper(x)) => x.semver(),
+            Version::V0_4_0_2(Wrapper(x)) => x.semver(), // VERSION_BUMP
             Version::Other(x) => x.clone(),
         }
     }

--- a/shared-libs/crates/start-core/src/version/v0_4_0_2.rs
+++ b/shared-libs/crates/start-core/src/version/v0_4_0_2.rs
@@ -1,0 +1,33 @@
+use exver::VersionRange;
+
+use super::v0_3_5::V0_3_0_COMPAT;
+use super::{VersionT, v0_4_0_1};
+use crate::prelude::*;
+
+lazy_static::lazy_static! {
+    static ref V0_4_0_2: exver::Version = exver::Version::new([0, 4, 0, 2], []);
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Version;
+
+impl VersionT for Version {
+    type Previous = v0_4_0_1::Version;
+    type PreUpRes = ();
+
+    async fn pre_up(self) -> Result<Self::PreUpRes, Error> {
+        Ok(())
+    }
+    fn semver(self) -> exver::Version {
+        V0_4_0_2.clone()
+    }
+    fn compat(self) -> &'static VersionRange {
+        &V0_3_0_COMPAT
+    }
+    fn up(self, _db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+        Ok(Value::Null)
+    }
+    fn down(self, _db: &mut Value) -> Result<(), Error> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Symptom

A fresh LND install never finds its first peer — it sits at zero peers and never leaves "Syncing to graph":

```
[INF] DISC: Attempting to bootstrap with: BOLT-0010 DNS Seed: [[nodes.lightning.wiki ...]]
[ERR] SRVR: Unable to retrieve initial bootstrap peers: no addresses found
```

Not LND-specific: any large DNS answer fails, `TXT` lookups (SPF/DKIM) included.

## Cause

The forwarder returns SERVFAIL for any answer an upstream will not hand back over UDP. hickory leaves `try_tcp_on_error` off, so a truncated or oversized UDP reply has no TCP retry behind it. Measured through the StartOS resolver at `10.0.3.1`:

| query | upstream size | result |
| --- | --- | --- |
| MX google.com | 60 B | NOERROR |
| SRV `_matrix._tcp.matrix.org` | 119 B | NOERROR |
| A nodes.lightning.wiki | 449 B | NOERROR |
| TXT google.com | 1058 B | **SERVFAIL** |
| SRV nodes.lightning.wiki | 2624 B | **SERVFAIL** |

BOLT-10 seed lookups are `SRV`, and `nodes.lightning.wiki` answers with 25 records — so LND's bootstrap sits squarely in the failing range while its `A` lookups succeed.

Whether an upstream needs TCP for a given answer varies by resolver, which is why this reproduces on some networks and not others. With `staticServers` at `1.1.1.1` these queries succeed; pointed at the LAN router they fail — while that same router serves the identical query to `dig` over both UDP and TCP.

Second, smaller issue: the `resolv.conf` branch picked upstreams positionally with `skip(2)`. That was written when `name_servers()` yielded one entry per nameserver-**and-protocol**, where it dropped exactly the loopback UDP/TCP pair. Since #3302 (hickory 0.26) it yields one entry per nameserver, so the same `skip(2)` discards two whole upstreams — on a box whose `resolv.conf` is `127.0.0.1`, `1.1.1.1`, `<router>`, that leaves only the router. `ServerOrderingStrategy` defaults to `QueryStatistics`, so the low-latency router would usually win anyway; restoring the pool is not what fixes the bug, but the positional select is wrong on its own terms and also fed the `dhcpServers` db field.

## The change

- `opts.try_tcp_on_error = true` — the actual fix.
- Replace `skip(2)` with `upstream_name_servers()`, which selects by address (filtering loopback, which would be a query loop) and builds each `resolv.conf` upstream through `forward_name_server` so it carries TCP alongside UDP. The same helper now feeds the `dhcpServers` write.
- Bumps StartOS to 0.4.0.2 with its changelog entry, migration node, and the release-gated doc links, since `start-os/v0.4.0.1` is already tagged.

## Verification

The diagnosis is verified on hardware: swapping `staticServers` between `1.1.1.1` and the LAN router flips the failure deterministically, and LND bootstraps immediately once the resolver can serve `SRV` (`Obtained 3 addrs to bootstrap network with`, three peers connected).

**The patched binary is not yet verified** — this PR is how it first gets compiled, and it wants a deploy onto a box on an affected network before merge.

Related: #3302 (hickory 0.26 migration, where `skip(2)`'s meaning silently changed), #3418 (blocks services from querying a gateway resolver directly, so a service has no path around `10.0.3.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
