### PR TITLE
chore(start-sdk): pin 2.0.10 to StartOS 0.4.0

### DIFF
--- a/projects/start-sdk/ARCHITECTURE.md
+++ b/projects/start-sdk/ARCHITECTURE.md
@@ -24,7 +24,7 @@ The Start SDK builds on a shared core library to form a layered architecture: **
 └─────────────────────────────────────────────────────────────┘
 ```
 
-The SDK follows [Semantic Versioning](https://semver.org/) and is versioned independently of StartOS (the current `@start9labs/start-sdk` 2.0.0 targets StartOS 0.4.0-beta.10). Each `CHANGELOG.md` heading records the SDK version and the StartOS release it targets.
+The SDK follows [Semantic Versioning](https://semver.org/) and is versioned independently of StartOS (the current `@start9labs/start-sdk` 2.0.10 targets StartOS 0.4.0). Each `CHANGELOG.md` heading records the SDK version and the StartOS release it targets.
 
 ## Place in the monorepo
 

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 2.0.10 — StartOS 0.4.0-beta.10
+## 2.0.10 — StartOS 0.4.0
+
+### Changed
+
+- **Minimum StartOS version bumped to `0.4.0`.** The 2.0 line has declared
+  `0.4.0-beta.10` since 2.0.0; 0.4.0 is the release that shipped, and it is what
+  a package built with this SDK now writes as its manifest `osVersion` — so the
+  registry offers that package to servers on 0.4.0 or later
 
 ### Fixed
 

--- a/projects/start-sdk/lib/StartSdk.ts
+++ b/projects/start-sdk/lib/StartSdk.ts
@@ -76,7 +76,7 @@ import { createVolumes } from './util/Volume'
 import { getDataVersion, setDataVersion } from './version'
 
 /** The minimum StartOS version required by this SDK release */
-export const OSVersion = testTypeVersion('0.4.0-beta.10')
+export const OSVersion = testTypeVersion('0.4.0')
 
 // prettier-ignore
 type AnyNeverCond<T extends any[], Then, Else> = 


### PR DESCRIPTION
`OSVersion` still named `0.4.0-beta.10` — set when the 2.0 line was cut against
what was then master. 0.4.0 is the release that shipped, so that is what the SDK
declares and what `setupManifest` writes into every built package manifest as
`osVersion`.

Three files, one fact: the constant, the (unpublished) 2.0.10 changelog heading
and its `### Changed` entry, and the `ARCHITECTURE.md` sentence that states the
SDK's OS target.

## Why this is only a tightening

Manifest `osVersion` is a **minimum server version**, enforced at discovery
time. The registry keeps a package version only when

```rust
// shared-libs/crates/start-core/src/registry/package/index.rs:251
self.as_metadata().as_os_version().de()?.satisfies(&device_info.os.compat)
```

and every version node since 0.3.5 returns `V0_3_0_COMPAT` = `>=0.3.0 && <=Current::semver()`
(`version/v0_3_5.rs`; `v0_4_0.rs` and `v0_4_0_1.rs` both hand it back), so the
test reduces to `server_version >= osVersion`. exver sorts a prerelease below its
release, so `0.4.0-beta.10 < 0.4.0` — the change can only remove hosts, never add
them. Ran the real `exver` code against each compat range:

| host | `osVersion: 0.4.0-beta.10` | `osVersion: 0.4.0` |
| --- | --- | --- |
| 0.4.0-beta.9 | hidden | hidden |
| 0.4.0-beta.10 | visible | **hidden** |
| 0.4.0 | visible | visible |
| 0.4.0.1 | visible | visible |

The one row that moves is a host running exactly `0.4.0-beta.10` — never cut as a
tag and absent from both registries, i.e. only locally built master images from
the June–July window. Sideload is ungated (`install/mod.rs` has no `os_version`
check), so even there it degrades to "the registry keeps offering the previous
package revision".

Pinning to `0.4.0.1` instead would be a real regression: it would hide every
newly built package from the 0.4.0 hosts the registry serves today, and no SDK
2.0.x feature needs the revision.

## Deliberately not included

- `docs/package-template/package.json`'s SDK pin stays at 2.0.9 — `AGENTS.md`
  says to sync it with the release, not the bump, since `s9pk init-package`
  scaffolds from the checkout and a pin ahead of npm breaks `npm install`.
  `make sync-template` handles it at release time.
- The other `0.4.0-beta.10` strings in the repo are unrelated: the registry's
  `alerts` back-compat shim, the version graph, the released 2.0.0–2.0.9
  changelog headings (true when cut), and a `release.yml` comment naming a
  start-cli version.

## Verified

- `make check` (tsc) and `make test` (84 tests) green; `make check-fmt` and the
  repo-pinned prettier 3.8.3 clean on all three files.
- `testTypeVersion('0.4.0')` compiles — checked through the repo's own tsc, with
  an invalid literal as the control.
- `manage-release.sh pre-check` matches the changelog heading on the SDK version
  token only (`^##[[:space:]]+\[?2\.0\.10(]| |$)`), so the `— StartOS …` suffix
  is free to change.
